### PR TITLE
[codex] Fix SDK review findings

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -65,13 +65,11 @@ jobs:
 
       - name: Validate tag version
         if: github.event_name == 'push'
-        run: |
-          package_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
-          tag_version="${GITHUB_REF_NAME#python-sdk-v}"
-          if [[ "$tag_version" != "$package_version" ]]; then
-            echo "Tag version ($tag_version) does not match pyproject.toml version ($package_version)."
-            exit 1
-          fi
+        run: >
+          python "${GITHUB_WORKSPACE}/scripts/validate_publish_tag.py"
+          --pyproject pyproject.toml
+          --tag "${GITHUB_REF_NAME}"
+          --prefix python-sdk-v
 
       - name: Build package
         run: hatch build
@@ -136,13 +134,11 @@ jobs:
 
       - name: Validate tag version
         if: github.event_name == 'push'
-        run: |
-          package_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
-          tag_version="${GITHUB_REF_NAME#python-admin-v}"
-          if [[ "$tag_version" != "$package_version" ]]; then
-            echo "Tag version ($tag_version) does not match pyproject.toml version ($package_version)."
-            exit 1
-          fi
+        run: >
+          python "${GITHUB_WORKSPACE}/scripts/validate_publish_tag.py"
+          --pyproject pyproject.toml
+          --tag "${GITHUB_REF_NAME}"
+          --prefix python-admin-v
 
       - name: Build package
         run: hatch build

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -18,6 +18,7 @@ from honua_sdk._http import (
     _to_http_error,
     _to_transport_error,
     _validate_auth_configuration,
+    _validate_external_client_auth_configuration,
 )
 from honua_sdk.auth import AuthProvider
 from ._models import (
@@ -69,6 +70,12 @@ class AsyncHonuaAdminClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _validate_external_client_auth_configuration(
+            client=client,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            auth_provider=auth_provider,
+        )
 
         self._owns_client = client is None
         if client is not None:

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -18,6 +18,7 @@ from honua_sdk._http import (
     _to_http_error,
     _to_transport_error,
     _validate_auth_configuration,
+    _validate_external_client_auth_configuration,
 )
 from honua_sdk.auth import AuthProvider
 from ._models import (
@@ -69,6 +70,12 @@ class HonuaAdminClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _validate_external_client_auth_configuration(
+            client=client,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            auth_provider=auth_provider,
+        )
 
         self._owns_client = client is None
         if client is not None:

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -42,6 +42,24 @@ def _validate_auth_configuration(
         raise ValueError("Provide either `bearer_token` or `auth_provider`, not both.")
 
 
+def _validate_external_client_auth_configuration(
+    *,
+    client: object | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    auth_provider: AuthProvider | None,
+) -> None:
+    if client is None:
+        return
+    if api_key is None and bearer_token is None and auth_provider is None:
+        return
+    raise ValueError(
+        "Configure authentication on the supplied `client`; "
+        "`api_key`, `bearer_token`, and `auth_provider` are only applied "
+        "when the SDK creates the HTTP client."
+    )
+
+
 def _extract_trusted_authority(url: httpx.URL) -> tuple[str, int | None]:
     """Return ``(host, port)`` from *url* for use as a trusted-origin key.
 

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -17,6 +17,7 @@ from ._http import (
     _to_http_error,
     _to_transport_error,
     _validate_auth_configuration,
+    _validate_external_client_auth_configuration,
 )
 from .models import ApplyEditsResult, Feature, FeatureSet, ServiceSummary
 
@@ -48,6 +49,12 @@ class AsyncHonuaClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _validate_external_client_auth_configuration(
+            client=client,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            auth_provider=auth_provider,
+        )
 
         self._owns_client = client is None
         if client is not None:

--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -17,6 +17,7 @@ from ._http import (
     _to_http_error,
     _to_transport_error,
     _validate_auth_configuration,
+    _validate_external_client_auth_configuration,
 )
 from .auth import AuthProvider
 from .geocoding import GeocodeResult, GeocodeSuggestion, ReverseGeocodeResult
@@ -41,6 +42,12 @@ class AsyncHonuaGeocodingClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _validate_external_client_auth_configuration(
+            client=client,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            auth_provider=auth_provider,
+        )
 
         self._locator_name = locator_name
         self._owns_client = client is None

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -17,6 +17,7 @@ from ._http import (
     _to_http_error,
     _to_transport_error,
     _validate_auth_configuration,
+    _validate_external_client_auth_configuration,
 )
 from .models import ApplyEditsResult, Feature, FeatureSet, ServiceSummary
 
@@ -63,6 +64,12 @@ class HonuaClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _validate_external_client_auth_configuration(
+            client=client,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            auth_provider=auth_provider,
+        )
 
         self._owns_client = client is None
         if client is not None:

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -18,6 +18,7 @@ from ._http import (
     _to_http_error,
     _to_transport_error,
     _validate_auth_configuration,
+    _validate_external_client_auth_configuration,
 )
 from .auth import AuthProvider
 
@@ -65,6 +66,12 @@ class HonuaGeocodingClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _validate_external_client_auth_configuration(
+            client=client,
+            api_key=api_key,
+            bearer_token=bearer_token,
+            auth_provider=auth_provider,
+        )
 
         self._locator_name = locator_name
         self._owns_client = client is None

--- a/packages/honua-sdk/honua_sdk/geopandas.py
+++ b/packages/honua-sdk/honua_sdk/geopandas.py
@@ -7,10 +7,12 @@ This module requires the optional ``geopandas`` extra::
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Any
 
 try:
     import geopandas as gpd
+    import pandas as pd
     from shapely.geometry import (
         LinearRing,
         MultiLineString,
@@ -145,7 +147,7 @@ def _esri_geometry_to_shapely(geom: dict[str, Any] | None) -> Any:
         return MultiPolygon(
             [
                 (ext, holes)
-                for ext, holes in zip(exteriors, holes_for)
+                for ext, holes in zip(exteriors, holes_for, strict=True)
             ]
         )
 
@@ -280,7 +282,7 @@ def geodataframe_to_features(
     features: list[dict[str, Any]] = []
     for idx in range(len(gdf)):
         row = gdf.iloc[idx]
-        attrs = {col: row[col] for col in attr_columns}
+        attrs = {col: _json_safe_value(row[col]) for col in attr_columns}
         geom_obj = row[gdf.geometry.name]
         esri_geom = _shapely_to_esri_geometry(geom_obj)
         feat: dict[str, Any] = {"attributes": attrs}
@@ -289,3 +291,27 @@ def geodataframe_to_features(
         features.append(feat)
 
     return features
+
+
+def _json_safe_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {str(key): _json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_value(item) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            pass
+    return value

--- a/packages/honua-sdk/honua_sdk/ogc.py
+++ b/packages/honua-sdk/honua_sdk/ogc.py
@@ -114,8 +114,8 @@ def _normalize_offset(offset: int | None) -> int:
 
 
 def _normalize_total_limit(limit: int | None) -> int | None:
-    if isinstance(limit, int) and limit > 0:
-        return limit
+    if isinstance(limit, int):
+        return max(0, limit)
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82"]
+select = ["E9", "F63", "F7", "F82", "B"]

--- a/scripts/_smoke_harness.py
+++ b/scripts/_smoke_harness.py
@@ -229,7 +229,7 @@ def _probe_error_context(
 
 
 def _attach_cleanup_error(main_error: Exception, cleanup_error: Exception) -> Exception:
-    setattr(main_error, "_smoke_cleanup_error", _serialize_probe_exception(cleanup_error))
+    main_error._smoke_cleanup_error = _serialize_probe_exception(cleanup_error)  # type: ignore[attr-defined]
     return main_error
 
 

--- a/scripts/validate_publish_tag.py
+++ b/scripts/validate_publish_tag.py
@@ -1,0 +1,69 @@
+"""Validate that a package publish tag matches a package version."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+import tomllib
+
+
+def normalized_tag_version(tag_name: str, prefix: str) -> str:
+    """Return the version suffix from a publish tag.
+
+    Release automation has produced both ``python-sdk-v0.0.2`` and
+    ``python-sdk-vv0.0.2`` style tags. The publish gate accepts either and
+    compares the normalized version to the package metadata.
+    """
+    if not tag_name.startswith(prefix):
+        raise ValueError(f"Tag {tag_name!r} does not start with expected prefix {prefix!r}.")
+
+    version = tag_name[len(prefix) :]
+    if version.startswith("v"):
+        version = version[1:]
+    if not version:
+        raise ValueError(f"Tag {tag_name!r} does not include a version suffix.")
+    return version
+
+
+def package_version(pyproject_path: Path) -> str:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    try:
+        version = data["project"]["version"]
+    except KeyError as exc:
+        raise ValueError(f"{pyproject_path} is missing project.version.") from exc
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"{pyproject_path} project.version must be a non-empty string.")
+    return version
+
+
+def validate_publish_tag(pyproject_path: Path, tag_name: str, prefix: str) -> None:
+    expected_version = package_version(pyproject_path)
+    actual_version = normalized_tag_version(tag_name, prefix)
+    if actual_version != expected_version:
+        raise ValueError(
+            f"Tag version ({actual_version}) does not match "
+            f"pyproject.toml version ({expected_version})."
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pyproject", type=Path, required=True, help="Path to package pyproject.toml.")
+    parser.add_argument("--tag", required=True, help="Git ref name/tag to validate.")
+    parser.add_argument("--prefix", required=True, help="Expected tag prefix, for example python-sdk-v.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        validate_publish_tag(args.pyproject, args.tag, args.prefix)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/admin/test_services.py
+++ b/tests/admin/test_services.py
@@ -295,6 +295,18 @@ def test_admin_client_auth_provider_headers_are_resolved_per_request() -> None:
     assert seen == ["admin-key-1", "admin-key-2"]
 
 
+def test_custom_http_client_rejects_sdk_auth_options() -> None:
+    client = httpx.Client(
+        base_url="http://test.honua.io",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    )
+    try:
+        with pytest.raises(ValueError, match="supplied `client`"):
+            HonuaAdminClient("http://ignored.test", client=client, api_key="test-key")
+    finally:
+        client.close()
+
+
 def test_transport_errors_are_normalized_to_honua_http_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("dial failed", request=request)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -150,6 +150,17 @@ async def test_ogc_features_items_all_paginates() -> None:
     assert seen == [("2", "0"), ("1", "2")]
 
 
+async def test_ogc_features_items_all_zero_limit_does_not_request() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("items_all(limit=0) should not issue a request")
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        features = await client.ogc_features().collection("parcels").items_all(limit=0)
+
+    assert features == []
+
+
 async def test_auth_headers_are_attached() -> None:
     seen: dict[str, str] = {}
 
@@ -190,6 +201,18 @@ async def test_auth_provider_headers_are_resolved_per_request() -> None:
         await client.list_services()
 
     assert seen == ["async-key-1", "async-key-2"]
+
+
+async def test_custom_http_client_rejects_sdk_auth_options() -> None:
+    client = httpx.AsyncClient(
+        base_url="http://example.test",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    )
+    try:
+        with pytest.raises(ValueError, match="supplied `client`"):
+            AsyncHonuaClient("http://ignored.test", client=client, api_key="test-key")
+    finally:
+        await client.aclose()
 
 
 async def test_non_success_raises_honua_http_error() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -211,6 +211,17 @@ def test_ogc_features_items_all_paginates_with_limit() -> None:
     assert seen == [("2", "0"), ("2", "2"), ("1", "4")]
 
 
+def test_ogc_features_items_all_zero_limit_does_not_request() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("items_all(limit=0) should not issue a request")
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        features = client.ogc_features().collection("parcels").items_all(limit=0)
+
+    assert features == []
+
+
 def test_ogc_features_item_crud_uses_geojson_endpoints() -> None:
     seen: list[dict[str, Any]] = []
 
@@ -352,6 +363,26 @@ def test_auth_provider_cannot_be_combined_with_static_bearer_token() -> None:
             auth_provider=auth_provider,
             transport=httpx.MockTransport(lambda request: httpx.Response(200)),
         )
+
+
+@pytest.mark.parametrize(
+    "auth_kwargs",
+    [
+        {"api_key": "test-key"},
+        {"bearer_token": "test-token"},
+        {"auth_provider": CallableAuthProvider(lambda: {"X-API-Key": "test-key"})},
+    ],
+)
+def test_custom_http_client_rejects_sdk_auth_options(auth_kwargs: dict[str, object]) -> None:
+    client = httpx.Client(
+        base_url="http://example.test",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    )
+    try:
+        with pytest.raises(ValueError, match="supplied `client`"):
+            HonuaClient("http://ignored.test", client=client, **auth_kwargs)
+    finally:
+        client.close()
 
 
 def test_non_success_raises_honua_http_error() -> None:

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -279,6 +279,18 @@ def test_auth_headers_bearer_token() -> None:
     assert seen["authorization"] == "Bearer geo-test-token"
 
 
+def test_custom_http_client_rejects_sdk_auth_options() -> None:
+    client = httpx.Client(
+        base_url="http://example.test",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+    )
+    try:
+        with pytest.raises(ValueError, match="supplied `client`"):
+            HonuaGeocodingClient("http://ignored.test", client=client, api_key="geo-test-key")
+    finally:
+        client.close()
+
+
 # ---------------------------------------------------------------------------
 # HTTP errors
 # ---------------------------------------------------------------------------

--- a/tests/test_geopandas.py
+++ b/tests/test_geopandas.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 gpd = pytest.importorskip("geopandas")
+pd = pytest.importorskip("pandas")
 shapely = pytest.importorskip("shapely")
 
 from shapely.geometry import LineString, MultiPoint, Point, Polygon
@@ -247,3 +250,22 @@ class TestRoundTrip:
         assert len(features) == 1
         assert features[0]["attributes"]["objectid"] == 1
         assert "geometry" not in features[0]
+
+    def test_geodataframe_to_features_returns_json_safe_attributes(self) -> None:
+        frame = pd.DataFrame(
+            {
+                "count": pd.Series([1], dtype="Int64"),
+                "missing": pd.Series([pd.NA], dtype="Int64"),
+                "observed_at": [pd.Timestamp("2026-04-27T12:00:00Z")],
+            }
+        )
+        gdf = gpd.GeoDataFrame(frame, geometry=[Point(0, 0)], crs="EPSG:4326")
+
+        features = geodataframe_to_features(gdf)
+
+        json.dumps(features)
+        attrs = features[0]["attributes"]
+        assert attrs["count"] == 1
+        assert type(attrs["count"]) is int
+        assert attrs["missing"] is None
+        assert attrs["observed_at"] == "2026-04-27T12:00:00+00:00"

--- a/tests/test_publish_tag_validation.py
+++ b/tests/test_publish_tag_validation.py
@@ -1,0 +1,49 @@
+"""Tests for publish tag validation helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "validate_publish_tag.py"
+SPEC = importlib.util.spec_from_file_location("validate_publish_tag", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+validate_publish_tag = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validate_publish_tag)
+
+
+@pytest.mark.parametrize(
+    "tag_name",
+    [
+        "python-sdk-v0.0.2",
+        "python-sdk-vv0.0.2",
+    ],
+)
+def test_validate_publish_tag_accepts_single_or_double_v_prefix(tag_name: str) -> None:
+    validate_publish_tag.validate_publish_tag(
+        ROOT / "packages" / "honua-sdk" / "pyproject.toml",
+        tag_name,
+        "python-sdk-v",
+    )
+
+
+def test_validate_publish_tag_rejects_version_mismatch() -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        validate_publish_tag.validate_publish_tag(
+            ROOT / "packages" / "honua-sdk" / "pyproject.toml",
+            "python-sdk-v9.9.9",
+            "python-sdk-v",
+        )
+
+
+def test_validate_publish_tag_rejects_wrong_component_prefix() -> None:
+    with pytest.raises(ValueError, match="does not start"):
+        validate_publish_tag.validate_publish_tag(
+            ROOT / "packages" / "honua-sdk" / "pyproject.toml",
+            "python-admin-v0.0.2",
+            "python-sdk-v",
+        )


### PR DESCRIPTION
## Summary

- normalize publish tag validation for both single- and double-`v` release tags before comparing package versions
- reject SDK/admin/geocoding auth options when callers provide their own HTTP client, avoiding silently ignored credentials
- make OGC `items_all(limit=0)` return without issuing a request
- serialize GeoPandas feature attributes through JSON-safe scalar/date/null conversion
- broaden Ruff CI coverage by enabling Bugbear checks and fixing the exposed findings

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests -q -p no:cacheprovider`
- `.venv/bin/ruff check .`
- `.venv/bin/python scripts/compatibility_gate.py`
- `git diff --check`
- `python -m hatch build && python -m twine check dist/*` for `packages/honua-sdk`
- `python -m hatch build && python -m twine check dist/*` for `packages/honua-admin`