### PR TITLE
[codex] Add SDK compatibility gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,29 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -q --tb=short
 
+  compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+          cache-dependency-path: |
+            packages/honua-sdk/pyproject.toml
+            packages/honua-admin/pyproject.toml
+
+      - name: Install packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "packages/honua-sdk[grpc]"
+          pip install -e "packages/honua-admin"
+
+      - name: Run compatibility gate
+        run: python scripts/compatibility_gate.py
+
   package:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -53,6 +53,10 @@ jobs:
           pip install -e ".[grpc]"
           pip install pytest hatch twine
 
+      - name: Run compatibility gate
+        run: python scripts/compatibility_gate.py
+        working-directory: ${{ github.workspace }}
+
       - name: Run SDK tests
         run: python -m pytest ../../tests/ -q --tb=short -k "not admin"
         working-directory: ${{ github.workspace }}
@@ -118,9 +122,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e "${{ github.workspace }}/packages/honua-sdk"
+          pip install -e "${{ github.workspace }}/packages/honua-sdk[grpc]"
           pip install -e .
           pip install pytest hatch twine
+
+      - name: Run compatibility gate
+        run: python scripts/compatibility_gate.py
+        working-directory: ${{ github.workspace }}
 
       - name: Run admin tests
         run: python -m pytest ../../tests/admin/ -q --tb=short

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ client = HonuaClient("https://your-server.com", max_retries=0)
 - [Core Client](docs/core-client.md) -- typed service, FeatureServer, applyEdits, pagination, and error handling helpers
 - [Geospatial ETL demo](examples/geospatial_etl/README.md) -- canonical script-first ETL flow plus notebook companion, with `load-summary.json` / `post-load-preview.png` artifacts and the `apply_edits` contract
 - [Authentication](docs/auth.md) -- refreshable bearer tokens, secure storage guidance, revocation, rotation, and failure modes
+- [Compatibility](docs/compatibility.md) -- supported server matrix, public API snapshot gate, and release blocking policy
 - [Troubleshooting](docs/troubleshooting.md) -- staging smoke env vars and result artifacts, auth expectations, seeded `test_service` / layer `0` assumptions, optional example dependencies, and cleanup guidance
 - [Operating Cadence](docs/operating-cadence.md) -- weekly backlog review, scope gate, and done/close hygiene
 - [INSTALL.md](INSTALL.md) -- installation options and version policy
@@ -186,6 +187,9 @@ pip install -e "packages/honua-admin"
 
 # Run the deterministic local suite
 python3 -m pytest tests/ -q
+
+# Run the compatibility gate
+python3 scripts/compatibility_gate.py
 
 # Run the opt-in staging smoke suite
 python3 -m pytest tests/integration -q --run-integration -m "integration and staging and smoke"

