### PR TITLE
[codex] Add refreshable auth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ client = HonuaClient("https://your-server.com", max_retries=0)
 
 - [5-Minute Quickstart](docs/quickstart.md) -- query, GeoDataFrame, and plot
 - [Geospatial ETL demo](examples/geospatial_etl/README.md) -- canonical script-first ETL flow plus notebook companion, with `load-summary.json` / `post-load-preview.png` artifacts and the `apply_edits` contract
+- [Authentication](docs/auth.md) -- refreshable bearer tokens, secure storage guidance, revocation, rotation, and failure modes
 - [Troubleshooting](docs/troubleshooting.md) -- staging smoke env vars and result artifacts, auth expectations, seeded `test_service` / layer `0` assumptions, optional example dependencies, and cleanup guidance
 - [Operating Cadence](docs/operating-cadence.md) -- weekly backlog review, scope gate, and done/close hygiene
 - [INSTALL.md](INSTALL.md) -- installation options and version policy

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,117 @@
+# Authentication
+
+Honua SDK clients support static API keys, static bearer tokens, and refreshable
+auth providers.
+
+Static credentials are still available for simple service accounts:
+
+```python
+from honua_sdk import HonuaClient
+
+client = HonuaClient("https://honua.example", api_key="honua-api-key")
+```
+
+For user or workload tokens that expire, use
+`RefreshableBearerTokenProvider`. The SDK calls the provider before each request
+and refreshes when the cached token is missing or within the configured refresh
+window.
+
+```python
+from honua_sdk import BearerToken, HonuaClient, RefreshableBearerTokenProvider
+
+
+def refresh_token() -> BearerToken:
+    # Call your identity provider here.
+    payload = issue_token()
+    return BearerToken.from_expires_in(
+        payload["access_token"],
+        payload["expires_in"],
+    )
+
+
+auth = RefreshableBearerTokenProvider(
+    refresh_token,
+    refresh_window_seconds=120,
+)
+
+with HonuaClient("https://honua.example", auth_provider=auth) as client:
+    services = client.list_services()
+```
+
+The same `auth_provider` argument is accepted by:
+
+- `HonuaClient`
+- `AsyncHonuaClient`
+- `HonuaGeocodingClient`
+- `AsyncHonuaGeocodingClient`
+- `HonuaAdminClient`
+- `AsyncHonuaAdminClient`
+
+Do not pass both `bearer_token` and `auth_provider`; the SDK rejects that
+combination so the source of the `Authorization` header stays unambiguous. A
+static `api_key` can be combined with a bearer-token provider only when the
+server expects both headers.
+
+## Rotation
+
+`auth_provider` is resolved per request. This lets applications rotate API keys
+or bearer tokens without reconstructing the SDK client:
+
+```python
+from honua_sdk import CallableAuthProvider, HonuaClient
+
+
+def current_headers() -> dict[str, str]:
+    return {"X-API-Key": current_key_from_secret_manager()}
+
+
+with HonuaClient("https://honua.example", auth_provider=CallableAuthProvider(current_headers)) as client:
+    client.list_services()
+```
+
+Auth headers are attached only to the configured base URL authority. When
+redirects are enabled, `Authorization` and `X-API-Key` are stripped from
+cross-host redirects.
+
+## Revocation
+
+Use `RefreshableBearerTokenProvider.revoke()` when a logout, token revocation,
+or incident response flow invalidates the current token. The provider calls the
+optional revocation hook with the cached token and clears the token store.
+
+```python
+def revoke_token(token: BearerToken) -> None:
+    revoke_with_identity_provider(token.access_token)
+
+
+auth = RefreshableBearerTokenProvider(refresh_token, revoke=revoke_token)
+auth.revoke()
+```
+
+The next request refreshes a new token through the configured refresh callback.
+
+## Storage
+
+The SDK default token store is in memory only. This avoids writing bearer tokens
+to plaintext files and keeps process lifetime explicit.
+
+For persistent tokens, adapt a secure system to the `TokenStore` protocol:
+
+- macOS Keychain, Windows Credential Manager, or libsecret through a package
+  such as `keyring`
+- a cloud secret manager
+- a workload identity cache owned by the deployment platform
+
+Do not store long-lived bearer tokens in source-controlled files, shell history,
+or unencrypted dotfiles. Prefer short-lived access tokens plus refresh or
+workload identity credentials.
+
+## Failure Modes
+
+- Refresh callback failures propagate before the request is sent. Handle those
+  exceptions around SDK calls when the identity provider may be unavailable.
+- HTTP `401` or `403` responses are returned as `HonuaHttpError` and are not
+  retried by the SDK retry transport.
+- Retry remains limited to transient statuses such as `429`, `502`, and `503`.
+- If a token is revoked server-side, call `auth.revoke()` or
+  `auth.refresh()` before retrying with new credentials.

