### PR TITLE
[codex] Add typed core endpoint helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ client = HonuaClient("https://your-server.com", max_retries=0)
 ## Documentation
 
 - [5-Minute Quickstart](docs/quickstart.md) -- query, GeoDataFrame, and plot
+- [Core Client](docs/core-client.md) -- typed service, FeatureServer, applyEdits, pagination, and error handling helpers
 - [Geospatial ETL demo](examples/geospatial_etl/README.md) -- canonical script-first ETL flow plus notebook companion, with `load-summary.json` / `post-load-preview.png` artifacts and the `apply_edits` contract
 - [Authentication](docs/auth.md) -- refreshable bearer tokens, secure storage guidance, revocation, rotation, and failure modes
 - [Troubleshooting](docs/troubleshooting.md) -- staging smoke env vars and result artifacts, auth expectations, seeded `test_service` / layer `0` assumptions, optional example dependencies, and cleanup guidance

--- a/docs/core-client.md
+++ b/docs/core-client.md
@@ -1,0 +1,122 @@
+# Core Client
+
+The SDK keeps the original protocol-native methods for callers that need exact
+server JSON, and adds typed wrappers for common early-adopter workflows.
+
+## Service Catalog
+
+Use `list_services()` when you need the raw `/rest/services` payload:
+
+```python
+from honua_sdk import HonuaClient
+
+with HonuaClient("https://honua.example") as client:
+    payload = client.list_services()
+```
+
+Use `list_service_summaries()` when you want typed service entries:
+
+```python
+from honua_sdk import HonuaClient
+
+with HonuaClient("https://honua.example") as client:
+    services = client.list_service_summaries()
+    for service in services:
+        print(service.name, service.type)
+```
+
+## FeatureServer Queries
+
+`query_features()` returns the raw FeatureServer response. `query_feature_set()`
+wraps the same response in a `FeatureSet` with typed `Feature` entries:
+
+```python
+from honua_sdk import HonuaClient
+
+with HonuaClient("https://honua.example") as client:
+    feature_set = client.query_feature_set(
+        "parcels",
+        0,
+        where="status = 'active'",
+        out_fields=["objectid", "name", "status"],
+    )
+
+    for feature in feature_set.features:
+        print(feature.object_id, feature.attributes["name"])
+```
+
+The raw response is preserved on `FeatureSet.raw` and `Feature.raw` for fields
+that are not lifted into typed attributes.
+
+## Pagination
+
+Use `query_features_all()` to page a FeatureServer layer with
+`resultOffset` and `resultRecordCount`:
+
+```python
+from honua_sdk import HonuaClient
+
+with HonuaClient("https://honua.example") as client:
+    features = client.query_features_all(
+        "parcels",
+        0,
+        where="1=1",
+        page_size=500,
+        limit=2000,
+    )
+```
+
+The helper stops when:
+
+- the requested `limit` is reached
+- a page returns fewer features than requested
+- `exceededTransferLimit` is absent or false
+- `max_pages` is reached
+
+Use `max_pages` as a guardrail for broad queries. Keep `page_size` aligned with
+the server layer's configured maximum record count.
+
+The async client exposes the same methods:
+
+```python
+from honua_sdk import AsyncHonuaClient
+
+async with AsyncHonuaClient("https://honua.example") as client:
+    features = await client.query_features_all("parcels", 0, page_size=500)
+```
+
+## Edits
+
+`apply_edits()` returns raw JSON. `apply_edits_result()` wraps add, update, and
+delete outcomes in typed operation results:
+
+```python
+result = client.apply_edits_result(
+    "parcels",
+    0,
+    updates=[
+        {
+            "attributes": {"objectid": 10, "status": "retired"},
+        }
+    ],
+)
+
+if not result.all_succeeded:
+    print(result.raw)
+```
+
+## Errors And Retries
+
+Non-2xx HTTP responses raise `HonuaHttpError`. The exception includes:
+
+- `status_code`
+- `message`
+- `body`, when the server response body can be parsed or decoded
+
+Transport failures such as DNS, TLS, or connection errors are normalized to
+`HonuaHttpError` with `status_code == 0`.
+
+Clients retry transient responses through the shared retry transport. Retry is
+limited to `429`, `502`, and `503`, with `Retry-After` support when the server
+provides it. Auth failures such as `401` and `403` are not retried; refresh or
+replace credentials before retrying those requests.

