### PR TITLE
Complete Python SDK MVP publishing baseline

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ with HonuaGeocodingClient("https://your-honua-server.com") as geocoder:
 
 - [5-Minute Quickstart](docs/quickstart.md) -- query, GeoDataFrame, and plot
 - [INSTALL.md](INSTALL.md) -- installation options and version policy
+- [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md) -- release automation and publishing checklist
 - [gRPC usage](honua_sdk/grpc/) -- streaming feature queries
 - [Admin client](honua_sdk/admin/) -- server administration
 
 ## Status
 
-This package is in **alpha** (`0.x`) and not yet published to PyPI.
+This package is in **alpha** (`0.x`).
+Release automation is configured for PyPI publishing from `python-sdk-v<version>` tags.
 APIs may change before the 1.0 stable release.
 
 ## Development

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,19 @@
+# Honua Python SDK Release Checklist
+
+## Baseline
+
+- Update `pyproject.toml` version using semantic versioning.
+- Add release notes to [CHANGELOG.md](CHANGELOG.md).
+- Confirm `README.md` and [INSTALL.md](INSTALL.md) match the current package surface.
+
+## Validation
+
+- Run `python -m pytest tests/ -q --tb=short` on Python 3.11+.
+- Build the package with `hatch build`.
+- Dry-run the `Publish Python SDK` workflow when validating a release candidate.
+
+## Publish
+
+- Merge release changes to `trunk`.
+- Create a `python-sdk-v<version>` tag that matches `pyproject.toml`.
+- Monitor the `Publish Python SDK` workflow for PyPI upload completion.


### PR DESCRIPTION
## Summary
- align release-please with the trunk default branch
- update README status and publishing guidance
- add a release checklist to satisfy the MVP packaging baseline

## Validation
- repo consistency and workflow/docs pass locally
- full pytest run still requires Python 3.11+, which is not available on this machine

Closes #1