--- a/packages/honua-admin/README.md
+++ b/packages/honua-admin/README.md
@@ -33,6 +33,18 @@ with HonuaAdminClient("https://your-honua-server.com", api_key="key") as admin:
         print(f"{svc.service_name}: {svc.layer_count} layers")
 ```
 
+Refreshable SDK auth providers are also accepted:
+
+```python
+from honua_admin import HonuaAdminClient
+from honua_sdk import RefreshableBearerTokenProvider
+
+auth = RefreshableBearerTokenProvider(lambda: {"access_token": "token", "expires_in": 3600})
+
+with HonuaAdminClient("https://your-honua-server.com", auth_provider=auth) as admin:
+    services = admin.list_services()
+```
+
 ## License
 
 Apache-2.0

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -17,7 +17,9 @@ from honua_sdk._http import (
     _normalize_base_url,
     _to_http_error,
     _to_transport_error,
+    _validate_auth_configuration,
 )
+from honua_sdk.auth import AuthProvider
 from ._models import (
     AdminCompatibilityBaseline,
     AdminCompatibilityCheckResult,
@@ -59,6 +61,7 @@ class AsyncHonuaAdminClient:
         timeout: float = 30.0,
         api_key: str | None = None,
         bearer_token: str | None = None,
+        auth_provider: AuthProvider | None = None,
         follow_redirects: bool = False,
         client: httpx.AsyncClient | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
@@ -66,6 +69,7 @@ class AsyncHonuaAdminClient:
     ) -> None:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
+        _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
 
         self._owns_client = client is None
         if client is not None:
@@ -81,6 +85,7 @@ class AsyncHonuaAdminClient:
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
+                auth_provider=auth_provider,
             )
 
         effective_transport = transport

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -17,7 +17,9 @@ from honua_sdk._http import (
     _normalize_base_url,
     _to_http_error,
     _to_transport_error,
+    _validate_auth_configuration,
 )
+from honua_sdk.auth import AuthProvider
 from ._models import (
     AdminCompatibilityBaseline,
     AdminCompatibilityCheckResult,
@@ -59,6 +61,7 @@ class HonuaAdminClient:
         timeout: float = 30.0,
         api_key: str | None = None,
         bearer_token: str | None = None,
+        auth_provider: AuthProvider | None = None,
         follow_redirects: bool = False,
         client: httpx.Client | None = None,
         transport: httpx.BaseTransport | None = None,
@@ -66,6 +69,7 @@ class HonuaAdminClient:
     ) -> None:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
+        _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
 
         self._owns_client = client is None
         if client is not None:
@@ -81,6 +85,7 @@ class HonuaAdminClient:
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
+                auth_provider=auth_provider,
             )
 
         effective_transport = transport

--- a/packages/honua-sdk/README.md
+++ b/packages/honua-sdk/README.md
@@ -31,6 +31,17 @@ with HonuaClient("https://your-honua-server.com") as client:
     print(f"Found {len(result.get('features', []))} features")
 ```
 