--- a/packages/honua-sdk/README.md
+++ b/packages/honua-sdk/README.md
@@ -27,8 +27,8 @@ Requires Python 3.11+.
 from honua_sdk import HonuaClient
 
 with HonuaClient("https://your-honua-server.com") as client:
-    result = client.query_features("natural-earth", layer_id=0)
-    print(f"Found {len(result.get('features', []))} features")
+    result = client.query_feature_set("natural-earth", layer_id=0)
+    print(f"Found {len(result.features)} features")
 ```
 
 ## Refreshable Auth
@@ -70,6 +70,7 @@ with HonuaClient("https://your-honua-server.com") as client:
 ## Documentation
 
 - [5-Minute Quickstart](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/quickstart.md) - query features, convert them to a GeoDataFrame, and plot them
+- [Core Client](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/core-client.md) - typed service, FeatureServer, applyEdits, pagination, and error handling helpers
 - [Geospatial ETL demo](https://github.com/honua-io/honua-sdk-python/blob/trunk/examples/geospatial_etl/README.md) - canonical script-first extract/validate/write/reconcile flow with the notebook companion and `load-summary.json` / `post-load-preview.png` contract
 - [Authentication](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/auth.md) - refreshable bearer tokens, secure storage guidance, revocation, rotation, and failure modes
 - [Troubleshooting](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/troubleshooting.md) - base URL selection, auth, staging smoke env vars, JSON/JUnit artifacts, and cleanup guidance

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -35,6 +35,7 @@ from .geocoding import (
     HonuaGeocodingClient,
     ReverseGeocodeResult,
 )
+from .models import ApplyEditsResult, EditOperationResult, Feature, FeatureSet, ServiceSummary
 from .ogc import (
     AsyncHonuaOgcFeatureCollection,
     AsyncHonuaOgcFeatures,
@@ -64,8 +65,12 @@ __all__ = [
     "AsyncHonuaGeocodingClient",
     "AsyncHonuaOgcFeatureCollection",
     "AsyncHonuaOgcFeatures",
+    "ApplyEditsResult",
     "BearerToken",
     "CallableAuthProvider",
+    "EditOperationResult",
+    "Feature",
+    "FeatureSet",
     "GeocodeResult",
     "GeocodeSuggestion",
     "GeoServicesFeatureServerClient",
@@ -87,6 +92,7 @@ __all__ = [
     "OgcTilesClient",
     "RefreshableBearerTokenProvider",
     "ReverseGeocodeResult",
+    "ServiceSummary",
     "StacClient",
     "StaticAuthProvider",
     "TokenStore",

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -18,6 +18,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
 )
+from .models import ApplyEditsResult, Feature, FeatureSet, ServiceSummary
 
 if TYPE_CHECKING:
     from .auth import AuthProvider
@@ -101,6 +102,14 @@ class AsyncHonuaClient:
             params={"f": response_format},
         )
 
+    async def list_service_summaries(self, *, response_format: str = "json") -> list[ServiceSummary]:
+        """List services as typed catalog summaries."""
+        response = await self.list_services(response_format=response_format)
+        services = response.get("services")
+        if not isinstance(services, list):
+            return []
+        return [ServiceSummary.from_dict(service) for service in services if isinstance(service, Mapping)]
+
     def ogc_features(self) -> "AsyncHonuaOgcFeatures":
         """Return an async OGC API Features wrapper bound to this client."""
         from .ogc import AsyncHonuaOgcFeatures
@@ -139,6 +148,67 @@ class AsyncHonuaClient:
             params=params,
         )
 
+    async def query_feature_set(
+        self,
+        service_id: str,
+        layer_id: int,
+        **kwargs: Any,
+    ) -> FeatureSet:
+        """Query a FeatureServer layer and return a typed feature set."""
+        return FeatureSet.from_dict(await self.query_features(service_id, layer_id, **kwargs))
+
+    async def query_features_all(
+        self,
+        service_id: str,
+        layer_id: int,
+        *,
+        where: str = "1=1",
+        out_fields: str | Sequence[str] = "*",
+        return_geometry: bool = True,
+        page_size: int = 1000,
+        limit: int | None = None,
+        max_pages: int = 100,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> list[Feature]:
+        """Page through FeatureServer query results and return typed features."""
+        if page_size <= 0:
+            raise ValueError("page_size must be greater than zero.")
+        if max_pages <= 0:
+            raise ValueError("max_pages must be greater than zero.")
+        if limit is not None and limit <= 0:
+            return []
+
+        features: list[Feature] = []
+        offset = int((extra_params or {}).get("resultOffset", 0))
+        base_extra_params = dict(extra_params or {})
+        for _ in range(max_pages):
+            remaining = None if limit is None else limit - len(features)
+            if remaining is not None and remaining <= 0:
+                break
+            record_count = page_size if remaining is None else min(page_size, remaining)
+            page_extra_params = {
+                **base_extra_params,
+                "resultOffset": offset,
+                "resultRecordCount": record_count,
+            }
+            page = await self.query_feature_set(
+                service_id,
+                layer_id,
+                where=where,
+                out_fields=out_fields,
+                return_geometry=return_geometry,
+                extra_params=page_extra_params,
+            )
+            page_features = list(page.features)
+            if remaining is not None:
+                page_features = page_features[:remaining]
+            features.extend(page_features)
+            if len(page.features) < record_count or not page.exceeded_transfer_limit:
+                break
+            offset += len(page.features)
+
+        return features
+
     async def apply_edits(
         self,
         service_id: str,
@@ -170,6 +240,15 @@ class AsyncHonuaClient:
             f"/rest/services/{service_segment}/FeatureServer/{layer_id}/applyEdits",
             json_body=payload,
         )
+
+    async def apply_edits_result(
+        self,
+        service_id: str,
+        layer_id: int,
+        **kwargs: Any,
+    ) -> ApplyEditsResult:
+        """Submit applyEdits and return typed operation results."""
+        return ApplyEditsResult.from_dict(await self.apply_edits(service_id, layer_id, **kwargs))
 
     async def export_map(
         self,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -18,6 +18,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
 )
+from .models import ApplyEditsResult, Feature, FeatureSet, ServiceSummary
 
 if TYPE_CHECKING:
     from .auth import AuthProvider
@@ -115,6 +116,14 @@ class HonuaClient:
             "/rest/services",
             params={"f": response_format},
         )
+
+    def list_service_summaries(self, *, response_format: str = "json") -> list[ServiceSummary]:
+        """List services as typed catalog summaries."""
+        response = self.list_services(response_format=response_format)
+        services = response.get("services")
+        if not isinstance(services, list):
+            return []
+        return [ServiceSummary.from_dict(service) for service in services if isinstance(service, Mapping)]
 
     def ogc_features(self) -> "HonuaOgcFeatures":
         """Return an OGC API Features wrapper bound to this client."""
@@ -232,6 +241,67 @@ class HonuaClient:
             params=params,
         )
 
+    def query_feature_set(
+        self,
+        service_id: str,
+        layer_id: int,
+        **kwargs: Any,
+    ) -> FeatureSet:
+        """Query a FeatureServer layer and return a typed feature set."""
+        return FeatureSet.from_dict(self.query_features(service_id, layer_id, **kwargs))
+
+    def query_features_all(
+        self,
+        service_id: str,
+        layer_id: int,
+        *,
+        where: str = "1=1",
+        out_fields: str | Sequence[str] = "*",
+        return_geometry: bool = True,
+        page_size: int = 1000,
+        limit: int | None = None,
+        max_pages: int = 100,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> list[Feature]:
+        """Page through FeatureServer query results and return typed features."""
+        if page_size <= 0:
+            raise ValueError("page_size must be greater than zero.")
+        if max_pages <= 0:
+            raise ValueError("max_pages must be greater than zero.")
+        if limit is not None and limit <= 0:
+            return []
+
+        features: list[Feature] = []
+        offset = int((extra_params or {}).get("resultOffset", 0))
+        base_extra_params = dict(extra_params or {})
+        for _ in range(max_pages):
+            remaining = None if limit is None else limit - len(features)
+            if remaining is not None and remaining <= 0:
+                break
+            record_count = page_size if remaining is None else min(page_size, remaining)
+            page_extra_params = {
+                **base_extra_params,
+                "resultOffset": offset,
+                "resultRecordCount": record_count,
+            }
+            page = self.query_feature_set(
+                service_id,
+                layer_id,
+                where=where,
+                out_fields=out_fields,
+                return_geometry=return_geometry,
+                extra_params=page_extra_params,
+            )
+            page_features = list(page.features)
+            if remaining is not None:
+                page_features = page_features[:remaining]
+            features.extend(page_features)
+            if len(page.features) < record_count or not page.exceeded_transfer_limit:
+                break
+            offset += len(page.features)
+
+        return features
+
     def apply_edits(
         self,
         service_id: str,
@@ -263,6 +333,15 @@ class HonuaClient:
             f"/rest/services/{service_segment}/FeatureServer/{layer_id}/applyEdits",
             json_body=payload,
         )
+
+    def apply_edits_result(
+        self,
+        service_id: str,
+        layer_id: int,
+        **kwargs: Any,
+    ) -> ApplyEditsResult:
+        """Submit applyEdits and return typed operation results."""
+        return ApplyEditsResult.from_dict(self.apply_edits(service_id, layer_id, **kwargs))
 
     def export_map(
         self,

--- a/packages/honua-sdk/honua_sdk/models.py
+++ b/packages/honua-sdk/honua_sdk/models.py
@@ -1,0 +1,149 @@
+"""Typed models for core Honua SDK responses."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ServiceSummary:
+    """GeoServices catalog service summary."""
+
+    name: str
+    type: str | None = None
+    url: str | None = None
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ServiceSummary":
+        return cls(
+            name=str(payload.get("name") or payload.get("serviceName") or ""),
+            type=_optional_str(payload.get("type")),
+            url=_optional_str(payload.get("url")),
+            raw=dict(payload),
+        )
+
+
+@dataclass(frozen=True)
+class Feature:
+    """FeatureServer feature with attributes and optional geometry."""
+
+    attributes: Mapping[str, Any]
+    geometry: Mapping[str, Any] | None = None
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Feature":
+        attributes = payload.get("attributes")
+        geometry = payload.get("geometry")
+        return cls(
+            attributes=dict(attributes) if isinstance(attributes, Mapping) else {},
+            geometry=dict(geometry) if isinstance(geometry, Mapping) else None,
+            raw=dict(payload),
+        )
+
+    @property
+    def object_id(self) -> int | None:
+        for key in ("objectid", "objectId", "OBJECTID"):
+            value = self.attributes.get(key)
+            if value is not None:
+                return int(value)
+        return None
+
+
+@dataclass(frozen=True)
+class FeatureSet:
+    """Typed FeatureServer query response."""
+
+    features: tuple[Feature, ...]
+    fields: tuple[Mapping[str, Any], ...] = ()
+    geometry_type: str | None = None
+    spatial_reference: Mapping[str, Any] | None = None
+    exceeded_transfer_limit: bool = False
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "FeatureSet":
+        raw_features = payload.get("features")
+        raw_fields = payload.get("fields")
+        spatial_reference = payload.get("spatialReference")
+        return cls(
+            features=tuple(
+                Feature.from_dict(feature)
+                for feature in raw_features or []
+                if isinstance(feature, Mapping)
+            ),
+            fields=tuple(dict(field) for field in raw_fields or [] if isinstance(field, Mapping)),
+            geometry_type=_optional_str(payload.get("geometryType")),
+            spatial_reference=dict(spatial_reference) if isinstance(spatial_reference, Mapping) else None,
+            exceeded_transfer_limit=bool(payload.get("exceededTransferLimit", False)),
+            raw=dict(payload),
+        )
+
+
+@dataclass(frozen=True)
+class EditOperationResult:
+    """One add, update, or delete result from applyEdits."""
+
+    success: bool
+    object_id: int | None = None
+    global_id: str | None = None
+    error: Mapping[str, Any] | None = None
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "EditOperationResult":
+        return cls(
+            success=bool(payload.get("success", False)),
+            object_id=_optional_int(_first_present(payload, "objectId", "objectid")),
+            global_id=_optional_str(_first_present(payload, "globalId", "globalid")),
+            error=dict(payload["error"]) if isinstance(payload.get("error"), Mapping) else None,
+            raw=dict(payload),
+        )
+
+
+@dataclass(frozen=True)
+class ApplyEditsResult:
+    """Typed applyEdits response grouped by operation."""
+
+    add_results: tuple[EditOperationResult, ...] = ()
+    update_results: tuple[EditOperationResult, ...] = ()
+    delete_results: tuple[EditOperationResult, ...] = ()
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ApplyEditsResult":
+        return cls(
+            add_results=_edit_results(payload.get("addResults")),
+            update_results=_edit_results(payload.get("updateResults")),
+            delete_results=_edit_results(payload.get("deleteResults")),
+            raw=dict(payload),
+        )
+
+    @property
+    def all_succeeded(self) -> bool:
+        results = [*self.add_results, *self.update_results, *self.delete_results]
+        return bool(results) and all(result.success for result in results)
+
+
+def _edit_results(value: Any) -> tuple[EditOperationResult, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return ()
+    return tuple(EditOperationResult.from_dict(item) for item in value if isinstance(item, Mapping))
+
+
+def _optional_str(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if value is not None else None
+
+
+def _first_present(payload: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in payload:
+            return payload[key]
+    return None

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -59,6 +59,48 @@ async def test_list_services_returns_json() -> None:
     assert response == {"services": [{"name": "s1"}]}
 
 
+async def test_list_service_summaries_returns_typed_catalog_entries() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/services"
+        return httpx.Response(
+            200,
+            json={"services": [{"name": "parcels", "type": "FeatureServer"}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        services = await client.list_service_summaries()
+
+    assert services[0].name == "parcels"
+    assert services[0].type == "FeatureServer"
+
+
+async def test_query_features_all_returns_typed_paginated_features() -> None:
+    seen: list[tuple[str, str]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        query = dict(request.url.params.multi_items())
+        seen.append((query["resultOffset"], query["resultRecordCount"]))
+        offset = int(query["resultOffset"])
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {"attributes": {"objectid": offset + 1}},
+                    {"attributes": {"objectid": offset + 2}},
+                ],
+                "exceededTransferLimit": offset == 0,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        features = await client.query_features_all("parcels", 0, page_size=2, limit=3)
+
+    assert [feature.object_id for feature in features] == [1, 2, 3]
+    assert seen == [("0", "2"), ("2", "1")]
+
+
 async def test_ogc_features_items_builds_expected_request() -> None:
     seen: dict[str, Any] = {}
 
@@ -234,6 +276,19 @@ async def test_apply_edits_posts_json_payload() -> None:
     assert seen["payload"]["rollbackOnFailure"] is True
     assert seen["payload"]["adds"][0]["attributes"]["name"] == "A"
     assert seen["payload"]["deletes"] == [1, 3]
+
+
+async def test_apply_edits_result_returns_typed_operation_results() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"addResults": [{"success": True, "objectId": 10}]})
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        result = await client.apply_edits_result("parcels", 0, adds=[{"attributes": {"name": "A"}}])
+
+    assert result.add_results[0].success is True
+    assert result.add_results[0].object_id == 10
+    assert result.all_succeeded is True
 
 
 async def test_client_rejects_both_client_and_transport() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -51,6 +51,83 @@ def test_query_features_url_encodes_service_id_path_segment() -> None:
     assert seen["raw_path"] == "/rest/services/team%20alpha%2Fdefault/FeatureServer/2/query"
 
 
+def test_list_service_summaries_returns_typed_catalog_entries() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/services"
+        return httpx.Response(
+            200,
+            json={
+                "services": [
+                    {"name": "parcels", "type": "FeatureServer", "url": "/rest/services/parcels/FeatureServer"}
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        services = client.list_service_summaries()
+
+    assert len(services) == 1
+    assert services[0].name == "parcels"
+    assert services[0].type == "FeatureServer"
+    assert services[0].raw["url"] == "/rest/services/parcels/FeatureServer"
+
+
+def test_query_feature_set_returns_typed_features() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/services/parcels/FeatureServer/0/query"
+        return httpx.Response(
+            200,
+            json={
+                "geometryType": "esriGeometryPoint",
+                "spatialReference": {"wkid": 4326},
+                "fields": [{"name": "objectid", "type": "esriFieldTypeOID"}],
+                "features": [
+                    {
+                        "attributes": {"objectid": 10, "name": "A"},
+                        "geometry": {"x": -157.8, "y": 21.3},
+                    }
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        feature_set = client.query_feature_set("parcels", 0)
+
+    assert feature_set.geometry_type == "esriGeometryPoint"
+    assert feature_set.spatial_reference == {"wkid": 4326}
+    assert feature_set.features[0].object_id == 10
+    assert feature_set.features[0].attributes["name"] == "A"
+
+
+def test_query_features_all_pages_until_transfer_limit_clears() -> None:
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = dict(request.url.params.multi_items())
+        seen.append((query["resultOffset"], query["resultRecordCount"]))
+        offset = int(query["resultOffset"])
+        features = [
+            {"attributes": {"objectid": offset + 1}},
+            {"attributes": {"objectid": offset + 2}},
+        ]
+        return httpx.Response(
+            200,
+            json={
+                "features": features,
+                "exceededTransferLimit": offset == 0,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        features = client.query_features_all("parcels", 0, page_size=2, limit=3)
+
+    assert [feature.object_id for feature in features] == [1, 2, 3]
+    assert seen == [("0", "2"), ("2", "1")]
+
+
 def test_ogc_features_metadata_and_items_build_expected_requests() -> None:
     seen: list[dict[str, Any]] = []
 
@@ -200,6 +277,27 @@ def test_apply_edits_posts_json_payload() -> None:
     assert seen["payload"]["rollbackOnFailure"] is True
     assert seen["payload"]["adds"][0]["attributes"]["name"] == "A"
     assert seen["payload"]["deletes"] == [1, 3]
+
+
+def test_apply_edits_result_returns_typed_operation_results() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "addResults": [{"success": True, "objectId": 10}],
+                "updateResults": [{"success": True, "objectId": 11}],
+                "deleteResults": [{"success": False, "objectId": 12, "error": {"message": "locked"}}],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        result = client.apply_edits_result("parcels", 0, deletes=[12])
+
+    assert result.add_results[0].object_id == 10
+    assert result.update_results[0].success is True
+    assert result.delete_results[0].error == {"message": "locked"}
+    assert result.all_succeeded is False
 
 
 def test_auth_headers_are_attached() -> None:


### PR DESCRIPTION
## Summary

Closes #2.

- Add typed core response models for service catalog entries, FeatureServer features/query responses, and applyEdits operation results.
- Add non-breaking sync/async helpers: `list_service_summaries`, `query_feature_set`, `query_features_all`, and `apply_edits_result` while keeping raw dict APIs intact.
- Document core client usage, FeatureServer pagination, retry behavior, and normalized `HonuaHttpError` failure modes.

## Validation

- `.venv/bin/ruff check .`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests/test_client.py tests/test_async_client.py -q -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests -q -p no:cacheprovider`
- `git diff --check`
- `(cd packages/honua-sdk && /home/makani/honua-sdk-python/.venv/bin/python -m hatch build && /home/makani/honua-sdk-python/.venv/bin/python -m twine check dist/*)`
- `(cd packages/honua-admin && /home/makani/honua-sdk-python/.venv/bin/python -m hatch build && /home/makani/honua-sdk-python/.venv/bin/python -m twine check dist/*)`