--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -1,0 +1,3574 @@
+{
+  "modules": {
+    "honua_admin": {
+      "exports": [
+        "AccessPolicyResponse",
+        "AdminCapabilitiesResponse",
+        "AdminCompatibilityBaseline",
+        "AdminCompatibilityCheckResult",
+        "AdminCompatibilityFeatureFlags",
+        "AdminCompatibilityMetadata",
+        "AdminControlPlaneApiCompatibility",
+        "AdminMetadataSchemaCompatibility",
+        "AdminVersionResponse",
+        "AsyncHonuaAdminClient",
+        "ColumnInfo",
+        "ConnectionTestResult",
+        "CreateSecureConnectionRequest",
+        "EncryptionValidationResult",
+        "HonuaAdminClient",
+        "KeyRotationResult",
+        "LayerStyleResponse",
+        "LayerStyleUpdateRequest",
+        "MINIMUM_SUPPORTED_CONTROL_PLANE_API_MAJOR",
+        "MINIMUM_SUPPORTED_CONTROL_PLANE_BASE_PATH",
+        "MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL",
+        "MINIMUM_SUPPORTED_SERVER_VERSION",
+        "ManifestApplyEntry",
+        "ManifestApplyRequest",
+        "ManifestApplyResult",
+        "ManifestApplySummary",
+        "MapServerSettings",
+        "MetadataManifest",
+        "MetadataResource",
+        "MetadataResourceIdentifier",
+        "PublishLayerRequest",
+        "PublishedLayerSummary",
+        "ResourceMetadata",
+        "SecureConnectionDetail",
+        "SecureConnectionSummary",
+        "ServiceSettingsResponse",
+        "ServiceSummary",
+        "TableDiscoveryResponse",
+        "TableInfo",
+        "TimeInfoResponse",
+        "UpdateSecureConnectionRequest",
+        "__version__",
+        "evaluate_admin_compatibility"
+      ],
+      "symbols": {
+        "AccessPolicyResponse": {
+          "fields": [
+            {
+              "annotation": "bool",
+              "name": "allow_anonymous"
+            },
+            {
+              "annotation": "bool",
+              "name": "allow_anonymous_write"
+            },
+            {
+              "annotation": "list[str]",
+              "name": "allowed_roles"
+            },
+            {
+              "annotation": "list[str]",
+              "name": "allowed_write_roles"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AccessPolicyResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AccessPolicyResponse",
+          "signature": "(allow_anonymous: 'bool', allow_anonymous_write: 'bool', allowed_roles: 'list[str]', allowed_write_roles: 'list[str]') -> None"
+        },
+        "AdminCapabilitiesResponse": {
+          "fields": [
+            {
+              "annotation": "list[str]",
+              "defaultFactory": "list",
+              "name": "metadata_api_versions"
+            },
+            {
+              "annotation": "list[str]",
+              "defaultFactory": "list",
+              "name": "resource_kinds"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_supported"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_dry_run_supported"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_prune_supported"
+            },
+            {
+              "annotation": "AdminCompatibilityMetadata | None",
+              "default": "None",
+              "name": "compatibility"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AdminCapabilitiesResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AdminCapabilitiesResponse",
+          "signature": "(metadata_api_versions: 'list[str]' = <factory>, resource_kinds: 'list[str]' = <factory>, manifest_supported: 'bool' = False, manifest_dry_run_supported: 'bool' = False, manifest_prune_supported: 'bool' = False, compatibility: 'AdminCompatibilityMetadata | None' = None) -> None"
+        },
+        "AdminCompatibilityBaseline": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "'2026.3.0'",
+              "name": "minimum_server_version"
+            },
+            {
+              "annotation": "int",
+              "default": "1",
+              "name": "control_plane_api_major"
+            },
+            {
+              "annotation": "str",
+              "default": "'/api/v1/admin'",
+              "name": "base_path"
+            },
+            {
+              "annotation": "str",
+              "default": "'preview'",
+              "name": "minimum_release_channel"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_admin._models",
+          "qualname": "AdminCompatibilityBaseline",
+          "signature": "(minimum_server_version: 'str' = '2026.3.0', control_plane_api_major: 'int' = 1, base_path: 'str' = '/api/v1/admin', minimum_release_channel: 'str' = 'preview') -> None"
+        },
+        "AdminCompatibilityCheckResult": {
+          "fields": [
+            {
+              "annotation": "bool",
+              "name": "supported"
+            },
+            {
+              "annotation": "AdminCompatibilityBaseline",
+              "name": "baseline"
+            },
+            {
+              "annotation": "AdminCompatibilityMetadata | None",
+              "name": "compatibility"
+            },
+            {
+              "annotation": "list[str]",
+              "defaultFactory": "list",
+              "name": "reasons"
+            },
+            {
+              "annotation": "list[str]",
+              "defaultFactory": "list",
+              "name": "warnings"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_admin._models",
+          "qualname": "AdminCompatibilityCheckResult",
+          "signature": "(supported: 'bool', baseline: 'AdminCompatibilityBaseline', compatibility: 'AdminCompatibilityMetadata | None', reasons: 'list[str]' = <factory>, warnings: 'list[str]' = <factory>) -> None"
+        },
+        "AdminCompatibilityFeatureFlags": {
+          "fields": [
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "metadata_resources"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_export"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_apply"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_dry_run"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "manifest_prune"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AdminCompatibilityFeatureFlags'"
+            },
+            "supports": {
+              "kind": "method",
+              "signature": "(self, feature: 'str') -> 'bool'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AdminCompatibilityFeatureFlags",
+          "signature": "(metadata_resources: 'bool' = False, manifest_export: 'bool' = False, manifest_apply: 'bool' = False, manifest_dry_run: 'bool' = False, manifest_prune: 'bool' = False) -> None"
+        },
+        "AdminCompatibilityMetadata": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "server_version"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "release_channel"
+            },
+            {
+              "annotation": "AdminControlPlaneApiCompatibility",
+              "defaultFactory": "honua_admin._models.AdminControlPlaneApiCompatibility",
+              "name": "control_plane_api"
+            },
+            {
+              "annotation": "list[AdminMetadataSchemaCompatibility]",
+              "defaultFactory": "list",
+              "name": "metadata_schemas"
+            },
+            {
+              "annotation": "AdminCompatibilityFeatureFlags",
+              "defaultFactory": "honua_admin._models.AdminCompatibilityFeatureFlags",
+              "name": "features"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AdminCompatibilityMetadata'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AdminCompatibilityMetadata",
+          "signature": "(server_version: 'str' = '', release_channel: 'str' = '', control_plane_api: 'AdminControlPlaneApiCompatibility' = <factory>, metadata_schemas: 'list[AdminMetadataSchemaCompatibility]' = <factory>, features: 'AdminCompatibilityFeatureFlags' = <factory>) -> None"
+        },
+        "AdminControlPlaneApiCompatibility": {
+          "fields": [
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "major"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "base_path"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "deprecated"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AdminControlPlaneApiCompatibility'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AdminControlPlaneApiCompatibility",
+          "signature": "(major: 'int' = 0, base_path: 'str' = '', deprecated: 'bool' = False) -> None"
+        },
+        "AdminMetadataSchemaCompatibility": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "version"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "deprecated"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AdminMetadataSchemaCompatibility'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AdminMetadataSchemaCompatibility",
+          "signature": "(version: 'str', deprecated: 'bool' = False) -> None"
+        },
+        "AdminVersionResponse": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "version"
+            },
+            {
+              "annotation": "str",
+              "name": "metadata_api_version"
+            },
+            {
+              "annotation": "str | None",
+              "name": "server_time"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'AdminVersionResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "AdminVersionResponse",
+          "signature": "(version: 'str', metadata_api_version: 'str', server_time: 'str | None') -> None"
+        },
+        "AsyncHonuaAdminClient": {
+          "kind": "class",
+          "methods": {
+            "apply_manifest": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, request: 'ManifestApplyRequest') -> 'ManifestApplyResult'"
+            },
+            "check_compatibility": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'AdminCompatibilityCheckResult'"
+            },
+            "close": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "create_connection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, request: 'CreateSecureConnectionRequest') -> 'SecureConnectionSummary'"
+            },
+            "create_metadata_resource": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, resource: 'MetadataResource') -> 'MetadataResource'"
+            },
+            "delete_connection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, id: 'str') -> 'None'"
+            },
+            "delete_metadata_resource": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, kind: 'str', ns: 'str', name: 'str', *, if_match: 'str | None' = None) -> 'None'"
+            },
+            "discover_tables": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, conn_id: 'str') -> 'TableDiscoveryResponse'"
+            },
+            "get_capabilities": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'AdminCapabilitiesResponse'"
+            },
+            "get_capability_flags": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'AdminCompatibilityFeatureFlags'"
+            },
+            "get_config": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            },
+            "get_connection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, id: 'str') -> 'SecureConnectionDetail'"
+            },
+            "get_layer_style": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, layer_id: 'int') -> 'LayerStyleResponse'"
+            },
+            "get_manifest": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, namespace: 'str | None' = None) -> 'MetadataManifest'"
+            },
+            "get_metadata_resource": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, kind: 'str', ns: 'str', name: 'str') -> 'tuple[MetadataResource, str | None]'"
+            },
+            "get_service_settings": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, name: 'str') -> 'ServiceSettingsResponse'"
+            },
+            "get_version": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'AdminVersionResponse'"
+            },
+            "list_connections": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'list[SecureConnectionSummary]'"
+            },
+            "list_layers": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', service_name: 'str | None' = None) -> 'list[PublishedLayerSummary]'"
+            },
+            "list_metadata_resources": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, kind: 'str | None' = None, namespace: 'str | None' = None) -> 'list[MetadataResource]'"
+            },
+            "list_services": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'list[ServiceSummary]'"
+            },
+            "publish_layer": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', request: 'PublishLayerRequest') -> 'PublishedLayerSummary'"
+            },
+            "rotate_encryption_key": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'KeyRotationResult'"
+            },
+            "set_layer_enabled": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', layer_id: 'int', enabled: 'bool', service_name: 'str | None' = None) -> 'PublishedLayerSummary'"
+            },
+            "set_service_layers_enabled": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', enabled: 'bool', service_name: 'str | None' = None) -> 'list[PublishedLayerSummary]'"
+            },
+            "test_connection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, id: 'str') -> 'ConnectionTestResult'"
+            },
+            "test_draft_connection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, request: 'CreateSecureConnectionRequest') -> 'ConnectionTestResult'"
+            },
+            "update_connection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, id: 'str', request: 'UpdateSecureConnectionRequest') -> 'SecureConnectionSummary'"
+            },
+            "update_layer_style": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', request: 'LayerStyleUpdateRequest') -> 'LayerStyleResponse'"
+            },
+            "update_mapserver_settings": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, name: 'str', **kwargs: 'Any') -> 'ServiceSettingsResponse'"
+            },
+            "update_metadata_resource": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, kind: 'str', ns: 'str', name: 'str', resource: 'MetadataResource', *, if_match: 'str | None' = None) -> 'MetadataResource'"
+            },
+            "update_protocols": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, name: 'str', protocols: 'list[str]') -> 'ServiceSettingsResponse'"
+            },
+            "validate_encryption": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'EncryptionValidationResult'"
+            }
+          },
+          "module": "honua_admin._async_client",
+          "qualname": "AsyncHonuaAdminClient",
+          "signature": "(base_url: 'str', *, timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, follow_redirects: 'bool' = False, client: 'httpx.AsyncClient | None' = None, transport: 'httpx.AsyncBaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "ColumnInfo": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "name"
+            },
+            {
+              "annotation": "str",
+              "name": "data_type"
+            },
+            {
+              "annotation": "bool",
+              "name": "is_nullable"
+            },
+            {
+              "annotation": "bool",
+              "name": "is_primary_key"
+            },
+            {
+              "annotation": "int | None",
+              "name": "max_length"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ColumnInfo'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ColumnInfo",
+          "signature": "(name: 'str', data_type: 'str', is_nullable: 'bool', is_primary_key: 'bool', max_length: 'int | None') -> None"
+        },
+        "ConnectionTestResult": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "name": "connection_id"
+            },
+            {
+              "annotation": "str | None",
+              "name": "connection_name"
+            },
+            {
+              "annotation": "bool",
+              "name": "is_healthy"
+            },
+            {
+              "annotation": "str | None",
+              "name": "tested_at"
+            },
+            {
+              "annotation": "str | None",
+              "name": "message"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ConnectionTestResult'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ConnectionTestResult",
+          "signature": "(connection_id: 'str | None', connection_name: 'str | None', is_healthy: 'bool', tested_at: 'str | None', message: 'str | None') -> None"
+        },
+        "CreateSecureConnectionRequest": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "name"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "description"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "host"
+            },
+            {
+              "annotation": "int",
+              "default": "5432",
+              "name": "port"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "database_name"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "username"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "password"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "secret_reference"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "secret_type"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "ssl_required"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "ssl_mode"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "to_dict": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "CreateSecureConnectionRequest",
+          "signature": "(name: 'str', description: 'str | None' = None, host: 'str' = '', port: 'int' = 5432, database_name: 'str' = '', username: 'str' = '', password: 'str | None' = None, secret_reference: 'str | None' = None, secret_type: 'str | None' = None, ssl_required: 'bool' = False, ssl_mode: 'str | None' = None) -> None"
+        },
+        "EncryptionValidationResult": {
+          "fields": [
+            {
+              "annotation": "bool",
+              "name": "is_valid"
+            },
+            {
+              "annotation": "int | None",
+              "name": "current_key_version"
+            },
+            {
+              "annotation": "str | None",
+              "name": "validated_at"
+            },
+            {
+              "annotation": "str | None",
+              "name": "message"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'EncryptionValidationResult'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "EncryptionValidationResult",
+          "signature": "(is_valid: 'bool', current_key_version: 'int | None', validated_at: 'str | None', message: 'str | None') -> None"
+        },
+        "HonuaAdminClient": {
+          "kind": "class",
+          "methods": {
+            "apply_manifest": {
+              "kind": "method",
+              "signature": "(self, request: 'ManifestApplyRequest') -> 'ManifestApplyResult'"
+            },
+            "check_compatibility": {
+              "kind": "method",
+              "signature": "(self) -> 'AdminCompatibilityCheckResult'"
+            },
+            "close": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "create_connection": {
+              "kind": "method",
+              "signature": "(self, request: 'CreateSecureConnectionRequest') -> 'SecureConnectionSummary'"
+            },
+            "create_metadata_resource": {
+              "kind": "method",
+              "signature": "(self, resource: 'MetadataResource') -> 'MetadataResource'"
+            },
+            "delete_connection": {
+              "kind": "method",
+              "signature": "(self, id: 'str') -> 'None'"
+            },
+            "delete_metadata_resource": {
+              "kind": "method",
+              "signature": "(self, kind: 'str', ns: 'str', name: 'str', *, if_match: 'str | None' = None) -> 'None'"
+            },
+            "discover_tables": {
+              "kind": "method",
+              "signature": "(self, conn_id: 'str') -> 'TableDiscoveryResponse'"
+            },
+            "get_capabilities": {
+              "kind": "method",
+              "signature": "(self) -> 'AdminCapabilitiesResponse'"
+            },
+            "get_capability_flags": {
+              "kind": "method",
+              "signature": "(self) -> 'AdminCompatibilityFeatureFlags'"
+            },
+            "get_config": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            },
+            "get_connection": {
+              "kind": "method",
+              "signature": "(self, id: 'str') -> 'SecureConnectionDetail'"
+            },
+            "get_layer_style": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int') -> 'LayerStyleResponse'"
+            },
+            "get_manifest": {
+              "kind": "method",
+              "signature": "(self, namespace: 'str | None' = None) -> 'MetadataManifest'"
+            },
+            "get_metadata_resource": {
+              "kind": "method",
+              "signature": "(self, kind: 'str', ns: 'str', name: 'str') -> 'tuple[MetadataResource, str | None]'"
+            },
+            "get_service_settings": {
+              "kind": "method",
+              "signature": "(self, name: 'str') -> 'ServiceSettingsResponse'"
+            },
+            "get_version": {
+              "kind": "method",
+              "signature": "(self) -> 'AdminVersionResponse'"
+            },
+            "list_connections": {
+              "kind": "method",
+              "signature": "(self) -> 'list[SecureConnectionSummary]'"
+            },
+            "list_layers": {
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', service_name: 'str | None' = None) -> 'list[PublishedLayerSummary]'"
+            },
+            "list_metadata_resources": {
+              "kind": "method",
+              "signature": "(self, kind: 'str | None' = None, namespace: 'str | None' = None) -> 'list[MetadataResource]'"
+            },
+            "list_services": {
+              "kind": "method",
+              "signature": "(self) -> 'list[ServiceSummary]'"
+            },
+            "publish_layer": {
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', request: 'PublishLayerRequest') -> 'PublishedLayerSummary'"
+            },
+            "rotate_encryption_key": {
+              "kind": "method",
+              "signature": "(self) -> 'KeyRotationResult'"
+            },
+            "set_layer_enabled": {
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', layer_id: 'int', enabled: 'bool', service_name: 'str | None' = None) -> 'PublishedLayerSummary'"
+            },
+            "set_service_layers_enabled": {
+              "kind": "method",
+              "signature": "(self, conn_id: 'str', enabled: 'bool', service_name: 'str | None' = None) -> 'list[PublishedLayerSummary]'"
+            },
+            "test_connection": {
+              "kind": "method",
+              "signature": "(self, id: 'str') -> 'ConnectionTestResult'"
+            },
+            "test_draft_connection": {
+              "kind": "method",
+              "signature": "(self, request: 'CreateSecureConnectionRequest') -> 'ConnectionTestResult'"
+            },
+            "update_connection": {
+              "kind": "method",
+              "signature": "(self, id: 'str', request: 'UpdateSecureConnectionRequest') -> 'SecureConnectionSummary'"
+            },
+            "update_layer_style": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', request: 'LayerStyleUpdateRequest') -> 'LayerStyleResponse'"
+            },
+            "update_mapserver_settings": {
+              "kind": "method",
+              "signature": "(self, name: 'str', **kwargs: 'Any') -> 'ServiceSettingsResponse'"
+            },
+            "update_metadata_resource": {
+              "kind": "method",
+              "signature": "(self, kind: 'str', ns: 'str', name: 'str', resource: 'MetadataResource', *, if_match: 'str | None' = None) -> 'MetadataResource'"
+            },
+            "update_protocols": {
+              "kind": "method",
+              "signature": "(self, name: 'str', protocols: 'list[str]') -> 'ServiceSettingsResponse'"
+            },
+            "validate_encryption": {
+              "kind": "method",
+              "signature": "(self) -> 'EncryptionValidationResult'"
+            }
+          },
+          "module": "honua_admin._client",
+          "qualname": "HonuaAdminClient",
+          "signature": "(base_url: 'str', *, timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, follow_redirects: 'bool' = False, client: 'httpx.Client | None' = None, transport: 'httpx.BaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "KeyRotationResult": {
+          "fields": [
+            {
+              "annotation": "int | None",
+              "name": "previous_key_version"
+            },
+            {
+              "annotation": "int | None",
+              "name": "new_key_version"
+            },
+            {
+              "annotation": "str | None",
+              "name": "rotated_at"
+            },
+            {
+              "annotation": "str | None",
+              "name": "message"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'KeyRotationResult'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "KeyRotationResult",
+          "signature": "(previous_key_version: 'int | None', new_key_version: 'int | None', rotated_at: 'str | None', message: 'str | None') -> None"
+        },
+        "LayerStyleResponse": {
+          "fields": [
+            {
+              "annotation": "dict[str, Any] | None",
+              "name": "map_libre_style"
+            },
+            {
+              "annotation": "dict[str, Any] | None",
+              "name": "drawing_info"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'LayerStyleResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "LayerStyleResponse",
+          "signature": "(map_libre_style: 'dict[str, Any] | None', drawing_info: 'dict[str, Any] | None') -> None"
+        },
+        "LayerStyleUpdateRequest": {
+          "fields": [
+            {
+              "annotation": "dict[str, Any] | None",
+              "default": "None",
+              "name": "map_libre_style"
+            },
+            {
+              "annotation": "dict[str, Any] | None",
+              "default": "None",
+              "name": "drawing_info"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "to_dict": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "LayerStyleUpdateRequest",
+          "signature": "(map_libre_style: 'dict[str, Any] | None' = None, drawing_info: 'dict[str, Any] | None' = None) -> None"
+        },
+        "MINIMUM_SUPPORTED_CONTROL_PLANE_API_MAJOR": {
+          "kind": "constant",
+          "type": "int",
+          "value": "1"
+        },
+        "MINIMUM_SUPPORTED_CONTROL_PLANE_BASE_PATH": {
+          "kind": "constant",
+          "type": "str",
+          "value": "'/api/v1/admin'"
+        },
+        "MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL": {
+          "kind": "constant",
+          "type": "str",
+          "value": "'preview'"
+        },
+        "MINIMUM_SUPPORTED_SERVER_VERSION": {
+          "kind": "constant",
+          "type": "str",
+          "value": "'2026.3.0'"
+        },
+        "ManifestApplyEntry": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "action"
+            },
+            {
+              "annotation": "MetadataResourceIdentifier",
+              "name": "resource"
+            },
+            {
+              "annotation": "str | None",
+              "name": "message"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ManifestApplyEntry'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ManifestApplyEntry",
+          "signature": "(action: 'str', resource: 'MetadataResourceIdentifier', message: 'str | None') -> None"
+        },
+        "ManifestApplyRequest": {
+          "fields": [
+            {
+              "annotation": "list[MetadataResource]",
+              "defaultFactory": "list",
+              "name": "resources"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "dry_run"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "prune"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "to_dict": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ManifestApplyRequest",
+          "signature": "(resources: 'list[MetadataResource]' = <factory>, dry_run: 'bool' = False, prune: 'bool' = False) -> None"
+        },
+        "ManifestApplyResult": {
+          "fields": [
+            {
+              "annotation": "bool",
+              "name": "dry_run"
+            },
+            {
+              "annotation": "ManifestApplySummary",
+              "name": "summary"
+            },
+            {
+              "annotation": "list[ManifestApplyEntry]",
+              "name": "entries"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ManifestApplyResult'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ManifestApplyResult",
+          "signature": "(dry_run: 'bool', summary: 'ManifestApplySummary', entries: 'list[ManifestApplyEntry]') -> None"
+        },
+        "ManifestApplySummary": {
+          "fields": [
+            {
+              "annotation": "int",
+              "name": "created"
+            },
+            {
+              "annotation": "int",
+              "name": "updated"
+            },
+            {
+              "annotation": "int",
+              "name": "deleted"
+            },
+            {
+              "annotation": "int",
+              "name": "skipped"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ManifestApplySummary'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ManifestApplySummary",
+          "signature": "(created: 'int', updated: 'int', deleted: 'int', skipped: 'int') -> None"
+        },
+        "MapServerSettings": {
+          "fields": [
+            {
+              "annotation": "int",
+              "name": "max_image_width"
+            },
+            {
+              "annotation": "int",
+              "name": "max_image_height"
+            },
+            {
+              "annotation": "int",
+              "name": "default_image_width"
+            },
+            {
+              "annotation": "int",
+              "name": "default_image_height"
+            },
+            {
+              "annotation": "int",
+              "name": "default_dpi"
+            },
+            {
+              "annotation": "str",
+              "name": "default_format"
+            },
+            {
+              "annotation": "bool",
+              "name": "default_transparent"
+            },
+            {
+              "annotation": "int",
+              "name": "max_features_per_layer"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'MapServerSettings'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "MapServerSettings",
+          "signature": "(max_image_width: 'int', max_image_height: 'int', default_image_width: 'int', default_image_height: 'int', default_dpi: 'int', default_format: 'str', default_transparent: 'bool', max_features_per_layer: 'int') -> None"
+        },
+        "MetadataManifest": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "api_version"
+            },
+            {
+              "annotation": "str | None",
+              "name": "generated_at"
+            },
+            {
+              "annotation": "list[MetadataResource]",
+              "name": "resources"
+            },
+            {
+              "annotation": "list[MetadataResourceIdentifier]",
+              "name": "drifted_resources"
+            },
+            {
+              "annotation": "str | None",
+              "name": "manifest_hash"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'MetadataManifest'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "MetadataManifest",
+          "signature": "(api_version: 'str', generated_at: 'str | None', resources: 'list[MetadataResource]', drifted_resources: 'list[MetadataResourceIdentifier]', manifest_hash: 'str | None') -> None"
+        },
+        "MetadataResource": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "api_version"
+            },
+            {
+              "annotation": "str",
+              "name": "kind"
+            },
+            {
+              "annotation": "ResourceMetadata",
+              "name": "metadata"
+            },
+            {
+              "annotation": "dict[str, Any]",
+              "name": "spec"
+            },
+            {
+              "annotation": "dict[str, Any] | None",
+              "name": "status"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'MetadataResource'"
+            },
+            "to_dict": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "MetadataResource",
+          "signature": "(api_version: 'str', kind: 'str', metadata: 'ResourceMetadata', spec: 'dict[str, Any]', status: 'dict[str, Any] | None') -> None"
+        },
+        "MetadataResourceIdentifier": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "kind"
+            },
+            {
+              "annotation": "str",
+              "name": "namespace"
+            },
+            {
+              "annotation": "str",
+              "name": "name"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'MetadataResourceIdentifier'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "MetadataResourceIdentifier",
+          "signature": "(kind: 'str', namespace: 'str', name: 'str') -> None"
+        },
+        "PublishLayerRequest": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "'public'",
+              "name": "schema"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "table"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "layer_name"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "description"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "geometry_column"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "geometry_type"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "srid"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "primary_key"
+            },
+            {
+              "annotation": "list[str] | None",
+              "default": "None",
+              "name": "fields_list"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "service_name"
+            },
+            {
+              "annotation": "bool",
+              "default": "True",
+              "name": "enabled"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "to_dict": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "PublishLayerRequest",
+          "signature": "(schema: 'str' = 'public', table: 'str' = '', layer_name: 'str | None' = None, description: 'str | None' = None, geometry_column: 'str | None' = None, geometry_type: 'str | None' = None, srid: 'int | None' = None, primary_key: 'str | None' = None, fields_list: 'list[str] | None' = None, service_name: 'str | None' = None, enabled: 'bool' = True) -> None"
+        },
+        "PublishedLayerSummary": {
+          "fields": [
+            {
+              "annotation": "int",
+              "name": "layer_id"
+            },
+            {
+              "annotation": "str",
+              "name": "layer_name"
+            },
+            {
+              "annotation": "str",
+              "name": "schema"
+            },
+            {
+              "annotation": "str",
+              "name": "table"
+            },
+            {
+              "annotation": "str | None",
+              "name": "description"
+            },
+            {
+              "annotation": "str | None",
+              "name": "geometry_type"
+            },
+            {
+              "annotation": "int | None",
+              "name": "srid"
+            },
+            {
+              "annotation": "str | None",
+              "name": "primary_key"
+            },
+            {
+              "annotation": "int",
+              "name": "field_count"
+            },
+            {
+              "annotation": "bool",
+              "name": "enabled"
+            },
+            {
+              "annotation": "str | None",
+              "name": "service_name"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'PublishedLayerSummary'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "PublishedLayerSummary",
+          "signature": "(layer_id: 'int', layer_name: 'str', schema: 'str', table: 'str', description: 'str | None', geometry_type: 'str | None', srid: 'int | None', primary_key: 'str | None', field_count: 'int', enabled: 'bool', service_name: 'str | None') -> None"
+        },
+        "ResourceMetadata": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "name": "id"
+            },
+            {
+              "annotation": "str",
+              "name": "name"
+            },
+            {
+              "annotation": "str",
+              "name": "namespace"
+            },
+            {
+              "annotation": "dict[str, str]",
+              "name": "labels"
+            },
+            {
+              "annotation": "dict[str, str]",
+              "name": "annotations"
+            },
+            {
+              "annotation": "str | None",
+              "name": "resource_version"
+            },
+            {
+              "annotation": "int | None",
+              "name": "generation"
+            },
+            {
+              "annotation": "str | None",
+              "name": "created_at"
+            },
+            {
+              "annotation": "str | None",
+              "name": "updated_at"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ResourceMetadata'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ResourceMetadata",
+          "signature": "(id: 'str | None', name: 'str', namespace: 'str', labels: 'dict[str, str]', annotations: 'dict[str, str]', resource_version: 'str | None', generation: 'int | None', created_at: 'str | None', updated_at: 'str | None') -> None"
+        },
+        "SecureConnectionDetail": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "connection_id"
+            },
+            {
+              "annotation": "str",
+              "name": "name"
+            },
+            {
+              "annotation": "str | None",
+              "name": "description"
+            },
+            {
+              "annotation": "str",
+              "name": "host"
+            },
+            {
+              "annotation": "int",
+              "name": "port"
+            },
+            {
+              "annotation": "str",
+              "name": "database_name"
+            },
+            {
+              "annotation": "str",
+              "name": "username"
+            },
+            {
+              "annotation": "bool",
+              "name": "ssl_required"
+            },
+            {
+              "annotation": "str | None",
+              "name": "ssl_mode"
+            },
+            {
+              "annotation": "str | None",
+              "name": "storage_type"
+            },
+            {
+              "annotation": "bool",
+              "name": "is_active"
+            },
+            {
+              "annotation": "str | None",
+              "name": "health_status"
+            },
+            {
+              "annotation": "str | None",
+              "name": "last_health_check"
+            },
+            {
+              "annotation": "str | None",
+              "name": "created_at"
+            },
+            {
+              "annotation": "str | None",
+              "name": "created_by"
+            },
+            {
+              "annotation": "str | None",
+              "name": "credential_reference"
+            },
+            {
+              "annotation": "int | None",
+              "name": "encryption_version"
+            },
+            {
+              "annotation": "str | None",
+              "name": "updated_at"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'SecureConnectionDetail'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "SecureConnectionDetail",
+          "signature": "(connection_id: 'str', name: 'str', description: 'str | None', host: 'str', port: 'int', database_name: 'str', username: 'str', ssl_required: 'bool', ssl_mode: 'str | None', storage_type: 'str | None', is_active: 'bool', health_status: 'str | None', last_health_check: 'str | None', created_at: 'str | None', created_by: 'str | None', credential_reference: 'str | None', encryption_version: 'int | None', updated_at: 'str | None') -> None"
+        },
+        "SecureConnectionSummary": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "connection_id"
+            },
+            {
+              "annotation": "str",
+              "name": "name"
+            },
+            {
+              "annotation": "str | None",
+              "name": "description"
+            },
+            {
+              "annotation": "str",
+              "name": "host"
+            },
+            {
+              "annotation": "int",
+              "name": "port"
+            },
+            {
+              "annotation": "str",
+              "name": "database_name"
+            },
+            {
+              "annotation": "str",
+              "name": "username"
+            },
+            {
+              "annotation": "bool",
+              "name": "ssl_required"
+            },
+            {
+              "annotation": "str | None",
+              "name": "ssl_mode"
+            },
+            {
+              "annotation": "str | None",
+              "name": "storage_type"
+            },
+            {
+              "annotation": "bool",
+              "name": "is_active"
+            },
+            {
+              "annotation": "str | None",
+              "name": "health_status"
+            },
+            {
+              "annotation": "str | None",
+              "name": "last_health_check"
+            },
+            {
+              "annotation": "str | None",
+              "name": "created_at"
+            },
+            {
+              "annotation": "str | None",
+              "name": "created_by"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'SecureConnectionSummary'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "SecureConnectionSummary",
+          "signature": "(connection_id: 'str', name: 'str', description: 'str | None', host: 'str', port: 'int', database_name: 'str', username: 'str', ssl_required: 'bool', ssl_mode: 'str | None', storage_type: 'str | None', is_active: 'bool', health_status: 'str | None', last_health_check: 'str | None', created_at: 'str | None', created_by: 'str | None') -> None"
+        },
+        "ServiceSettingsResponse": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "service_name"
+            },
+            {
+              "annotation": "list[str]",
+              "name": "enabled_protocols"
+            },
+            {
+              "annotation": "list[str]",
+              "name": "available_protocols"
+            },
+            {
+              "annotation": "AccessPolicyResponse | None",
+              "name": "access_policy"
+            },
+            {
+              "annotation": "TimeInfoResponse | None",
+              "name": "time_info"
+            },
+            {
+              "annotation": "MapServerSettings | None",
+              "name": "map_server"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ServiceSettingsResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ServiceSettingsResponse",
+          "signature": "(service_name: 'str', enabled_protocols: 'list[str]', available_protocols: 'list[str]', access_policy: 'AccessPolicyResponse | None', time_info: 'TimeInfoResponse | None', map_server: 'MapServerSettings | None') -> None"
+        },
+        "ServiceSummary": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "service_name"
+            },
+            {
+              "annotation": "str | None",
+              "name": "description"
+            },
+            {
+              "annotation": "int",
+              "name": "layer_count"
+            },
+            {
+              "annotation": "list[str]",
+              "name": "enabled_protocols"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'ServiceSummary'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "ServiceSummary",
+          "signature": "(service_name: 'str', description: 'str | None', layer_count: 'int', enabled_protocols: 'list[str]') -> None"
+        },
+        "TableDiscoveryResponse": {
+          "fields": [
+            {
+              "annotation": "list[TableInfo]",
+              "name": "tables"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'TableDiscoveryResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "TableDiscoveryResponse",
+          "signature": "(tables: 'list[TableInfo]') -> None"
+        },
+        "TableInfo": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "schema"
+            },
+            {
+              "annotation": "str",
+              "name": "table"
+            },
+            {
+              "annotation": "str | None",
+              "name": "geometry_column"
+            },
+            {
+              "annotation": "str | None",
+              "name": "geometry_type"
+            },
+            {
+              "annotation": "int | None",
+              "name": "srid"
+            },
+            {
+              "annotation": "int | None",
+              "name": "estimated_rows"
+            },
+            {
+              "annotation": "list[ColumnInfo]",
+              "name": "columns"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'TableInfo'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "TableInfo",
+          "signature": "(schema: 'str', table: 'str', geometry_column: 'str | None', geometry_type: 'str | None', srid: 'int | None', estimated_rows: 'int | None', columns: 'list[ColumnInfo]') -> None"
+        },
+        "TimeInfoResponse": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "name": "start_time_field"
+            },
+            {
+              "annotation": "str | None",
+              "name": "end_time_field"
+            },
+            {
+              "annotation": "str | None",
+              "name": "track_id_field"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, data: 'dict[str, Any]') -> 'TimeInfoResponse'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "TimeInfoResponse",
+          "signature": "(start_time_field: 'str | None', end_time_field: 'str | None', track_id_field: 'str | None') -> None"
+        },
+        "UpdateSecureConnectionRequest": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "description"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "host"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "port"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "database_name"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "username"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "password"
+            },
+            {
+              "annotation": "bool | None",
+              "default": "None",
+              "name": "ssl_required"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "ssl_mode"
+            },
+            {
+              "annotation": "bool | None",
+              "default": "None",
+              "name": "is_active"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "to_dict": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_admin._models",
+          "qualname": "UpdateSecureConnectionRequest",
+          "signature": "(description: 'str | None' = None, host: 'str | None' = None, port: 'int | None' = None, database_name: 'str | None' = None, username: 'str | None' = None, password: 'str | None' = None, ssl_required: 'bool | None' = None, ssl_mode: 'str | None' = None, is_active: 'bool | None' = None) -> None"
+        },
+        "__version__": {
+          "kind": "constant",
+          "type": "str"
+        },
+        "evaluate_admin_compatibility": {
+          "kind": "function",
+          "module": "honua_admin._models",
+          "qualname": "evaluate_admin_compatibility",
+          "signature": "(compatibility: 'AdminCompatibilityMetadata | None', baseline: 'AdminCompatibilityBaseline | None' = None) -> 'AdminCompatibilityCheckResult'"
+        }
+      }
+    },
+    "honua_sdk": {
+      "exports": [
+        "ApplyEditsResult",
+        "AsyncHonuaClient",
+        "AsyncHonuaGeocodingClient",
+        "AsyncHonuaOgcFeatureCollection",
+        "AsyncHonuaOgcFeatures",
+        "AuthProvider",
+        "BearerToken",
+        "CallableAuthProvider",
+        "EditOperationResult",
+        "Feature",
+        "FeatureSet",
+        "GeoServicesFeatureServerClient",
+        "GeoServicesGeometryServerClient",
+        "GeoServicesImageServerClient",
+        "GeoServicesMapServerClient",
+        "GeocodeResult",
+        "GeocodeSuggestion",
+        "HonuaClient",
+        "HonuaError",
+        "HonuaGeocodingClient",
+        "HonuaGrpcError",
+        "HonuaHttpError",
+        "HonuaOgcFeatureCollection",
+        "HonuaOgcFeatures",
+        "InMemoryTokenStore",
+        "ODataClient",
+        "OgcCoveragesClient",
+        "OgcMapsClient",
+        "OgcProcessesClient",
+        "OgcTilesClient",
+        "RefreshableBearerTokenProvider",
+        "ReverseGeocodeResult",
+        "ServiceSummary",
+        "StacClient",
+        "StaticAuthProvider",
+        "TokenStore",
+        "WfsClient",
+        "WmsClient",
+        "WmtsClient",
+        "__version__"
+      ],
+      "symbols": {
+        "ApplyEditsResult": {
+          "fields": [
+            {
+              "annotation": "tuple[EditOperationResult, ...]",
+              "default": "()",
+              "name": "add_results"
+            },
+            {
+              "annotation": "tuple[EditOperationResult, ...]",
+              "default": "()",
+              "name": "update_results"
+            },
+            {
+              "annotation": "tuple[EditOperationResult, ...]",
+              "default": "()",
+              "name": "delete_results"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "all_succeeded": {
+              "kind": "property"
+            },
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'ApplyEditsResult'\""
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "ApplyEditsResult",
+          "signature": "(add_results: 'tuple[EditOperationResult, ...]' = (), update_results: 'tuple[EditOperationResult, ...]' = (), delete_results: 'tuple[EditOperationResult, ...]' = (), raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "AsyncHonuaClient": {
+          "kind": "class",
+          "methods": {
+            "apply_edits": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', *, adds: 'Sequence[Mapping[str, Any]] | None' = None, updates: 'Sequence[Mapping[str, Any]] | None' = None, deletes: 'Sequence[int] | str | None' = None, rollback_on_failure: 'bool' = True) -> 'dict[str, Any]'"
+            },
+            "apply_edits_result": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', **kwargs: 'Any') -> 'ApplyEditsResult'"
+            },
+            "close": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "export_map": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, service_id: 'str', bbox: 'Sequence[float] | str', *, size: 'tuple[int, int]' = (400, 400), image_format: 'str' = 'png', transparent: 'bool' = True, dpi: 'int' = 96, extra_params: 'Mapping[str, Any] | None' = None) -> 'bytes'"
+            },
+            "list_service_summaries": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json') -> 'list[ServiceSummary]'"
+            },
+            "list_services": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json') -> 'dict[str, Any]'"
+            },
+            "ogc_features": {
+              "kind": "method",
+              "signature": "(self) -> \"'AsyncHonuaOgcFeatures'\""
+            },
+            "query_feature_set": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', **kwargs: 'Any') -> 'FeatureSet'"
+            },
+            "query_features": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', *, where: 'str' = '1=1', out_fields: 'str | Sequence[str]' = '*', return_geometry: 'bool' = True, extra_params: 'Mapping[str, Any] | None' = None) -> 'dict[str, Any]'"
+            },
+            "query_features_all": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', *, where: 'str' = '1=1', out_fields: 'str | Sequence[str]' = '*', return_geometry: 'bool' = True, page_size: 'int' = 1000, limit: 'int | None' = None, max_pages: 'int' = 100, extra_params: 'Mapping[str, Any] | None' = None) -> 'list[Feature]'"
+            },
+            "readiness": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            }
+          },
+          "module": "honua_sdk.async_client",
+          "qualname": "AsyncHonuaClient",
+          "signature": "(base_url: 'str', *, timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, follow_redirects: 'bool' = False, client: 'httpx.AsyncClient | None' = None, transport: 'httpx.AsyncBaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "AsyncHonuaGeocodingClient": {
+          "kind": "class",
+          "methods": {
+            "close": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "forward_geocode": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, address: 'str', *, max_results: 'int' = 10, country_codes: 'str | None' = None, spatial_reference_wkid: 'int' = 4326) -> 'list[GeocodeResult]'"
+            },
+            "reverse_geocode": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, latitude: 'float', longitude: 'float', *, spatial_reference_wkid: 'int' = 4326) -> 'ReverseGeocodeResult | None'"
+            },
+            "suggest": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, text: 'str', *, max_suggestions: 'int' = 5, country_codes: 'str | None' = None) -> 'list[GeocodeSuggestion]'"
+            }
+          },
+          "module": "honua_sdk.async_geocoding",
+          "qualname": "AsyncHonuaGeocodingClient",
+          "signature": "(base_url: 'str', *, locator_name: 'str' = 'World', timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, client: 'httpx.AsyncClient | None' = None, transport: 'httpx.AsyncBaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "AsyncHonuaOgcFeatureCollection": {
+          "kind": "class",
+          "methods": {
+            "create_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "delete_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'None'"
+            },
+            "item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items_all": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'list[JsonObject]'"
+            },
+            "metadata": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "patch_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', patch: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "queryables": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "replace_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.ogc",
+          "qualname": "AsyncHonuaOgcFeatureCollection",
+          "signature": "(client: 'Any', collection_id: 'FeatureId') -> 'None'"
+        },
+        "AsyncHonuaOgcFeatures": {
+          "kind": "class",
+          "methods": {
+            "collection": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId') -> \"'AsyncHonuaOgcFeatureCollection'\""
+            },
+            "collections": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "conformance": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "create_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "delete_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'None'"
+            },
+            "get_collection": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items_all": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'list[JsonObject]'"
+            },
+            "landing": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "patch_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', patch: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "queryables": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "replace_item": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.ogc",
+          "qualname": "AsyncHonuaOgcFeatures",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "AuthProvider": {
+          "kind": "class",
+          "methods": {
+            "auth_headers": {
+              "kind": "method",
+              "signature": "(self) -> 'Mapping[str, str]'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "AuthProvider",
+          "signature": "(*args, **kwargs)"
+        },
+        "BearerToken": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "access_token"
+            },
+            {
+              "annotation": "datetime | None",
+              "default": "None",
+              "name": "expires_at"
+            },
+            {
+              "annotation": "str",
+              "default": "'Bearer'",
+              "name": "token_type"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "authorization_value": {
+              "kind": "property"
+            },
+            "expires_within": {
+              "kind": "method",
+              "signature": "(self, window: 'timedelta', *, now: 'datetime | None' = None) -> 'bool'"
+            },
+            "from_expires_in": {
+              "kind": "classmethod",
+              "signature": "(cls, access_token: 'str', expires_in_seconds: 'int | float', *, token_type: 'str' = 'Bearer', now: 'datetime | None' = None) -> \"'BearerToken'\""
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "BearerToken",
+          "signature": "(access_token: 'str', expires_at: 'datetime | None' = None, token_type: 'str' = 'Bearer') -> None"
+        },
+        "CallableAuthProvider": {
+          "kind": "class",
+          "methods": {
+            "auth_headers": {
+              "kind": "method",
+              "signature": "(self) -> 'Mapping[str, str]'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "CallableAuthProvider",
+          "signature": "(callback: 'Callable[[], Mapping[str, str]]') -> 'None'"
+        },
+        "EditOperationResult": {
+          "fields": [
+            {
+              "annotation": "bool",
+              "name": "success"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "object_id"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "global_id"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "error"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'EditOperationResult'\""
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "EditOperationResult",
+          "signature": "(success: 'bool', object_id: 'int | None' = None, global_id: 'str | None' = None, error: 'Mapping[str, Any] | None' = None, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "Feature": {
+          "fields": [
+            {
+              "annotation": "Mapping[str, Any]",
+              "name": "attributes"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "geometry"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'Feature'\""
+            },
+            "object_id": {
+              "kind": "property"
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "Feature",
+          "signature": "(attributes: 'Mapping[str, Any]', geometry: 'Mapping[str, Any] | None' = None, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "FeatureSet": {
+          "fields": [
+            {
+              "annotation": "tuple[Feature, ...]",
+              "name": "features"
+            },
+            {
+              "annotation": "tuple[Mapping[str, Any], ...]",
+              "default": "()",
+              "name": "fields"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "geometry_type"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "spatial_reference"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "exceeded_transfer_limit"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'FeatureSet'\""
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "FeatureSet",
+          "signature": "(features: 'tuple[Feature, ...]', fields: 'tuple[Mapping[str, Any], ...]' = (), geometry_type: 'str | None' = None, spatial_reference: 'Mapping[str, Any] | None' = None, exceeded_transfer_limit: 'bool' = False, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "GeoServicesFeatureServerClient": {
+          "kind": "class",
+          "methods": {
+            "apply_edits": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', **kwargs: 'Any') -> 'JsonObject'"
+            },
+            "layer_metadata": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "metadata": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "path": {
+              "kind": "property"
+            },
+            "query": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', **kwargs: 'Any') -> 'JsonObject'"
+            },
+            "query_related_records": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', *, object_ids: 'CsvValue', relationship_id: 'int', response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "GeoServicesFeatureServerClient",
+          "signature": "(client: 'Any', service_id: 'str') -> 'None'"
+        },
+        "GeoServicesGeometryServerClient": {
+          "kind": "class",
+          "methods": {
+            "buffer": {
+              "kind": "method",
+              "signature": "(self, geometries: 'Any', *, in_sr: 'int | str', distances: 'CsvValue', unit: 'str | None' = None, **kwargs: 'Any') -> 'JsonObject'"
+            },
+            "metadata": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "operation": {
+              "kind": "method",
+              "signature": "(self, name: 'str', *, params: 'Params' = None, json_body: 'Mapping[str, Any] | None' = None, method: 'str' = 'GET', response_format: 'str' = 'json') -> 'JsonObject'"
+            },
+            "project": {
+              "kind": "method",
+              "signature": "(self, geometries: 'Any', *, in_sr: 'int | str', out_sr: 'int | str', **kwargs: 'Any') -> 'JsonObject'"
+            },
+            "simplify": {
+              "kind": "method",
+              "signature": "(self, geometries: 'Any', *, sr: 'int | str | None' = None, **kwargs: 'Any') -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "GeoServicesGeometryServerClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "GeoServicesImageServerClient": {
+          "kind": "class",
+          "methods": {
+            "export_image": {
+              "kind": "method",
+              "signature": "(self, bbox: 'BboxValue', *, size: 'tuple[int, int] | None' = None, image_format: 'str' = 'png', response_format: 'str' = 'image', extra_params: 'Params' = None) -> 'bytes'"
+            },
+            "identify": {
+              "kind": "method",
+              "signature": "(self, geometry: 'Mapping[str, Any] | str', *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "legend": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "metadata": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "path": {
+              "kind": "property"
+            },
+            "query": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "tile": {
+              "kind": "method",
+              "signature": "(self, level: 'int', row: 'int', col: 'int') -> 'bytes'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "GeoServicesImageServerClient",
+          "signature": "(client: 'Any', service_id: 'str | None' = None) -> 'None'"
+        },
+        "GeoServicesMapServerClient": {
+          "kind": "class",
+          "methods": {
+            "export": {
+              "kind": "method",
+              "signature": "(self, bbox: 'BboxValue', **kwargs: 'Any') -> 'bytes'"
+            },
+            "identify": {
+              "kind": "method",
+              "signature": "(self, *, geometry: 'Mapping[str, Any] | str', map_extent: 'BboxValue', image_display: 'str', tolerance: 'int' = 3, layers: 'str | None' = None, return_geometry: 'bool' = True, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "layer_metadata": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "metadata": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "path": {
+              "kind": "property"
+            },
+            "tile": {
+              "kind": "method",
+              "signature": "(self, level: 'int', row: 'int', col: 'int') -> 'bytes'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "GeoServicesMapServerClient",
+          "signature": "(client: 'Any', service_id: 'str') -> 'None'"
+        },
+        "GeocodeResult": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "address"
+            },
+            {
+              "annotation": "float",
+              "name": "latitude"
+            },
+            {
+              "annotation": "float",
+              "name": "longitude"
+            },
+            {
+              "annotation": "float",
+              "name": "score"
+            },
+            {
+              "annotation": "dict[str, str | None]",
+              "name": "attributes"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.geocoding",
+          "qualname": "GeocodeResult",
+          "signature": "(address: 'str', latitude: 'float', longitude: 'float', score: 'float', attributes: 'dict[str, str | None]') -> None"
+        },
+        "GeocodeSuggestion": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "text"
+            },
+            {
+              "annotation": "str",
+              "name": "magic_key"
+            },
+            {
+              "annotation": "bool",
+              "name": "is_collection"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.geocoding",
+          "qualname": "GeocodeSuggestion",
+          "signature": "(text: 'str', magic_key: 'str', is_collection: 'bool') -> None"
+        },
+        "HonuaClient": {
+          "kind": "class",
+          "methods": {
+            "apply_edits": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', *, adds: 'Sequence[Mapping[str, Any]] | None' = None, updates: 'Sequence[Mapping[str, Any]] | None' = None, deletes: 'Sequence[int] | str | None' = None, rollback_on_failure: 'bool' = True) -> 'dict[str, Any]'"
+            },
+            "apply_edits_result": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', **kwargs: 'Any') -> 'ApplyEditsResult'"
+            },
+            "close": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "export_map": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str', bbox: 'Sequence[float] | str', *, size: 'tuple[int, int]' = (400, 400), image_format: 'str' = 'png', transparent: 'bool' = True, dpi: 'int' = 96, extra_params: 'Mapping[str, Any] | None' = None) -> 'bytes'"
+            },
+            "feature_server": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str') -> \"'GeoServicesFeatureServerClient'\""
+            },
+            "geometry_server": {
+              "kind": "method",
+              "signature": "(self) -> \"'GeoServicesGeometryServerClient'\""
+            },
+            "image_server": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str | None' = None) -> \"'GeoServicesImageServerClient'\""
+            },
+            "list_service_summaries": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json') -> 'list[ServiceSummary]'"
+            },
+            "list_services": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json') -> 'dict[str, Any]'"
+            },
+            "map_server": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str') -> \"'GeoServicesMapServerClient'\""
+            },
+            "odata": {
+              "kind": "method",
+              "signature": "(self) -> \"'ODataClient'\""
+            },
+            "ogc_coverages": {
+              "kind": "method",
+              "signature": "(self) -> \"'OgcCoveragesClient'\""
+            },
+            "ogc_features": {
+              "kind": "method",
+              "signature": "(self) -> \"'HonuaOgcFeatures'\""
+            },
+            "ogc_maps": {
+              "kind": "method",
+              "signature": "(self) -> \"'OgcMapsClient'\""
+            },
+            "ogc_processes": {
+              "kind": "method",
+              "signature": "(self) -> \"'OgcProcessesClient'\""
+            },
+            "ogc_tiles": {
+              "kind": "method",
+              "signature": "(self) -> \"'OgcTilesClient'\""
+            },
+            "query_feature_set": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', **kwargs: 'Any') -> 'FeatureSet'"
+            },
+            "query_features": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', *, where: 'str' = '1=1', out_fields: 'str | Sequence[str]' = '*', return_geometry: 'bool' = True, extra_params: 'Mapping[str, Any] | None' = None) -> 'dict[str, Any]'"
+            },
+            "query_features_all": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str', layer_id: 'int', *, where: 'str' = '1=1', out_fields: 'str | Sequence[str]' = '*', return_geometry: 'bool' = True, page_size: 'int' = 1000, limit: 'int | None' = None, max_pages: 'int' = 100, extra_params: 'Mapping[str, Any] | None' = None) -> 'list[Feature]'"
+            },
+            "readiness": {
+              "kind": "method",
+              "signature": "(self) -> 'dict[str, Any]'"
+            },
+            "stac": {
+              "kind": "method",
+              "signature": "(self) -> \"'StacClient'\""
+            },
+            "wfs": {
+              "kind": "method",
+              "signature": "(self) -> \"'WfsClient'\""
+            },
+            "wms": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str') -> \"'WmsClient'\""
+            },
+            "wmts": {
+              "kind": "method",
+              "signature": "(self, service_id: 'str') -> \"'WmtsClient'\""
+            }
+          },
+          "module": "honua_sdk.client",
+          "qualname": "HonuaClient",
+          "signature": "(base_url: 'str', *, timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, follow_redirects: 'bool' = False, client: 'httpx.Client | None' = None, transport: 'httpx.BaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "HonuaError": {
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "HonuaError"
+        },
+        "HonuaGeocodingClient": {
+          "kind": "class",
+          "methods": {
+            "close": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "forward_geocode": {
+              "kind": "method",
+              "signature": "(self, address: 'str', *, max_results: 'int' = 10, country_codes: 'str | None' = None, spatial_reference_wkid: 'int' = 4326) -> 'list[GeocodeResult]'"
+            },
+            "reverse_geocode": {
+              "kind": "method",
+              "signature": "(self, latitude: 'float', longitude: 'float', *, spatial_reference_wkid: 'int' = 4326) -> 'ReverseGeocodeResult | None'"
+            },
+            "suggest": {
+              "kind": "method",
+              "signature": "(self, text: 'str', *, max_suggestions: 'int' = 5, country_codes: 'str | None' = None) -> 'list[GeocodeSuggestion]'"
+            }
+          },
+          "module": "honua_sdk.geocoding",
+          "qualname": "HonuaGeocodingClient",
+          "signature": "(base_url: 'str', *, locator_name: 'str' = 'World', timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, client: 'httpx.Client | None' = None, transport: 'httpx.BaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "HonuaGrpcError": {
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "HonuaGrpcError",
+          "signature": "(code: 'Any', message: 'str', details: 'Any' = None) -> 'None'"
+        },
+        "HonuaHttpError": {
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "HonuaHttpError",
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None) -> 'None'"
+        },
+        "HonuaOgcFeatureCollection": {
+          "kind": "class",
+          "methods": {
+            "create_item": {
+              "kind": "method",
+              "signature": "(self, feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "delete_item": {
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'None'"
+            },
+            "item": {
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items_all": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'list[JsonObject]'"
+            },
+            "metadata": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "patch_item": {
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', patch: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "queryables": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "replace_item": {
+              "kind": "method",
+              "signature": "(self, feature_id: 'FeatureId', feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.ogc",
+          "qualname": "HonuaOgcFeatureCollection",
+          "signature": "(client: 'Any', collection_id: 'FeatureId') -> 'None'"
+        },
+        "HonuaOgcFeatures": {
+          "kind": "class",
+          "methods": {
+            "collection": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId') -> \"'HonuaOgcFeatureCollection'\""
+            },
+            "collections": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "conformance": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "create_item": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "delete_item": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'None'"
+            },
+            "get_collection": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "item": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "items_all": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, offset: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, bbox: 'BboxValue | None' = None, datetime: 'str | None' = None, filter: 'str | None' = None, ids: 'CsvValue | None' = None, properties: 'CsvValue | None' = None, sortby: 'str | None' = None, crs: 'str | None' = None) -> 'list[JsonObject]'"
+            },
+            "landing": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "patch_item": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', patch: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            },
+            "queryables": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            },
+            "replace_item": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', feature_id: 'FeatureId', feature: 'Mapping[str, Any]', *, response_format: 'str' = 'json', extra_params: 'Mapping[str, Any] | None' = None, crs: 'str | None' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.ogc",
+          "qualname": "HonuaOgcFeatures",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "InMemoryTokenStore": {
+          "kind": "class",
+          "methods": {
+            "clear": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "get": {
+              "kind": "method",
+              "signature": "(self) -> 'BearerToken | None'"
+            },
+            "set": {
+              "kind": "method",
+              "signature": "(self, token: 'BearerToken') -> 'None'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "InMemoryTokenStore",
+          "signature": "(token: 'BearerToken | Mapping[str, Any] | str | None' = None) -> 'None'"
+        },
+        "ODataClient": {
+          "kind": "class",
+          "methods": {
+            "feature": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', object_id: 'int') -> 'JsonObject'"
+            },
+            "features": {
+              "kind": "method",
+              "signature": "(self, *, layer_id: 'int | None' = None, extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "layer": {
+              "kind": "method",
+              "signature": "(self, layer_id: 'int', *, extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "layers": {
+              "kind": "method",
+              "signature": "(self, *, extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "metadata": {
+              "kind": "method",
+              "signature": "(self) -> 'str'"
+            },
+            "service_document": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "ODataClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "OgcCoveragesClient": {
+          "kind": "class",
+          "methods": {
+            "collection": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "collections": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "coverage": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'bytes'"
+            },
+            "landing": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "OgcCoveragesClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "OgcMapsClient": {
+          "kind": "class",
+          "methods": {
+            "collection_map": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, bbox: 'BboxValue', response_format: 'str' = 'png', extra_params: 'Params' = None) -> 'bytes'"
+            },
+            "collection_tileset": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', tile_matrix_set_id: 'str') -> 'JsonObject'"
+            },
+            "collection_tilesets": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId') -> 'JsonObject'"
+            },
+            "conformance": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "landing": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "map": {
+              "kind": "method",
+              "signature": "(self, *, collections: 'CsvValue', bbox: 'BboxValue', response_format: 'str' = 'png', extra_params: 'Params' = None) -> 'bytes'"
+            },
+            "openapi": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            },
+            "styled_collection_map": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', style_id: 'str', *, bbox: 'BboxValue', response_format: 'str' = 'png', extra_params: 'Params' = None) -> 'bytes'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "OgcMapsClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "OgcProcessesClient": {
+          "kind": "class",
+          "methods": {
+            "conformance": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "dismiss_job": {
+              "kind": "method",
+              "signature": "(self, job_id: 'str') -> 'None'"
+            },
+            "execute": {
+              "kind": "method",
+              "signature": "(self, process_id: 'str', payload: 'Mapping[str, Any]') -> 'JsonObject'"
+            },
+            "job": {
+              "kind": "method",
+              "signature": "(self, job_id: 'str') -> 'JsonObject'"
+            },
+            "job_results": {
+              "kind": "method",
+              "signature": "(self, job_id: 'str') -> 'JsonObject'"
+            },
+            "jobs": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            },
+            "landing": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "process": {
+              "kind": "method",
+              "signature": "(self, process_id: 'str') -> 'JsonObject'"
+            },
+            "processes": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "OgcProcessesClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "OgcTilesClient": {
+          "kind": "class",
+          "methods": {
+            "collection": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "collection_tilesets": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId') -> 'JsonObject'"
+            },
+            "collections": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "conformance": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "dataset_tilesets": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            },
+            "landing": {
+              "kind": "method",
+              "signature": "(self, *, response_format: 'str' = 'json', extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "tile": {
+              "kind": "method",
+              "signature": "(self, tile_matrix_set_id: 'str', tile_matrix: 'str', row: 'int', col: 'int', *, collection_id: 'FeatureId | None' = None) -> 'bytes'"
+            },
+            "tile_matrix_set": {
+              "kind": "method",
+              "signature": "(self, tile_matrix_set_id: 'str') -> 'JsonObject'"
+            },
+            "tile_matrix_sets": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "OgcTilesClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "RefreshableBearerTokenProvider": {
+          "kind": "class",
+          "methods": {
+            "auth_headers": {
+              "kind": "method",
+              "signature": "(self) -> 'Mapping[str, str]'"
+            },
+            "get_token": {
+              "kind": "method",
+              "signature": "(self) -> 'BearerToken'"
+            },
+            "refresh": {
+              "kind": "method",
+              "signature": "(self) -> 'BearerToken'"
+            },
+            "revoke": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "RefreshableBearerTokenProvider",
+          "signature": "(refresh: 'Callable[[], BearerToken | Mapping[str, Any] | str]', *, initial_token: 'BearerToken | Mapping[str, Any] | str | None' = None, token_store: 'TokenStore | None' = None, refresh_window_seconds: 'int | float' = 60, revoke: 'Callable[[BearerToken], None] | None' = None) -> 'None'"
+        },
+        "ReverseGeocodeResult": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "address"
+            },
+            {
+              "annotation": "float",
+              "name": "latitude"
+            },
+            {
+              "annotation": "float",
+              "name": "longitude"
+            },
+            {
+              "annotation": "dict[str, str | None]",
+              "name": "attributes"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.geocoding",
+          "qualname": "ReverseGeocodeResult",
+          "signature": "(address: 'str', latitude: 'float', longitude: 'float', attributes: 'dict[str, str | None]') -> None"
+        },
+        "ServiceSummary": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "name"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "type"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "url"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'ServiceSummary'\""
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "ServiceSummary",
+          "signature": "(name: 'str', type: 'str | None' = None, url: 'str | None' = None, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "StacClient": {
+          "kind": "class",
+          "methods": {
+            "catalog": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            },
+            "collection": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId') -> 'JsonObject'"
+            },
+            "collections": {
+              "kind": "method",
+              "signature": "(self) -> 'JsonObject'"
+            },
+            "item": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', item_id: 'FeatureId') -> 'JsonObject'"
+            },
+            "items": {
+              "kind": "method",
+              "signature": "(self, collection_id: 'FeatureId', *, extra_params: 'Params' = None) -> 'JsonObject'"
+            },
+            "search": {
+              "kind": "method",
+              "signature": "(self, *, params: 'Params' = None, json_body: 'Mapping[str, Any] | None' = None) -> 'JsonObject'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "StacClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "StaticAuthProvider": {
+          "kind": "class",
+          "methods": {
+            "auth_headers": {
+              "kind": "method",
+              "signature": "(self) -> 'Mapping[str, str]'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "StaticAuthProvider",
+          "signature": "(headers: 'Mapping[str, str]') -> 'None'"
+        },
+        "TokenStore": {
+          "kind": "class",
+          "methods": {
+            "clear": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "get": {
+              "kind": "method",
+              "signature": "(self) -> \"'BearerToken | None'\""
+            },
+            "set": {
+              "kind": "method",
+              "signature": "(self, token: \"'BearerToken'\") -> 'None'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "TokenStore",
+          "signature": "(*args, **kwargs)"
+        },
+        "WfsClient": {
+          "kind": "class",
+          "methods": {
+            "capabilities": {
+              "kind": "method",
+              "signature": "(self) -> 'str'"
+            },
+            "describe_feature_type": {
+              "kind": "method",
+              "signature": "(self, type_names: 'CsvValue | None' = None) -> 'str'"
+            },
+            "get_feature": {
+              "kind": "method",
+              "signature": "(self, *, type_names: 'CsvValue | None' = None, extra_params: 'Params' = None) -> 'str'"
+            },
+            "request": {
+              "kind": "method",
+              "signature": "(self, operation: 'str', *, params: 'Params' = None) -> 'str'"
+            },
+            "transaction": {
+              "kind": "method",
+              "signature": "(self, xml: 'str | bytes') -> 'str'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "WfsClient",
+          "signature": "(client: 'Any') -> 'None'"
+        },
+        "WmsClient": {
+          "kind": "class",
+          "methods": {
+            "capabilities": {
+              "kind": "method",
+              "signature": "(self) -> 'str'"
+            },
+            "feature_info": {
+              "kind": "method",
+              "signature": "(self, *, layers: 'CsvValue', query_layers: 'CsvValue', i: 'int', j: 'int', bbox: 'BboxValue', width: 'int', height: 'int', extra_params: 'Params' = None) -> 'bytes'"
+            },
+            "map": {
+              "kind": "method",
+              "signature": "(self, *, layers: 'CsvValue', bbox: 'BboxValue', width: 'int', height: 'int', crs: 'str' = 'EPSG:4326', image_format: 'str' = 'image/png', extra_params: 'Params' = None) -> 'bytes'"
+            },
+            "request": {
+              "kind": "method",
+              "signature": "(self, operation: 'str', *, params: 'Params' = None) -> 'bytes'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "WmsClient",
+          "signature": "(client: 'Any', service_id: 'str') -> 'None'"
+        },
+        "WmtsClient": {
+          "kind": "class",
+          "methods": {
+            "capabilities": {
+              "kind": "method",
+              "signature": "(self) -> 'str'"
+            },
+            "request": {
+              "kind": "method",
+              "signature": "(self, operation: 'str', *, params: 'Params' = None) -> 'bytes'"
+            },
+            "tile": {
+              "kind": "method",
+              "signature": "(self, *, layer: 'str', tile_matrix_set: 'str', tile_matrix: 'str', tile_row: 'int', tile_col: 'int', image_format: 'str' = 'image/png', extra_params: 'Params' = None) -> 'bytes'"
+            }
+          },
+          "module": "honua_sdk.protocols",
+          "qualname": "WmtsClient",
+          "signature": "(client: 'Any', service_id: 'str') -> 'None'"
+        },
+        "__version__": {
+          "kind": "constant",
+          "type": "str"
+        }
+      }
+    },
+    "honua_sdk.grpc": {
+      "exports": [
+        "DistanceUnit",
+        "Extent",
+        "Feature",
+        "FeaturePage",
+        "FieldDefinition",
+        "FieldType",
+        "GeometryType",
+        "HonuaGrpcAsyncClient",
+        "HonuaGrpcClient",
+        "HonuaGrpcError",
+        "QueryFeaturesRequest",
+        "QueryFeaturesResponse",
+        "SpatialFilter",
+        "SpatialReference",
+        "SpatialRelationship",
+        "StatisticDefinition",
+        "StatisticType"
+      ],
+      "symbols": {
+        "DistanceUnit": {
+          "kind": "enum",
+          "members": {
+            "FEET": 2,
+            "KILOMETERS": 3,
+            "METERS": 1,
+            "MILES": 4,
+            "UNSPECIFIED": 0
+          },
+          "module": "honua_sdk.grpc._models",
+          "qualname": "DistanceUnit"
+        },
+        "Extent": {
+          "fields": [
+            {
+              "annotation": "float",
+              "default": "0.0",
+              "name": "xmin"
+            },
+            {
+              "annotation": "float",
+              "default": "0.0",
+              "name": "ymin"
+            },
+            {
+              "annotation": "float",
+              "default": "0.0",
+              "name": "xmax"
+            },
+            {
+              "annotation": "float",
+              "default": "0.0",
+              "name": "ymax"
+            },
+            {
+              "annotation": "SpatialReference | None",
+              "default": "None",
+              "name": "spatial_reference"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "Extent",
+          "signature": "(xmin: 'float' = 0.0, ymin: 'float' = 0.0, xmax: 'float' = 0.0, ymax: 'float' = 0.0, spatial_reference: 'SpatialReference | None' = None) -> None"
+        },
+        "Feature": {
+          "fields": [
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "id"
+            },
+            {
+              "annotation": "dict[str, Any]",
+              "defaultFactory": "dict",
+              "name": "attributes"
+            },
+            {
+              "annotation": "dict[str, Any] | None",
+              "default": "None",
+              "name": "geometry"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "Feature",
+          "signature": "(id: 'int' = 0, attributes: 'dict[str, Any]' = <factory>, geometry: 'dict[str, Any] | None' = None) -> None"
+        },
+        "FeaturePage": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "object_id_field_name"
+            },
+            {
+              "annotation": "GeometryType",
+              "default": "<GeometryType.UNSPECIFIED: 0>",
+              "name": "geometry_type"
+            },
+            {
+              "annotation": "SpatialReference | None",
+              "default": "None",
+              "name": "spatial_reference"
+            },
+            {
+              "annotation": "list[FieldDefinition]",
+              "defaultFactory": "list",
+              "name": "fields"
+            },
+            {
+              "annotation": "list[Feature]",
+              "defaultFactory": "list",
+              "name": "features"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "is_last_page"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "FeaturePage",
+          "signature": "(object_id_field_name: 'str' = '', geometry_type: 'GeometryType' = <GeometryType.UNSPECIFIED: 0>, spatial_reference: 'SpatialReference | None' = None, fields: 'list[FieldDefinition]' = <factory>, features: 'list[Feature]' = <factory>, is_last_page: 'bool' = False) -> None"
+        },
+        "FieldDefinition": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "name"
+            },
+            {
+              "annotation": "FieldType",
+              "default": "<FieldType.UNSPECIFIED: 0>",
+              "name": "field_type"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "length"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "nullable"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "FieldDefinition",
+          "signature": "(name: 'str' = '', field_type: 'FieldType' = <FieldType.UNSPECIFIED: 0>, length: 'int' = 0, nullable: 'bool' = False) -> None"
+        },
+        "FieldType": {
+          "kind": "enum",
+          "members": {
+            "BIG_INTEGER": 3,
+            "BINARY": 12,
+            "BOOLEAN": 6,
+            "DATE": 8,
+            "DATE_TIME": 7,
+            "DOUBLE": 4,
+            "FLOAT": 5,
+            "GEOMETRY": 10,
+            "INTEGER": 2,
+            "JSON": 11,
+            "STRING": 1,
+            "TIME": 9,
+            "UNSPECIFIED": 0,
+            "UUID": 13
+          },
+          "module": "honua_sdk.grpc._models",
+          "qualname": "FieldType"
+        },
+        "GeometryType": {
+          "kind": "enum",
+          "members": {
+            "GEOMETRY_COLLECTION": 7,
+            "LINE_STRING": 3,
+            "MULTI_LINE_STRING": 4,
+            "MULTI_POINT": 2,
+            "MULTI_POLYGON": 6,
+            "NONE": 8,
+            "POINT": 1,
+            "POLYGON": 5,
+            "UNSPECIFIED": 0
+          },
+          "module": "honua_sdk.grpc._models",
+          "qualname": "GeometryType"
+        },
+        "HonuaGrpcAsyncClient": {
+          "kind": "class",
+          "methods": {
+            "close": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "query_features": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, request: 'models.QueryFeaturesRequest') -> 'models.QueryFeaturesResponse'"
+            },
+            "query_features_stream": {
+              "kind": "method",
+              "signature": "(self, request: 'models.QueryFeaturesRequest')"
+            }
+          },
+          "module": "honua_sdk.grpc._client",
+          "qualname": "HonuaGrpcAsyncClient",
+          "signature": "(target: 'str', *, channel: 'grpc.aio.Channel | None' = None, credentials: 'grpc.ChannelCredentials | None' = None, insecure: 'bool' = False, metadata: 'list[tuple[str, str]] | None' = None, timeout: 'float | None' = 30.0, compression: 'grpc.Compression | None' = <Compression.Gzip: 2>) -> 'None'"
+        },
+        "HonuaGrpcClient": {
+          "kind": "class",
+          "methods": {
+            "close": {
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            },
+            "query_features": {
+              "kind": "method",
+              "signature": "(self, request: 'models.QueryFeaturesRequest') -> 'models.QueryFeaturesResponse'"
+            },
+            "query_features_stream": {
+              "kind": "method",
+              "signature": "(self, request: 'models.QueryFeaturesRequest') -> 'Iterator[models.FeaturePage]'"
+            }
+          },
+          "module": "honua_sdk.grpc._client",
+          "qualname": "HonuaGrpcClient",
+          "signature": "(target: 'str', *, channel: 'grpc.Channel | None' = None, credentials: 'grpc.ChannelCredentials | None' = None, insecure: 'bool' = False, metadata: 'list[tuple[str, str]] | None' = None, timeout: 'float | None' = 30.0, compression: 'grpc.Compression | None' = <Compression.Gzip: 2>) -> 'None'"
+        },
+        "HonuaGrpcError": {
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "HonuaGrpcError",
+          "signature": "(code: 'Any', message: 'str', details: 'Any' = None) -> 'None'"
+        },
+        "QueryFeaturesRequest": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "service_id"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "layer_id"
+            },
+            {
+              "annotation": "str",
+              "default": "'1=1'",
+              "name": "where"
+            },
+            {
+              "annotation": "list[int] | None",
+              "default": "None",
+              "name": "object_ids"
+            },
+            {
+              "annotation": "list[str] | None",
+              "default": "None",
+              "name": "out_fields"
+            },
+            {
+              "annotation": "bool",
+              "default": "True",
+              "name": "return_geometry"
+            },
+            {
+              "annotation": "SpatialReference | None",
+              "default": "None",
+              "name": "out_sr"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "result_offset"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "result_record_count"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "order_by"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_distinct"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_count_only"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_ids_only"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_extent_only"
+            },
+            {
+              "annotation": "list[StatisticDefinition] | None",
+              "default": "None",
+              "name": "out_statistics"
+            },
+            {
+              "annotation": "list[str] | None",
+              "default": "None",
+              "name": "group_by"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "geometry_precision"
+            },
+            {
+              "annotation": "float",
+              "default": "0.0",
+              "name": "max_allowable_offset"
+            },
+            {
+              "annotation": "SpatialFilter | None",
+              "default": "None",
+              "name": "spatial_filter"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "QueryFeaturesRequest",
+          "signature": "(service_id: 'str' = '', layer_id: 'int' = 0, where: 'str' = '1=1', object_ids: 'list[int] | None' = None, out_fields: 'list[str] | None' = None, return_geometry: 'bool' = True, out_sr: 'SpatialReference | None' = None, result_offset: 'int' = 0, result_record_count: 'int' = 0, order_by: 'str' = '', return_distinct: 'bool' = False, return_count_only: 'bool' = False, return_ids_only: 'bool' = False, return_extent_only: 'bool' = False, out_statistics: 'list[StatisticDefinition] | None' = None, group_by: 'list[str] | None' = None, geometry_precision: 'int' = 0, max_allowable_offset: 'float' = 0.0, spatial_filter: 'SpatialFilter | None' = None) -> None"
+        },
+        "QueryFeaturesResponse": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "object_id_field_name"
+            },
+            {
+              "annotation": "GeometryType",
+              "default": "<GeometryType.UNSPECIFIED: 0>",
+              "name": "geometry_type"
+            },
+            {
+              "annotation": "SpatialReference | None",
+              "default": "None",
+              "name": "spatial_reference"
+            },
+            {
+              "annotation": "list[FieldDefinition]",
+              "defaultFactory": "list",
+              "name": "fields"
+            },
+            {
+              "annotation": "list[Feature]",
+              "defaultFactory": "list",
+              "name": "features"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "exceeded_transfer_limit"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "count"
+            },
+            {
+              "annotation": "list[int]",
+              "defaultFactory": "list",
+              "name": "object_ids"
+            },
+            {
+              "annotation": "Extent | None",
+              "default": "None",
+              "name": "extent"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "QueryFeaturesResponse",
+          "signature": "(object_id_field_name: 'str' = '', geometry_type: 'GeometryType' = <GeometryType.UNSPECIFIED: 0>, spatial_reference: 'SpatialReference | None' = None, fields: 'list[FieldDefinition]' = <factory>, features: 'list[Feature]' = <factory>, exceeded_transfer_limit: 'bool' = False, count: 'int' = 0, object_ids: 'list[int]' = <factory>, extent: 'Extent | None' = None) -> None"
+        },
+        "SpatialFilter": {
+          "fields": [
+            {
+              "annotation": "dict[str, Any] | None",
+              "default": "None",
+              "name": "geometry"
+            },
+            {
+              "annotation": "SpatialRelationship",
+              "default": "<SpatialRelationship.UNSPECIFIED: 0>",
+              "name": "spatial_relationship"
+            },
+            {
+              "annotation": "SpatialReference | None",
+              "default": "None",
+              "name": "spatial_reference"
+            },
+            {
+              "annotation": "float",
+              "default": "0.0",
+              "name": "distance"
+            },
+            {
+              "annotation": "DistanceUnit",
+              "default": "<DistanceUnit.UNSPECIFIED: 0>",
+              "name": "distance_unit"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "nearest_count"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_distance"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "SpatialFilter",
+          "signature": "(geometry: 'dict[str, Any] | None' = None, spatial_relationship: 'SpatialRelationship' = <SpatialRelationship.UNSPECIFIED: 0>, spatial_reference: 'SpatialReference | None' = None, distance: 'float' = 0.0, distance_unit: 'DistanceUnit' = <DistanceUnit.UNSPECIFIED: 0>, nearest_count: 'int' = 0, return_distance: 'bool' = False) -> None"
+        },
+        "SpatialReference": {
+          "fields": [
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "wkid"
+            },
+            {
+              "annotation": "int",
+              "default": "0",
+              "name": "latest_wkid"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "wkt"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "SpatialReference",
+          "signature": "(wkid: 'int' = 0, latest_wkid: 'int' = 0, wkt: 'str' = '') -> None"
+        },
+        "SpatialRelationship": {
+          "kind": "enum",
+          "members": {
+            "BEYOND_DISTANCE": 11,
+            "CONTAINS": 3,
+            "CROSSES": 5,
+            "DISJOINT": 8,
+            "ENVELOPE_INTERSECTS": 4,
+            "EQUALS": 9,
+            "INTERSECTS": 1,
+            "NEAREST_NEIGHBOR": 12,
+            "OVERLAPS": 7,
+            "TOUCHES": 6,
+            "UNSPECIFIED": 0,
+            "WITHIN": 2,
+            "WITHIN_DISTANCE": 10
+          },
+          "module": "honua_sdk.grpc._models",
+          "qualname": "SpatialRelationship"
+        },
+        "StatisticDefinition": {
+          "fields": [
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "on_statistic_field"
+            },
+            {
+              "annotation": "StatisticType",
+              "default": "<StatisticType.UNSPECIFIED: 0>",
+              "name": "statistic_type"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "out_statistic_field_name"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.grpc._models",
+          "qualname": "StatisticDefinition",
+          "signature": "(on_statistic_field: 'str' = '', statistic_type: 'StatisticType' = <StatisticType.UNSPECIFIED: 0>, out_statistic_field_name: 'str' = '') -> None"
+        },
+        "StatisticType": {
+          "kind": "enum",
+          "members": {
+            "AVG": 5,
+            "COUNT": 1,
+            "MAX": 4,
+            "MIN": 3,
+            "STDDEV": 6,
+            "SUM": 2,
+            "UNSPECIFIED": 0,
+            "VAR": 7
+          },
+          "module": "honua_sdk.grpc._models",
+          "qualname": "StatisticType"
+        }
+      }
+    }
+  },
+  "schemaVersion": 1
+}

--- a/compatibility/server-matrix.json
+++ b/compatibility/server-matrix.json
@@ -1,0 +1,255 @@
+{
+  "schemaVersion": 1,
+  "baseline": {
+    "minimumServerVersion": "2026.3.0",
+    "controlPlaneApiMajor": 1,
+    "basePath": "/api/v1/admin",
+    "minimumReleaseChannel": "preview"
+  },
+  "cases": [
+    {
+      "name": "minimum-preview-server",
+      "description": "The lowest supported public-preview server line remains compatible.",
+      "compatibility": {
+        "serverVersion": "2026.3.0-preview.0",
+        "releaseChannel": "preview",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [
+          {
+            "version": "v1",
+            "deprecated": false
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      },
+      "expected": {
+        "supported": true,
+        "features": {
+          "metadataResources": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      }
+    },
+    {
+      "name": "current-stable-server",
+      "description": "A newer stable server on the same control-plane major is compatible.",
+      "compatibility": {
+        "serverVersion": "2026.4.0",
+        "releaseChannel": "stable",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [
+          {
+            "version": "v1",
+            "deprecated": false
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      },
+      "expected": {
+        "supported": true,
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true
+        }
+      }
+    },
+    {
+      "name": "deprecated-compatible-control-plane",
+      "description": "Deprecated but still matching control-plane majors warn without blocking.",
+      "compatibility": {
+        "serverVersion": "2026.3.8",
+        "releaseChannel": "stable",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": true
+        },
+        "metadataSchemas": [
+          {
+            "version": "v1",
+            "deprecated": false
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": false,
+          "manifestPrune": false
+        }
+      },
+      "expected": {
+        "supported": true,
+        "warningsContain": [
+          "deprecated"
+        ],
+        "features": {
+          "manifestDryRun": false,
+          "manifestPrune": false
+        }
+      }
+    },
+    {
+      "name": "server-version-below-baseline",
+      "description": "Servers older than the minimum supported line are blocked.",
+      "compatibility": {
+        "serverVersion": "2026.2.28-preview.1",
+        "releaseChannel": "preview",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [
+          {
+            "version": "v1beta1",
+            "deprecated": true
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      },
+      "expected": {
+        "supported": false,
+        "reasonsContain": [
+          "below required"
+        ]
+      }
+    },
+    {
+      "name": "unsupported-control-plane-major",
+      "description": "A different control-plane major is a breaking server contract.",
+      "compatibility": {
+        "serverVersion": "2026.4.0",
+        "releaseChannel": "stable",
+        "controlPlaneApi": {
+          "major": 2,
+          "basePath": "/api/v2/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [
+          {
+            "version": "v2",
+            "deprecated": false
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      },
+      "expected": {
+        "supported": false,
+        "reasonsContain": [
+          "API major",
+          "base path"
+        ]
+      }
+    },
+    {
+      "name": "legacy-control-plane-base-path",
+      "description": "The expected control-plane major must also be mounted at the supported path.",
+      "compatibility": {
+        "serverVersion": "2026.3.2",
+        "releaseChannel": "stable",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [
+          {
+            "version": "v1",
+            "deprecated": false
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      },
+      "expected": {
+        "supported": false,
+        "reasonsContain": [
+          "base path"
+        ]
+      }
+    },
+    {
+      "name": "pre-preview-release-channel",
+      "description": "Nightly/dev/alpha server channels are not supported by release builds.",
+      "compatibility": {
+        "serverVersion": "2026.3.4-alpha.2",
+        "releaseChannel": "alpha",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [
+          {
+            "version": "v1",
+            "deprecated": false
+          }
+        ],
+        "features": {
+          "metadataResources": true,
+          "manifestExport": true,
+          "manifestApply": true,
+          "manifestDryRun": true,
+          "manifestPrune": true
+        }
+      },
+      "expected": {
+        "supported": false,
+        "reasonsContain": [
+          "release channel"
+        ]
+      }
+    },
+    {
+      "name": "missing-compatibility-contract",
+      "description": "Servers must publish the nested compatibility contract.",
+      "compatibility": null,
+      "expected": {
+        "supported": false,
+        "reasonsContain": [
+          "compatibility contract"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,60 @@
+# SDK Compatibility Policy
+
+The Python SDK compatibility gate protects two contracts:
+
+- The supported Honua Server compatibility contract returned by
+  `/api/v1/admin/capabilities`.
+- The public Python API exported by `honua_sdk`, `honua_sdk.grpc`, and
+  `honua_admin`.
+
+## Server Compatibility Baseline
+
+Release builds support Honua Server versions that meet all of these conditions:
+
+- `serverVersion` parses to at least `2026.3.0`.
+- `releaseChannel` is `preview` or a later channel (`beta`, `rc`, `stable`, or
+  `lts`).
+- `controlPlaneApi.major` is `1`.
+- `controlPlaneApi.basePath` is `/api/v1/admin`.
+- The server returns the nested `compatibility` object from
+  `/api/v1/admin/capabilities`.
+
+Matching control-plane APIs marked `deprecated` remain supported, but
+`check_compatibility()` returns a warning so applications can plan migrations
+before the API major is removed.
+
+The machine-readable matrix lives in
+[`compatibility/server-matrix.json`](../compatibility/server-matrix.json). It
+contains supported and unsupported server examples and is validated in CI by:
+
+```bash
+python scripts/compatibility_gate.py
+```
+
+Update the matrix in the same PR as any SDK baseline change. The gate also
+checks that the JSON baseline matches the constants exported by `honua_admin`.
+
+## Public API Snapshot
+
+The compatibility gate snapshots exported names, constructor and method
+signatures, enum members, and dataclass fields for the public SDK modules. This
+catches accidental breaking changes such as removed exports, renamed methods,
+or changed required parameters before they merge.
+
+When a public API change is intentional:
+
+1. Review whether it is additive, deprecating, or breaking.
+2. Document the behavior in the PR and changelog entry for the affected package.
+3. Regenerate the snapshot:
+
+   ```bash
+   python scripts/compatibility_gate.py --update-api-snapshot
+   ```
+
+4. Commit the updated `compatibility/public-api.json` with the code change.
+
+## CI And Release Blocking
+
+Pull request CI runs the compatibility gate as its own job. The publish workflow
+also runs the same gate before package build/upload steps, so a failed server
+matrix or public API drift blocks release tags and manual publish runs.

--- a/packages/honua-admin/README.md
+++ b/packages/honua-admin/README.md
@@ -18,6 +18,9 @@ and error types).
 
 Requires Python 3.11+.
 
+The server compatibility baseline and release gate policy are documented in the
+monorepo [compatibility guide](../../docs/compatibility.md).
+
 ## Quick Example
 
 ```python

--- a/packages/honua-admin/honua_admin/__init__.py
+++ b/packages/honua-admin/honua_admin/__init__.py
@@ -54,6 +54,7 @@ from ._models import (
     MINIMUM_SUPPORTED_CONTROL_PLANE_API_MAJOR,
     MINIMUM_SUPPORTED_CONTROL_PLANE_BASE_PATH,
     MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL,
+    evaluate_admin_compatibility,
 )
 
 __all__ = [
@@ -99,4 +100,5 @@ __all__ = [
     "TableInfo",
     "TimeInfoResponse",
     "UpdateSecureConnectionRequest",
+    "evaluate_admin_compatibility",
 ]

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -44,8 +44,7 @@ from ._models import (
     ServiceSummary,
     TableDiscoveryResponse,
     UpdateSecureConnectionRequest,
-    _parse_version_components,
-    get_release_channel_rank,
+    evaluate_admin_compatibility,
 )
 
 
@@ -350,74 +349,9 @@ class AsyncHonuaAdminClient:
     async def check_compatibility(self) -> AdminCompatibilityCheckResult:
         """Evaluate whether the connected server satisfies the admin SDK baseline."""
         capabilities = await self.get_capabilities()
-        compatibility = capabilities.compatibility
-        baseline = self.MINIMUM_SUPPORTED_SERVER_BASELINE
-        reasons: list[str] = []
-        warnings: list[str] = []
-
-        if compatibility is None:
-            reasons.append("Server did not return a compatibility contract.")
-            return AdminCompatibilityCheckResult(
-                supported=False,
-                baseline=baseline,
-                compatibility=None,
-                reasons=reasons,
-                warnings=warnings,
-            )
-
-        actual_version = _parse_version_components(compatibility.server_version)
-        minimum_version = _parse_version_components(baseline.minimum_server_version)
-        if actual_version is None:
-            reasons.append(
-                f"Server version {compatibility.server_version!r} could not be parsed."
-            )
-        elif minimum_version is None:
-            reasons.append(
-                "SDK minimum supported server version baseline could not be parsed."
-            )
-        elif actual_version < minimum_version:
-            reasons.append(
-                "Server version "
-                f"{compatibility.server_version!r} is below required "
-                f"{baseline.minimum_server_version!r}."
-            )
-
-        if compatibility.control_plane_api.major != baseline.control_plane_api_major:
-            reasons.append(
-                "Server control-plane API major "
-                f"{compatibility.control_plane_api.major} does not match required "
-                f"{baseline.control_plane_api_major}."
-            )
-
-        if compatibility.control_plane_api.base_path != baseline.base_path:
-            reasons.append(
-                "Server control-plane base path "
-                f"{compatibility.control_plane_api.base_path!r} does not match "
-                f"required {baseline.base_path!r}."
-            )
-
-        if compatibility.control_plane_api.deprecated:
-            warnings.append("Server control-plane API major is marked deprecated.")
-
-        actual_rank = get_release_channel_rank(compatibility.release_channel)
-        minimum_rank = get_release_channel_rank(baseline.minimum_release_channel)
-        if actual_rank is None:
-            reasons.append(
-                f"Server release channel {compatibility.release_channel!r} is unknown."
-            )
-        elif minimum_rank is None or actual_rank < minimum_rank:
-            reasons.append(
-                "Server release channel "
-                f"{compatibility.release_channel!r} is below required "
-                f"{baseline.minimum_release_channel!r}."
-            )
-
-        return AdminCompatibilityCheckResult(
-            supported=not reasons,
-            baseline=baseline,
-            compatibility=compatibility,
-            reasons=reasons,
-            warnings=warnings,
+        return evaluate_admin_compatibility(
+            capabilities.compatibility,
+            self.MINIMUM_SUPPORTED_SERVER_BASELINE,
         )
 
     async def get_manifest(self, namespace: str | None = None) -> MetadataManifest:

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -44,8 +44,7 @@ from ._models import (
     ServiceSummary,
     TableDiscoveryResponse,
     UpdateSecureConnectionRequest,
-    _parse_version_components,
-    get_release_channel_rank,
+    evaluate_admin_compatibility,
 )
 
 
@@ -350,74 +349,9 @@ class HonuaAdminClient:
     def check_compatibility(self) -> AdminCompatibilityCheckResult:
         """Evaluate whether the connected server satisfies the admin SDK baseline."""
         capabilities = self.get_capabilities()
-        compatibility = capabilities.compatibility
-        baseline = self.MINIMUM_SUPPORTED_SERVER_BASELINE
-        reasons: list[str] = []
-        warnings: list[str] = []
-
-        if compatibility is None:
-            reasons.append("Server did not return a compatibility contract.")
-            return AdminCompatibilityCheckResult(
-                supported=False,
-                baseline=baseline,
-                compatibility=None,
-                reasons=reasons,
-                warnings=warnings,
-            )
-
-        actual_version = _parse_version_components(compatibility.server_version)
-        minimum_version = _parse_version_components(baseline.minimum_server_version)
-        if actual_version is None:
-            reasons.append(
-                f"Server version {compatibility.server_version!r} could not be parsed."
-            )
-        elif minimum_version is None:
-            reasons.append(
-                "SDK minimum supported server version baseline could not be parsed."
-            )
-        elif actual_version < minimum_version:
-            reasons.append(
-                "Server version "
-                f"{compatibility.server_version!r} is below required "
-                f"{baseline.minimum_server_version!r}."
-            )
-
-        if compatibility.control_plane_api.major != baseline.control_plane_api_major:
-            reasons.append(
-                "Server control-plane API major "
-                f"{compatibility.control_plane_api.major} does not match required "
-                f"{baseline.control_plane_api_major}."
-            )
-
-        if compatibility.control_plane_api.base_path != baseline.base_path:
-            reasons.append(
-                "Server control-plane base path "
-                f"{compatibility.control_plane_api.base_path!r} does not match "
-                f"required {baseline.base_path!r}."
-            )
-
-        if compatibility.control_plane_api.deprecated:
-            warnings.append("Server control-plane API major is marked deprecated.")
-
-        actual_rank = get_release_channel_rank(compatibility.release_channel)
-        minimum_rank = get_release_channel_rank(baseline.minimum_release_channel)
-        if actual_rank is None:
-            reasons.append(
-                f"Server release channel {compatibility.release_channel!r} is unknown."
-            )
-        elif minimum_rank is None or actual_rank < minimum_rank:
-            reasons.append(
-                "Server release channel "
-                f"{compatibility.release_channel!r} is below required "
-                f"{baseline.minimum_release_channel!r}."
-            )
-
-        return AdminCompatibilityCheckResult(
-            supported=not reasons,
-            baseline=baseline,
-            compatibility=compatibility,
-            reasons=reasons,
-            warnings=warnings,
+        return evaluate_admin_compatibility(
+            capabilities.compatibility,
+            self.MINIMUM_SUPPORTED_SERVER_BASELINE,
         )
 
     def get_manifest(self, namespace: str | None = None) -> MetadataManifest:

--- a/packages/honua-admin/honua_admin/_models.py
+++ b/packages/honua-admin/honua_admin/_models.py
@@ -536,6 +536,75 @@ def get_release_channel_rank(channel: str | None) -> int | None:
     return _RELEASE_CHANNEL_ORDER.get(channel.lower())
 
 
+def evaluate_admin_compatibility(
+    compatibility: AdminCompatibilityMetadata | None,
+    baseline: AdminCompatibilityBaseline | None = None,
+) -> AdminCompatibilityCheckResult:
+    """Evaluate a server compatibility contract against the SDK baseline."""
+    baseline = baseline or AdminCompatibilityBaseline()
+    reasons: list[str] = []
+    warnings: list[str] = []
+
+    if compatibility is None:
+        reasons.append("Server did not return a compatibility contract.")
+        return AdminCompatibilityCheckResult(
+            supported=False,
+            baseline=baseline,
+            compatibility=None,
+            reasons=reasons,
+            warnings=warnings,
+        )
+
+    actual_version = _parse_version_components(compatibility.server_version)
+    minimum_version = _parse_version_components(baseline.minimum_server_version)
+    if actual_version is None:
+        reasons.append(f"Server version {compatibility.server_version!r} could not be parsed.")
+    elif minimum_version is None:
+        reasons.append("SDK minimum supported server version baseline could not be parsed.")
+    elif actual_version < minimum_version:
+        reasons.append(
+            "Server version "
+            f"{compatibility.server_version!r} is below required "
+            f"{baseline.minimum_server_version!r}."
+        )
+
+    if compatibility.control_plane_api.major != baseline.control_plane_api_major:
+        reasons.append(
+            "Server control-plane API major "
+            f"{compatibility.control_plane_api.major} does not match required "
+            f"{baseline.control_plane_api_major}."
+        )
+
+    if compatibility.control_plane_api.base_path != baseline.base_path:
+        reasons.append(
+            "Server control-plane base path "
+            f"{compatibility.control_plane_api.base_path!r} does not match "
+            f"required {baseline.base_path!r}."
+        )
+
+    if compatibility.control_plane_api.deprecated:
+        warnings.append("Server control-plane API major is marked deprecated.")
+
+    actual_rank = get_release_channel_rank(compatibility.release_channel)
+    minimum_rank = get_release_channel_rank(baseline.minimum_release_channel)
+    if actual_rank is None:
+        reasons.append(f"Server release channel {compatibility.release_channel!r} is unknown.")
+    elif minimum_rank is None or actual_rank < minimum_rank:
+        reasons.append(
+            "Server release channel "
+            f"{compatibility.release_channel!r} is below required "
+            f"{baseline.minimum_release_channel!r}."
+        )
+
+    return AdminCompatibilityCheckResult(
+        supported=not reasons,
+        baseline=baseline,
+        compatibility=compatibility,
+        reasons=reasons,
+        warnings=warnings,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class ColumnInfo:
     name: str

--- a/scripts/compatibility_gate.py
+++ b/scripts/compatibility_gate.py
@@ -1,0 +1,436 @@
+"""Compatibility gate for server contracts and public SDK API drift."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import difflib
+import enum
+import inspect
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+API_SNAPSHOT_PATH = ROOT / "compatibility" / "public-api.json"
+MATRIX_PATH = ROOT / "compatibility" / "server-matrix.json"
+PUBLIC_MODULES = ("honua_sdk", "honua_sdk.grpc", "honua_admin")
+
+
+def _add_source_paths() -> None:
+    for path in (ROOT / "packages" / "honua-admin", ROOT / "packages" / "honua-sdk"):
+        value = str(path)
+        if value not in sys.path:
+            sys.path.insert(0, value)
+
+
+_add_source_paths()
+
+from honua_admin import AdminCompatibilityBaseline  # noqa: E402
+from honua_admin import evaluate_admin_compatibility  # noqa: E402
+from honua_admin._models import AdminCompatibilityMetadata  # noqa: E402
+
+
+def _json_dumps(data: Mapping[str, Any]) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def _signature(value: Any) -> str | None:
+    try:
+        return str(inspect.signature(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _annotation(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    name = getattr(value, "__qualname__", None)
+    module = getattr(value, "__module__", None)
+    if name and module and module != "builtins":
+        return f"{module}.{name}"
+    if name:
+        return name
+    return repr(value)
+
+
+def _field_default(field: dataclasses.Field[Any]) -> dict[str, str]:
+    if field.default is not dataclasses.MISSING:
+        return {"default": repr(field.default)}
+    if field.default_factory is not dataclasses.MISSING:
+        factory = field.default_factory
+        factory_name = getattr(factory, "__qualname__", repr(factory))
+        factory_module = getattr(factory, "__module__", None)
+        if factory_module and factory_module != "builtins":
+            factory_name = f"{factory_module}.{factory_name}"
+        return {"defaultFactory": factory_name}
+    return {}
+
+
+def _collect_dataclass_fields(cls: type[Any]) -> list[dict[str, str]]:
+    annotations = getattr(cls, "__annotations__", {})
+    collected = []
+    for field in dataclasses.fields(cls):
+        item = {
+            "name": field.name,
+            "annotation": _annotation(annotations.get(field.name, field.type)),
+        }
+        item.update(_field_default(field))
+        collected.append(item)
+    return collected
+
+
+def _collect_public_methods(cls: type[Any]) -> dict[str, dict[str, Any]]:
+    methods: dict[str, dict[str, Any]] = {}
+    for name, raw_value in sorted(cls.__dict__.items()):
+        if name.startswith("_"):
+            continue
+        if isinstance(raw_value, (classmethod, staticmethod)):
+            target = raw_value.__func__
+            method_kind = "classmethod" if isinstance(raw_value, classmethod) else "staticmethod"
+        elif isinstance(raw_value, property):
+            methods[name] = {"kind": "property"}
+            continue
+        else:
+            target = raw_value
+            method_kind = "method"
+
+        if not (inspect.isfunction(target) or inspect.ismethoddescriptor(target)):
+            continue
+
+        method: dict[str, Any] = {"kind": method_kind}
+        signature = _signature(target)
+        if signature is not None:
+            method["signature"] = signature
+        if inspect.iscoroutinefunction(target):
+            method["async"] = True
+        methods[name] = method
+    return methods
+
+
+def _collect_class(export_name: str, cls: type[Any]) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "kind": "class",
+        "module": cls.__module__,
+        "qualname": cls.__qualname__,
+    }
+    if issubclass(cls, enum.Enum):
+        item["kind"] = "enum"
+        item["members"] = {name: member.value for name, member in cls.__members__.items()}
+        return item
+
+    signature = _signature(cls)
+    if signature is not None:
+        item["signature"] = signature
+    if dataclasses.is_dataclass(cls):
+        item["fields"] = _collect_dataclass_fields(cls)
+
+    methods = _collect_public_methods(cls)
+    if methods:
+        item["methods"] = methods
+    return item
+
+
+def _collect_export(module_name: str, export_name: str, value: Any) -> dict[str, Any]:
+    if inspect.isclass(value):
+        return _collect_class(export_name, value)
+    if inspect.isfunction(value):
+        item: dict[str, Any] = {
+            "kind": "function",
+            "module": value.__module__,
+            "qualname": value.__qualname__,
+        }
+        signature = _signature(value)
+        if signature is not None:
+            item["signature"] = signature
+        return item
+    if export_name == "__version__":
+        return {"kind": "constant", "type": type(value).__name__}
+    return {"kind": "constant", "type": type(value).__name__, "value": repr(value)}
+
+
+def collect_public_api_surface() -> dict[str, Any]:
+    surface: dict[str, Any] = {
+        "schemaVersion": 1,
+        "modules": {},
+    }
+    for module_name in PUBLIC_MODULES:
+        module = __import__(module_name, fromlist=["*"])
+        exports = sorted(getattr(module, "__all__", ()))
+        module_surface: dict[str, Any] = {
+            "exports": exports,
+            "symbols": {},
+        }
+        for export_name in exports:
+            module_surface["symbols"][export_name] = _collect_export(
+                module_name,
+                export_name,
+                getattr(module, export_name),
+            )
+        surface["modules"][module_name] = module_surface
+    return surface
+
+
+def update_api_snapshot(path: Path = API_SNAPSHOT_PATH) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_dumps(collect_public_api_surface()), encoding="utf-8")
+
+
+def check_public_api_snapshot(path: Path = API_SNAPSHOT_PATH) -> list[str]:
+    actual = collect_public_api_surface()
+    try:
+        expected = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [f"Public API snapshot is missing: {path}"]
+
+    if actual == expected:
+        return []
+
+    expected_text = _json_dumps(expected).splitlines()
+    actual_text = _json_dumps(actual).splitlines()
+    diff = "\n".join(
+        difflib.unified_diff(
+            expected_text,
+            actual_text,
+            fromfile=str(path),
+            tofile="current public API",
+            lineterm="",
+        )
+    )
+    return [
+        "Public API snapshot drift detected. "
+        "Run `python scripts/compatibility_gate.py --update-api-snapshot` "
+        "after reviewing any intentional public API change.\n"
+        f"{diff}"
+    ]
+
+
+def _required_str(data: Mapping[str, Any], key: str, scope: str) -> tuple[str | None, str | None]:
+    value = data.get(key)
+    if isinstance(value, str):
+        return value, None
+    return None, f"{scope}: expected {key!r} to be a string."
+
+
+def _required_int(data: Mapping[str, Any], key: str, scope: str) -> tuple[int | None, str | None]:
+    value = data.get(key)
+    if isinstance(value, int):
+        return value, None
+    return None, f"{scope}: expected {key!r} to be an integer."
+
+
+def _baseline_from_matrix(data: Mapping[str, Any]) -> tuple[AdminCompatibilityBaseline | None, list[str]]:
+    minimum_server_version, version_error = _required_str(data, "minimumServerVersion", "baseline")
+    control_plane_api_major, major_error = _required_int(data, "controlPlaneApiMajor", "baseline")
+    base_path, base_path_error = _required_str(data, "basePath", "baseline")
+    minimum_release_channel, channel_error = _required_str(data, "minimumReleaseChannel", "baseline")
+    errors = [
+        error
+        for error in (
+            version_error,
+            major_error,
+            base_path_error,
+            channel_error,
+        )
+        if error is not None
+    ]
+    if errors:
+        return None, errors
+    assert minimum_server_version is not None
+    assert control_plane_api_major is not None
+    assert base_path is not None
+    assert minimum_release_channel is not None
+    return AdminCompatibilityBaseline(
+        minimum_server_version=minimum_server_version,
+        control_plane_api_major=control_plane_api_major,
+        base_path=base_path,
+        minimum_release_channel=minimum_release_channel,
+    ), []
+
+
+def _to_snake(name: str) -> str:
+    s1 = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).replace("-", "_").lower()
+
+
+def _contains_any(values: Sequence[str], expected: str) -> bool:
+    return any(expected in value for value in values)
+
+
+def _expected_strings(case_name: str, expected: Mapping[str, Any], key: str) -> tuple[list[str], list[str]]:
+    value = expected.get(key)
+    if value is None:
+        return [], []
+    if not isinstance(value, list):
+        return [], [f"{case_name}: expected.{key} must be a list of strings."]
+    failures = []
+    strings = []
+    for item in value:
+        if isinstance(item, str):
+            strings.append(item)
+        else:
+            failures.append(f"{case_name}: expected.{key} entries must be strings.")
+    return strings, failures
+
+
+def _check_expected_features(case_name: str, result: Any, expected: Mapping[str, Any]) -> list[str]:
+    expected_features = expected.get("features")
+    if expected_features is None:
+        return []
+    if not isinstance(expected_features, Mapping):
+        return [f"{case_name}: expected.features must be an object."]
+    if result.compatibility is None:
+        return [f"{case_name}: expected feature checks but compatibility is missing."]
+
+    failures = []
+    for raw_name, expected_value in sorted(expected_features.items()):
+        if not isinstance(expected_value, bool):
+            failures.append(f"{case_name}: expected.features.{raw_name} must be a boolean.")
+            continue
+        attr = _to_snake(raw_name)
+        actual_value = getattr(result.compatibility.features, attr, None)
+        if actual_value != expected_value:
+            failures.append(
+                f"{case_name}: feature {raw_name!r} expected {expected_value!r}, "
+                f"got {actual_value!r}."
+            )
+    return failures
+
+
+def _check_matrix_case(case: Mapping[str, Any], baseline: AdminCompatibilityBaseline) -> list[str]:
+    case_name = case.get("name")
+    if not isinstance(case_name, str) or not case_name:
+        return ["Matrix case is missing a non-empty string name."]
+
+    expected = case.get("expected")
+    if not isinstance(expected, Mapping):
+        return [f"{case_name}: expected must be an object."]
+    expected_supported = expected.get("supported")
+    if not isinstance(expected_supported, bool):
+        return [f"{case_name}: expected.supported must be a boolean."]
+
+    if "compatibility" not in case:
+        return [f"{case_name}: compatibility must be present as an object or null."]
+
+    raw_compatibility = case["compatibility"]
+    if raw_compatibility is None:
+        compatibility = None
+    elif isinstance(raw_compatibility, Mapping):
+        compatibility = AdminCompatibilityMetadata.from_dict(dict(raw_compatibility))
+    else:
+        return [f"{case_name}: compatibility must be an object or null."]
+
+    result = evaluate_admin_compatibility(compatibility, baseline)
+    failures = []
+    if result.supported != expected_supported:
+        failures.append(
+            f"{case_name}: expected supported={expected_supported!r}, "
+            f"got supported={result.supported!r}; reasons={result.reasons!r}."
+        )
+
+    expected_reasons, reason_failures = _expected_strings(case_name, expected, "reasonsContain")
+    failures.extend(reason_failures)
+    for expected_reason in expected_reasons:
+        if not _contains_any(result.reasons, expected_reason):
+            failures.append(
+                f"{case_name}: no compatibility reason contained {expected_reason!r}; "
+                f"reasons={result.reasons!r}."
+            )
+
+    expected_warnings, warning_failures = _expected_strings(case_name, expected, "warningsContain")
+    failures.extend(warning_failures)
+    for expected_warning in expected_warnings:
+        if not _contains_any(result.warnings, expected_warning):
+            failures.append(
+                f"{case_name}: no compatibility warning contained {expected_warning!r}; "
+                f"warnings={result.warnings!r}."
+            )
+
+    failures.extend(_check_expected_features(case_name, result, expected))
+    return failures
+
+
+def check_server_matrix(path: Path = MATRIX_PATH) -> list[str]:
+    try:
+        matrix = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [f"Compatibility server matrix is missing: {path}"]
+
+    if not isinstance(matrix, Mapping):
+        return ["Compatibility server matrix must be a JSON object."]
+
+    failures = []
+    if matrix.get("schemaVersion") != 1:
+        failures.append("Compatibility server matrix schemaVersion must be 1.")
+
+    raw_baseline = matrix.get("baseline")
+    if not isinstance(raw_baseline, Mapping):
+        failures.append("Compatibility server matrix baseline must be an object.")
+        baseline = AdminCompatibilityBaseline()
+    else:
+        parsed_baseline, baseline_failures = _baseline_from_matrix(raw_baseline)
+        if baseline_failures:
+            failures.extend(baseline_failures)
+            baseline = AdminCompatibilityBaseline()
+        else:
+            assert parsed_baseline is not None
+            baseline = parsed_baseline
+            code_baseline = AdminCompatibilityBaseline()
+            if baseline != code_baseline:
+                failures.append(
+                    "Compatibility matrix baseline does not match honua_admin "
+                    f"constants: matrix={baseline!r}, code={code_baseline!r}."
+                )
+
+    cases = matrix.get("cases")
+    if not isinstance(cases, list) or not cases:
+        failures.append("Compatibility server matrix must include at least one case.")
+        return failures
+
+    for case in cases:
+        if not isinstance(case, Mapping):
+            failures.append("Compatibility server matrix cases must be objects.")
+            continue
+        failures.extend(_check_matrix_case(case, baseline))
+
+    return failures
+
+
+def run_gate() -> list[str]:
+    failures = []
+    failures.extend(check_public_api_snapshot())
+    failures.extend(check_server_matrix())
+    return failures
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--update-api-snapshot",
+        action="store_true",
+        help="Rewrite compatibility/public-api.json from the current public SDK surface.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.update_api_snapshot:
+        update_api_snapshot()
+        print(f"Updated {API_SNAPSHOT_PATH.relative_to(ROOT)}")
+        return 0
+
+    failures = run_gate()
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    print("Compatibility gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/admin/test_compatibility.py
+++ b/tests/admin/test_compatibility.py
@@ -2,16 +2,25 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import httpx
 
 from honua_admin import (
+    AdminCompatibilityBaseline,
+    AdminCompatibilityMetadata,
     MINIMUM_SUPPORTED_CONTROL_PLANE_API_MAJOR,
     MINIMUM_SUPPORTED_CONTROL_PLANE_BASE_PATH,
     MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL,
     MINIMUM_SUPPORTED_SERVER_VERSION,
+    evaluate_admin_compatibility,
 )
 
 from .conftest import make_api_response
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVER_MATRIX_PATH = ROOT / "compatibility" / "server-matrix.json"
 
 
 def _make_capabilities_payload(
@@ -163,3 +172,19 @@ def test_get_capability_flags_returns_coarse_feature_support(make_client) -> Non
     assert features.manifest_apply is False
     assert features.manifest_dry_run is False
     assert features.manifest_prune is False
+
+
+def test_server_compatibility_matrix_matches_admin_evaluator() -> None:
+    matrix = json.loads(SERVER_MATRIX_PATH.read_text(encoding="utf-8"))
+    baseline = AdminCompatibilityBaseline()
+
+    for case in matrix["cases"]:
+        raw_compatibility = case["compatibility"]
+        compatibility = (
+            None
+            if raw_compatibility is None
+            else AdminCompatibilityMetadata.from_dict(raw_compatibility)
+        )
+        result = evaluate_admin_compatibility(compatibility, baseline)
+
+        assert result.supported is case["expected"]["supported"], case["name"]

--- a/tests/test_compatibility_gate.py
+++ b/tests/test_compatibility_gate.py
@@ -1,0 +1,48 @@
+"""Tests for the repository compatibility gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE_PATH = ROOT / "scripts" / "compatibility_gate.py"
+SPEC = importlib.util.spec_from_file_location("compatibility_gate", GATE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+compatibility_gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compatibility_gate)
+
+
+def test_public_api_snapshot_is_current() -> None:
+    assert compatibility_gate.check_public_api_snapshot(compatibility_gate.API_SNAPSHOT_PATH) == []
+
+
+def test_public_api_snapshot_detects_removed_export(tmp_path: Path) -> None:
+    snapshot = compatibility_gate.collect_public_api_surface()
+    snapshot["modules"]["honua_sdk"]["exports"].remove("HonuaClient")
+
+    snapshot_path = tmp_path / "public-api.json"
+    snapshot_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    failures = compatibility_gate.check_public_api_snapshot(snapshot_path)
+
+    assert any("Public API snapshot drift detected" in failure for failure in failures)
+    assert any("HonuaClient" in failure for failure in failures)
+
+
+def test_server_matrix_is_valid() -> None:
+    assert compatibility_gate.check_server_matrix(compatibility_gate.MATRIX_PATH) == []
+
+
+def test_server_matrix_rejects_baseline_drift(tmp_path: Path) -> None:
+    matrix = json.loads(compatibility_gate.MATRIX_PATH.read_text(encoding="utf-8"))
+    matrix["baseline"]["minimumServerVersion"] = "1900.1.1"
+
+    matrix_path = tmp_path / "server-matrix.json"
+    matrix_path.write_text(json.dumps(matrix, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    failures = compatibility_gate.check_server_matrix(matrix_path)
+
+    assert any("baseline does not match" in failure for failure in failures)


### PR DESCRIPTION
Closes #4

## Summary
- Add a documented SDK compatibility policy covering the supported Honua Server baseline, public API snapshot process, and CI/release blocking behavior.
- Add `scripts/compatibility_gate.py` with a machine-readable server-version matrix and public API drift detection for `honua_sdk`, `honua_sdk.grpc`, and `honua_admin`.
- Reuse a pure `evaluate_admin_compatibility()` helper from sync/async admin clients and tests.
- Run the compatibility gate in pull request CI and before both package publish jobs.

## Validation
- `ruff check .`
- `python scripts/compatibility_gate.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin python -m pytest tests -q -p no:cacheprovider`
- `git diff --check`
- `python -m hatch build && python -m twine check dist/*` for `honua-sdk`
- `python -m hatch build && python -m twine check dist/*` for `honua-admin`