+## Refreshable Auth
+
+```python
+from honua_sdk import HonuaClient, RefreshableBearerTokenProvider
+
+auth = RefreshableBearerTokenProvider(lambda: {"access_token": "token", "expires_in": 3600})
+
+with HonuaClient("https://your-honua-server.com", auth_provider=auth) as client:
+    services = client.list_services()
+```
+
 ## OGC API Features
 
 ```python
@@ -60,6 +71,7 @@ with HonuaClient("https://your-honua-server.com") as client:
 
 - [5-Minute Quickstart](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/quickstart.md) - query features, convert them to a GeoDataFrame, and plot them
 - [Geospatial ETL demo](https://github.com/honua-io/honua-sdk-python/blob/trunk/examples/geospatial_etl/README.md) - canonical script-first extract/validate/write/reconcile flow with the notebook companion and `load-summary.json` / `post-load-preview.png` contract
+- [Authentication](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/auth.md) - refreshable bearer tokens, secure storage guidance, revocation, rotation, and failure modes
 - [Troubleshooting](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/troubleshooting.md) - base URL selection, auth, staging smoke env vars, JSON/JUnit artifacts, and cleanup guidance
 - [Monorepo README](https://github.com/honua-io/honua-sdk-python) - install options and package overview
 

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -16,6 +16,15 @@ try:
 except Exception:  # pragma: no cover -- editable / not-installed fallback
     __version__ = "0.0.0.dev0"
 
+from .auth import (
+    AuthProvider,
+    BearerToken,
+    CallableAuthProvider,
+    InMemoryTokenStore,
+    RefreshableBearerTokenProvider,
+    StaticAuthProvider,
+    TokenStore,
+)
 from .async_client import AsyncHonuaClient
 from .async_geocoding import AsyncHonuaGeocodingClient
 from .client import HonuaClient
@@ -50,10 +59,13 @@ from .protocols import (
 
 __all__ = [
     "__version__",
+    "AuthProvider",
     "AsyncHonuaClient",
     "AsyncHonuaGeocodingClient",
     "AsyncHonuaOgcFeatureCollection",
     "AsyncHonuaOgcFeatures",
+    "BearerToken",
+    "CallableAuthProvider",
     "GeocodeResult",
     "GeocodeSuggestion",
     "GeoServicesFeatureServerClient",
@@ -67,13 +79,17 @@ __all__ = [
     "HonuaGeocodingClient",
     "HonuaOgcFeatureCollection",
     "HonuaOgcFeatures",
+    "InMemoryTokenStore",
     "ODataClient",
     "OgcCoveragesClient",
     "OgcMapsClient",
     "OgcProcessesClient",
     "OgcTilesClient",
+    "RefreshableBearerTokenProvider",
     "ReverseGeocodeResult",
     "StacClient",
+    "StaticAuthProvider",
+    "TokenStore",
     "WfsClient",
     "WmsClient",
     "WmtsClient",

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 
 import httpx
 
+from .auth import AuthProvider, SENSITIVE_AUTH_HEADER_NAMES, normalize_auth_headers
 from .errors import HonuaHttpError
 
 
@@ -32,6 +33,15 @@ def _build_sensitive_auth_headers(
     return headers
 
 
+def _validate_auth_configuration(
+    *,
+    bearer_token: str | None,
+    auth_provider: AuthProvider | None,
+) -> None:
+    if bearer_token is not None and auth_provider is not None:
+        raise ValueError("Provide either `bearer_token` or `auth_provider`, not both.")
+
+
 def _extract_trusted_authority(url: httpx.URL) -> tuple[str, int | None]:
     """Return ``(host, port)`` from *url* for use as a trusted-origin key.
 
@@ -47,6 +57,7 @@ def _apply_sensitive_auth_headers(
     *,
     trusted_authority: tuple[str, int | None] | None,
     auth_headers: Mapping[str, str],
+    auth_provider: AuthProvider | None = None,
 ) -> None:
     """Attach or strip sensitive headers depending on the request target.
 
@@ -54,17 +65,26 @@ def _apply_sensitive_auth_headers(
     *trusted_authority* exactly; otherwise they are stripped to prevent
     credential leakage on redirects.
     """
-    if not auth_headers or trusted_authority is None:
+    if trusted_authority is None:
         return
 
     request_authority = (request.url.host, request.url.port)
     if request_authority == trusted_authority:
+        dynamic_headers = _auth_provider_headers(auth_provider)
         for name, value in auth_headers.items():
+            request.headers.setdefault(name, value)
+        for name, value in dynamic_headers.items():
             request.headers.setdefault(name, value)
         return
 
-    for name in auth_headers:
+    for name in SENSITIVE_AUTH_HEADER_NAMES:
         request.headers.pop(name, None)
+
+
+def _auth_provider_headers(auth_provider: AuthProvider | None) -> dict[str, str]:
+    if auth_provider is None:
+        return {}
+    return normalize_auth_headers(auth_provider.auth_headers())
 
 
 def _to_http_error(response: httpx.Response) -> HonuaHttpError:

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -16,9 +16,11 @@ from ._http import (
     _normalize_base_url,
     _to_http_error,
     _to_transport_error,
+    _validate_auth_configuration,
 )
 
 if TYPE_CHECKING:
+    from .auth import AuthProvider
     from .ogc import AsyncHonuaOgcFeatures
 
 
@@ -36,6 +38,7 @@ class AsyncHonuaClient:
         timeout: float = 30.0,
         api_key: str | None = None,
         bearer_token: str | None = None,
+        auth_provider: AuthProvider | None = None,
         follow_redirects: bool = False,
         client: httpx.AsyncClient | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
@@ -43,6 +46,7 @@ class AsyncHonuaClient:
     ) -> None:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
+        _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
 
         self._owns_client = client is None
         if client is not None:
@@ -58,6 +62,7 @@ class AsyncHonuaClient:
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
+                auth_provider=auth_provider,
             )
 
         effective_transport = transport

--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -16,7 +16,9 @@ from ._http import (
     _normalize_base_url,
     _to_http_error,
     _to_transport_error,
+    _validate_auth_configuration,
 )
+from .auth import AuthProvider
 from .geocoding import GeocodeResult, GeocodeSuggestion, ReverseGeocodeResult
 
 
@@ -31,12 +33,14 @@ class AsyncHonuaGeocodingClient:
         timeout: float = 30.0,
         api_key: str | None = None,
         bearer_token: str | None = None,
+        auth_provider: AuthProvider | None = None,
         client: httpx.AsyncClient | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
         max_retries: int = 3,
     ) -> None:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
+        _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
 
         self._locator_name = locator_name
         self._owns_client = client is None
@@ -53,6 +57,7 @@ class AsyncHonuaGeocodingClient:
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
+                auth_provider=auth_provider,
             )
 
         effective_transport = transport

--- a/packages/honua-sdk/honua_sdk/auth.py
+++ b/packages/honua-sdk/honua_sdk/auth.py
@@ -1,0 +1,239 @@
+"""Authentication helpers for refreshable Honua SDK credentials."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from threading import RLock
+from typing import Any, Protocol, runtime_checkable
+
+SENSITIVE_AUTH_HEADER_NAMES = frozenset({"authorization", "x-api-key"})
+
+
+@runtime_checkable
+class AuthProvider(Protocol):
+    """Provider interface used by SDK clients to resolve auth headers per request."""
+
+    def auth_headers(self) -> Mapping[str, str]:
+        """Return sensitive auth headers for the next request."""
+
+
+class TokenStore(Protocol):
+    """Storage interface for bearer tokens.
+
+    The SDK ships only an in-memory implementation. Applications that need
+    persistence should adapt an OS keychain, cloud secret manager, or workload
+    identity cache to this protocol.
+    """
+
+    def get(self) -> "BearerToken | None":
+        """Return the currently cached token, if any."""
+
+    def set(self, token: "BearerToken") -> None:
+        """Store a refreshed token."""
+
+    def clear(self) -> None:
+        """Forget any cached token."""
+
+
+@dataclass(frozen=True)
+class BearerToken:
+    """Bearer token plus optional expiration metadata."""
+
+    access_token: str
+    expires_at: datetime | None = None
+    token_type: str = "Bearer"
+
+    def __post_init__(self) -> None:
+        if not self.access_token:
+            raise ValueError("access_token must be non-empty.")
+        if not self.token_type:
+            raise ValueError("token_type must be non-empty.")
+        if self.expires_at is not None:
+            object.__setattr__(self, "expires_at", _normalize_datetime(self.expires_at))
+
+    @classmethod
+    def from_expires_in(
+        cls,
+        access_token: str,
+        expires_in_seconds: int | float,
+        *,
+        token_type: str = "Bearer",
+        now: datetime | None = None,
+    ) -> "BearerToken":
+        base = now or datetime.now(timezone.utc)
+        return cls(
+            access_token=access_token,
+            expires_at=base + timedelta(seconds=float(expires_in_seconds)),
+            token_type=token_type,
+        )
+
+    @property
+    def authorization_value(self) -> str:
+        return f"{self.token_type} {self.access_token}"
+
+    def expires_within(
+        self,
+        window: timedelta,
+        *,
+        now: datetime | None = None,
+    ) -> bool:
+        if self.expires_at is None:
+            return False
+        reference = now or datetime.now(timezone.utc)
+        return self.expires_at <= reference + window
+
+
+class InMemoryTokenStore:
+    """Thread-safe in-memory token cache."""
+
+    def __init__(self, token: BearerToken | Mapping[str, Any] | str | None = None) -> None:
+        self._lock = RLock()
+        self._token = _coerce_token(token) if token is not None else None
+
+    def get(self) -> BearerToken | None:
+        with self._lock:
+            return self._token
+
+    def set(self, token: BearerToken) -> None:
+        with self._lock:
+            self._token = token
+
+    def clear(self) -> None:
+        with self._lock:
+            self._token = None
+
+
+class StaticAuthProvider:
+    """Static auth header provider for API-key or bearer-token compatibility."""
+
+    def __init__(self, headers: Mapping[str, str]) -> None:
+        self._headers = normalize_auth_headers(headers)
+
+    def auth_headers(self) -> Mapping[str, str]:
+        return dict(self._headers)
+
+
+class CallableAuthProvider:
+    """Auth provider backed by a callback returning auth headers per request."""
+
+    def __init__(self, callback: Callable[[], Mapping[str, str]]) -> None:
+        self._callback = callback
+
+    def auth_headers(self) -> Mapping[str, str]:
+        return normalize_auth_headers(self._callback())
+
+
+class RefreshableBearerTokenProvider:
+    """Refresh bearer tokens before they expire and expose Authorization headers."""
+
+    def __init__(
+        self,
+        refresh: Callable[[], BearerToken | Mapping[str, Any] | str],
+        *,
+        initial_token: BearerToken | Mapping[str, Any] | str | None = None,
+        token_store: TokenStore | None = None,
+        refresh_window_seconds: int | float = 60,
+        revoke: Callable[[BearerToken], None] | None = None,
+    ) -> None:
+        if refresh_window_seconds < 0:
+            raise ValueError("refresh_window_seconds must be non-negative.")
+        self._refresh = refresh
+        self._store = token_store or InMemoryTokenStore(initial_token)
+        if token_store is not None and initial_token is not None:
+            token_store.set(_coerce_token(initial_token))
+        self._refresh_window = timedelta(seconds=float(refresh_window_seconds))
+        self._revoke = revoke
+        self._lock = RLock()
+
+    def auth_headers(self) -> Mapping[str, str]:
+        token = self.get_token()
+        return {"Authorization": token.authorization_value}
+
+    def get_token(self) -> BearerToken:
+        with self._lock:
+            token = self._store.get()
+            if token is None or token.expires_within(self._refresh_window):
+                token = self._refresh_locked()
+            return token
+
+    def refresh(self) -> BearerToken:
+        """Force a token refresh and store the result."""
+        with self._lock:
+            return self._refresh_locked()
+
+    def revoke(self) -> None:
+        """Call the optional revocation hook and clear the cached token."""
+        with self._lock:
+            token = self._store.get()
+            if token is not None and self._revoke is not None:
+                self._revoke(token)
+            self._store.clear()
+
+    def _refresh_locked(self) -> BearerToken:
+        token = _coerce_token(self._refresh())
+        self._store.set(token)
+        return token
+
+
+def normalize_auth_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for name, value in headers.items():
+        lower_name = name.lower()
+        if lower_name not in SENSITIVE_AUTH_HEADER_NAMES:
+            raise ValueError(f"Unsupported auth header {name!r}.")
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"Auth header {name!r} must be a non-empty string.")
+        canonical_name = "Authorization" if lower_name == "authorization" else "X-API-Key"
+        normalized[canonical_name] = value
+    return normalized
+
+
+def _coerce_token(value: BearerToken | Mapping[str, Any] | str) -> BearerToken:
+    if isinstance(value, BearerToken):
+        return value
+    if isinstance(value, str):
+        return BearerToken(value)
+    if not isinstance(value, Mapping):
+        raise TypeError("Token refresh callbacks must return BearerToken, mapping, or string.")
+
+    access_token = value.get("access_token") or value.get("accessToken") or value.get("token")
+    if not isinstance(access_token, str):
+        raise ValueError("Token mapping must include an access_token string.")
+
+    token_type = value.get("token_type") or value.get("tokenType") or "Bearer"
+    if not isinstance(token_type, str):
+        raise ValueError("Token mapping token_type must be a string.")
+
+    expires_at = value.get("expires_at") or value.get("expiresAt")
+    if expires_at is None and value.get("expires_in") is not None:
+        expires_in = value["expires_in"]
+        if not isinstance(expires_in, int | float):
+            raise ValueError("Token mapping expires_in must be numeric.")
+        return BearerToken.from_expires_in(access_token, expires_in, token_type=token_type)
+
+    return BearerToken(
+        access_token=access_token,
+        expires_at=_parse_expires_at(expires_at),
+        token_type=token_type,
+    )
+
+
+def _parse_expires_at(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _normalize_datetime(value)
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        return _normalize_datetime(datetime.fromisoformat(normalized))
+    raise ValueError("expires_at must be a datetime, timestamp, ISO datetime string, or None.")
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -16,9 +16,11 @@ from ._http import (
     _normalize_base_url,
     _to_http_error,
     _to_transport_error,
+    _validate_auth_configuration,
 )
 
 if TYPE_CHECKING:
+    from .auth import AuthProvider
     from .ogc import HonuaOgcFeatures
     from .protocols import (
         GeoServicesFeatureServerClient,
@@ -51,6 +53,7 @@ class HonuaClient:
         timeout: float = 30.0,
         api_key: str | None = None,
         bearer_token: str | None = None,
+        auth_provider: AuthProvider | None = None,
         follow_redirects: bool = False,
         client: httpx.Client | None = None,
         transport: httpx.BaseTransport | None = None,
@@ -58,6 +61,7 @@ class HonuaClient:
     ) -> None:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
+        _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
 
         self._owns_client = client is None
         if client is not None:
@@ -73,6 +77,7 @@ class HonuaClient:
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
+                auth_provider=auth_provider,
             )
 
         effective_transport = transport

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -17,7 +17,9 @@ from ._http import (
     _normalize_base_url,
     _to_http_error,
     _to_transport_error,
+    _validate_auth_configuration,
 )
+from .auth import AuthProvider
 
 
 @dataclass
@@ -55,12 +57,14 @@ class HonuaGeocodingClient:
         timeout: float = 30.0,
         api_key: str | None = None,
         bearer_token: str | None = None,
+        auth_provider: AuthProvider | None = None,
         client: httpx.Client | None = None,
         transport: httpx.BaseTransport | None = None,
         max_retries: int = 3,
     ) -> None:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
+        _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
 
         self._locator_name = locator_name
         self._owns_client = client is None
@@ -77,6 +81,7 @@ class HonuaGeocodingClient:
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
+                auth_provider=auth_provider,
             )
 
         effective_transport = transport

--- a/tests/admin/test_services.py
+++ b/tests/admin/test_services.py
@@ -8,7 +8,7 @@ from typing import Any
 import httpx
 import pytest
 
-from honua_sdk import HonuaHttpError
+from honua_sdk import CallableAuthProvider, HonuaHttpError
 from honua_admin import (
     HonuaAdminClient,
     ServiceSettingsResponse,
@@ -275,6 +275,24 @@ def test_follow_redirects_does_not_forward_sensitive_headers_to_different_host()
     assert len(seen) == 2
     assert seen[0] == ("test.honua.io", "test-key", "Bearer test-token")
     assert seen[1] == ("evil.example", "", "")
+
+
+def test_admin_client_auth_provider_headers_are_resolved_per_request() -> None:
+    seen: list[str] = []
+    api_keys = iter(["admin-key-1", "admin-key-2"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("x-api-key", ""))
+        return httpx.Response(200, json=make_api_response([]))
+
+    transport = httpx.MockTransport(handler)
+    auth_provider = CallableAuthProvider(lambda: {"X-API-Key": next(api_keys)})
+
+    with HonuaAdminClient("http://test.honua.io", transport=transport, auth_provider=auth_provider) as client:
+        client.list_services()
+        client.list_services()
+
+    assert seen == ["admin-key-1", "admin-key-2"]
 
 
 def test_transport_errors_are_normalized_to_honua_http_error() -> None:

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
+from honua_sdk import CallableAuthProvider
 from honua_sdk.async_client import AsyncHonuaClient
 from honua_sdk.errors import HonuaHttpError
 
@@ -127,6 +128,26 @@ async def test_auth_headers_are_attached() -> None:
     assert response["status"] == "ready"
     assert seen["x_api_key"] == "test-key"
     assert seen["authorization"] == "Bearer test-token"
+
+
+async def test_auth_provider_headers_are_resolved_per_request() -> None:
+    seen: list[str] = []
+    api_keys = iter(["async-key-1", "async-key-2"])
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("x-api-key", ""))
+        if request.url.path == "/healthz/ready":
+            return httpx.Response(200, json={"status": "ready"})
+        return httpx.Response(200, json={"services": []})
+
+    transport = httpx.MockTransport(handler)
+    auth_provider = CallableAuthProvider(lambda: {"X-API-Key": next(api_keys)})
+
+    async with AsyncHonuaClient("http://example.test", transport=transport, auth_provider=auth_provider) as client:
+        await client.readiness()
+        await client.list_services()
+
+    assert seen == ["async-key-1", "async-key-2"]
 
 
 async def test_non_success_raises_honua_http_error() -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from honua_sdk import (
+    BearerToken,
+    CallableAuthProvider,
+    InMemoryTokenStore,
+    RefreshableBearerTokenProvider,
+)
+
+
+def test_refreshable_bearer_provider_refreshes_expiring_token() -> None:
+    refreshed = BearerToken.from_expires_in("fresh-token", 3600)
+    calls = 0
+
+    def refresh() -> BearerToken:
+        nonlocal calls
+        calls += 1
+        return refreshed
+
+    provider = RefreshableBearerTokenProvider(
+        refresh,
+        initial_token=BearerToken(
+            "old-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(seconds=10),
+        ),
+        refresh_window_seconds=60,
+    )
+
+    assert provider.auth_headers() == {"Authorization": "Bearer fresh-token"}
+    assert provider.auth_headers() == {"Authorization": "Bearer fresh-token"}
+    assert calls == 1
+
+
+def test_refreshable_bearer_provider_reuses_non_expiring_token() -> None:
+    def refresh() -> BearerToken:
+        raise AssertionError("refresh should not be called for a non-expiring cached token")
+
+    provider = RefreshableBearerTokenProvider(
+        refresh,
+        initial_token=BearerToken("cached-token"),
+    )
+
+    assert provider.auth_headers() == {"Authorization": "Bearer cached-token"}
+
+
+def test_refreshable_bearer_provider_revokes_and_clears_cached_token() -> None:
+    revoked: list[str] = []
+    token_store = InMemoryTokenStore(BearerToken("cached-token"))
+
+    provider = RefreshableBearerTokenProvider(
+        lambda: {"access_token": "new-token", "expires_in": 3600},
+        token_store=token_store,
+        revoke=lambda token: revoked.append(token.access_token),
+    )
+
+    provider.revoke()
+
+    assert revoked == ["cached-token"]
+    assert token_store.get() is None
+    assert provider.auth_headers() == {"Authorization": "Bearer new-token"}
+
+
+def test_callable_auth_provider_rejects_non_auth_headers() -> None:
+    provider = CallableAuthProvider(lambda: {"X-Not-Auth": "value"})
+
+    with pytest.raises(ValueError, match="Unsupported auth header"):
+        provider.auth_headers()
+
+
+def test_bearer_token_accepts_epoch_and_iso_expiration_metadata() -> None:
+    epoch_token = RefreshableBearerTokenProvider(
+        lambda: {"access_token": "epoch", "expires_at": 2_000_000_000}
+    ).get_token()
+    iso_token = RefreshableBearerTokenProvider(
+        lambda: {"accessToken": "iso", "expiresAt": "2033-05-18T03:33:20Z"}
+    ).get_token()
+
+    assert epoch_token.expires_at == datetime.fromtimestamp(2_000_000_000, tz=timezone.utc)
+    assert iso_token.access_token == "iso"
+    assert iso_token.expires_at is not None
+    assert iso_token.expires_at.tzinfo is not None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
-from honua_sdk import HonuaClient, HonuaHttpError
+from honua_sdk import CallableAuthProvider, HonuaClient, HonuaHttpError
 
 
 def test_query_features_builds_expected_request() -> None:
@@ -224,6 +224,38 @@ def test_auth_headers_are_attached() -> None:
     assert seen["authorization"] == "Bearer test-token"
 
 
+def test_auth_provider_headers_are_resolved_per_request() -> None:
+    seen: list[str] = []
+    api_keys = iter(["rotated-key-1", "rotated-key-2"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("x-api-key", ""))
+        if request.url.path == "/healthz/ready":
+            return httpx.Response(200, json={"status": "ready"})
+        return httpx.Response(200, json={"services": []})
+
+    transport = httpx.MockTransport(handler)
+    auth_provider = CallableAuthProvider(lambda: {"X-API-Key": next(api_keys)})
+
+    with HonuaClient("http://example.test", transport=transport, auth_provider=auth_provider) as client:
+        client.readiness()
+        client.list_services()
+
+    assert seen == ["rotated-key-1", "rotated-key-2"]
+
+
+def test_auth_provider_cannot_be_combined_with_static_bearer_token() -> None:
+    auth_provider = CallableAuthProvider(lambda: {"Authorization": "Bearer dynamic"})
+
+    with pytest.raises(ValueError, match="bearer_token.*auth_provider"):
+        HonuaClient(
+            "http://example.test",
+            bearer_token="static",
+            auth_provider=auth_provider,
+            transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+        )
+
+
 def test_non_success_raises_honua_http_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -296,6 +328,46 @@ def test_follow_redirects_does_not_forward_sensitive_headers_to_different_host()
     assert len(seen) == 2
     assert seen[0] == ("example.test", "test-key", "Bearer test-token")
     assert seen[1] == ("evil.example", "", "")
+
+
+def test_follow_redirects_does_not_forward_auth_provider_headers_to_different_host() -> None:
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            (
+                request.url.host or "",
+                request.headers.get("x-api-key", ""),
+                request.headers.get("authorization", ""),
+            )
+        )
+        if request.url.host == "example.test":
+            return httpx.Response(
+                302,
+                headers={"Location": "https://evil.example/healthz/ready"},
+            )
+        return httpx.Response(200, json={"status": "ready"})
+
+    transport = httpx.MockTransport(handler)
+    auth_provider = CallableAuthProvider(
+        lambda: {
+            "Authorization": "Bearer dynamic-token",
+            "X-API-Key": "dynamic-key",
+        }
+    )
+    with HonuaClient(
+        "http://example.test",
+        transport=transport,
+        auth_provider=auth_provider,
+        follow_redirects=True,
+    ) as client:
+        response = client.readiness()
+
+    assert response == {"status": "ready"}
+    assert seen == [
+        ("example.test", "dynamic-key", "Bearer dynamic-token"),
+        ("evil.example", "", ""),
+    ]
 
 
 def test_transport_errors_are_normalized_to_honua_http_error() -> None:


### PR DESCRIPTION
## Summary

Closes #5.

- Add `honua_sdk.auth` with refreshable bearer token providers, in-memory token storage, callable auth headers, and explicit revocation support.
- Wire `auth_provider` through data-plane, async, geocoding, and admin clients while preserving trusted-host auth stripping on cross-host redirects.
- Document refresh, secure storage guidance, token/key rotation, revocation, and auth failure modes.

## Validation

- `.venv/bin/ruff check .`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests/test_auth.py tests/test_client.py tests/test_async_client.py tests/admin/test_services.py -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests -q -p no:cacheprovider`
- `git diff --check`
- `(cd packages/honua-sdk && /home/makani/honua-sdk-python/.venv/bin/python -m hatch build && /home/makani/honua-sdk-python/.venv/bin/python -m twine check dist/*)`
- `(cd packages/honua-admin && /home/makani/honua-sdk-python/.venv/bin/python -m hatch build && /home/makani/honua-sdk-python/.venv/bin/python -m twine check dist/*)`