### PR TITLE
[codex] Add unified feature query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,15 @@ with HonuaClient("https://your-honua-server.com") as client:
     # List available services
     services = client.list_services()
 
-    # Query features from a layer
-    result = client.query_features(
-        service_id="natural-earth",
+    # Query features through the shared feature-query API
+    result = client.query(
+        "natural-earth",
         layer_id=0,
         where="status = 'active'",
-        return_geometry=True,
-        out_fields=["*"],
+        fields=["*"],
     )
 
-    features = result.get("features", [])
+    features = result.features
     print(f"Found {len(features)} features")
 ```
 
@@ -68,52 +67,56 @@ with HonuaClient("https://your-honua-server.com") as client:
     feature = parcels.item("123")
 ```
 
-### Protocol clients
+### Shared feature query
 
 ```python
-from honua_sdk import HonuaClient, ODataQuery
+from honua_sdk import FeatureQuery, HonuaClient
 
 with HonuaClient("https://your-honua-server.com") as client:
-    capabilities = client.capabilities()
-    if capabilities.supports("stac"):
-        stac_items = client.stac().items("imagery")
-        stac_item_list = client.stac().items_all("imagery", page_size=100, limit=500)
-
-    map_png = client.ogc_maps().collection_map("parcels", bbox=[-180, -90, 180, 90])
-    tile_png = client.ogc_tiles().tile("WebMercatorQuad", "0", 0, 0, collection_id="parcels")
-    coverage = client.ogc_coverages().coverage("elevation", response_format="tiff")
-    process_list = client.ogc_processes().processes()
-    wfs_xml = client.wfs().get_feature(type_names="parcels")
-    wms_png = client.wms("basemap").map(layers="parcels", bbox=[-180, -90, 180, 90], width=512, height=512)
-    wms_response = client.wms("basemap").map_response(
-        layers="parcels",
-        bbox=[-180, -90, 180, 90],
-        width=512,
-        height=512,
-    )
-    wmts_tile = client.wmts("basemap").tile(
-        layer="parcels",
-        tile_matrix_set="WebMercatorQuad",
-        tile_matrix="0",
-        tile_row=0,
-        tile_col=0,
-    )
-    odata_features = client.odata().features_all(
+    feature_server = client.query(
+        "parcels",
         layer_id=0,
-        query=ODataQuery(select=["ObjectId", "Name"], count=True),
-        page_size=500,
+        where="status = 'active'",
+        fields=["objectid", "name", "status"],
+        limit=2000,
+    )
+
+    ogc_features = client.query(
+        "parcels",
+        protocol="ogc-features",
+        filter="status = 'active'",
+        bbox=[-180, -90, 180, 90],
+        fields=["name", "status"],
+        limit=2000,
+    )
+
+    stac_items = client.query(
+        FeatureQuery(
+            source="imagery",
+            protocol="stac",
+            filter="eo:cloud_cover < 10",
+            bbox=[-180, -90, 180, 90],
+            limit=500,
+        )
+    )
+
+    odata_features = client.query(
+        "4",
+        protocol="odata",
+        filter="Status eq 'active'",
+        fields=["ObjectId", "Name"],
         limit=2000,
     )
 ```
 
-Protocol helpers return protocol-native shapes: JSON `dict`, XML `str`, raw
-`bytes`, `BinaryResponse` metadata wrappers for WMS/WMTS payloads, or SDK
-models for geocoding and gRPC. Collection-style surfaces also expose paged
-iterators and collect-all helpers such as `iter_items()`, `query_items()`,
-`items_all()`, and `features_all()`. `client.capabilities()` and
-`client.supports("stac")` expose advertised data-plane capabilities. See
-[Protocol Examples](docs/protocol-examples.md) for every public wrapper and
-[Protocol Parity](docs/protocol-parity.md) for the Python/JS coverage map.
+`client.query()` returns a `FeatureQueryResult` with normalized `QueryFeature`
+entries: `id`, `properties`, `geometry`, `protocol`, `source`, and `raw`.
+Use `client.iter_query()` to stream normalized features without collecting the
+full result. Protocol-specific clients are still available for native payloads,
+map and tile bytes, OData metadata, WMS/WMTS `BinaryResponse` metadata, and
+advanced protocol options. See [Protocol Examples](docs/protocol-examples.md)
+for every wrapper and [Protocol Parity](docs/protocol-parity.md) for the
+Python/JS coverage map.
 
 ### Admin client
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ with HonuaClient("https://your-honua-server.com") as client:
 ### Protocol clients
 
 ```python
-from honua_sdk import HonuaClient
+from honua_sdk import HonuaClient, ODataQuery
 
 with HonuaClient("https://your-honua-server.com") as client:
     capabilities = client.capabilities()
     if capabilities.supports("stac"):
         stac_items = client.stac().items("imagery")
+        stac_item_list = client.stac().items_all("imagery", page_size=100, limit=500)
 
     map_png = client.ogc_maps().collection_map("parcels", bbox=[-180, -90, 180, 90])
     tile_png = client.ogc_tiles().tile("WebMercatorQuad", "0", 0, 0, collection_id="parcels")
@@ -84,6 +85,12 @@ with HonuaClient("https://your-honua-server.com") as client:
     process_list = client.ogc_processes().processes()
     wfs_xml = client.wfs().get_feature(type_names="parcels")
     wms_png = client.wms("basemap").map(layers="parcels", bbox=[-180, -90, 180, 90], width=512, height=512)
+    wms_response = client.wms("basemap").map_response(
+        layers="parcels",
+        bbox=[-180, -90, 180, 90],
+        width=512,
+        height=512,
+    )
     wmts_tile = client.wmts("basemap").tile(
         layer="parcels",
         tile_matrix_set="WebMercatorQuad",
@@ -91,11 +98,19 @@ with HonuaClient("https://your-honua-server.com") as client:
         tile_row=0,
         tile_col=0,
     )
-    odata_features = client.odata().features(layer_id=0)
+    odata_features = client.odata().features_all(
+        layer_id=0,
+        query=ODataQuery(select=["ObjectId", "Name"], count=True),
+        page_size=500,
+        limit=2000,
+    )
 ```
 
 Protocol helpers return protocol-native shapes: JSON `dict`, XML `str`, raw
-`bytes`, or SDK models for geocoding and gRPC. `client.capabilities()` and
+`bytes`, `BinaryResponse` metadata wrappers for WMS/WMTS payloads, or SDK
+models for geocoding and gRPC. Collection-style surfaces also expose paged
+iterators and collect-all helpers such as `iter_items()`, `query_items()`,
+`items_all()`, and `features_all()`. `client.capabilities()` and
 `client.supports("stac")` expose advertised data-plane capabilities. See
 [Protocol Examples](docs/protocol-examples.md) for every public wrapper and
 [Protocol Parity](docs/protocol-parity.md) for the Python/JS coverage map.

--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -1761,6 +1761,8 @@
         "EditOperationResult",
         "Feature",
         "FeatureId",
+        "FeatureQuery",
+        "FeatureQueryResult",
         "FeatureSet",
         "GeoServicesFeatureServerClient",
         "GeoServicesGeometryServerClient",
@@ -1786,6 +1788,8 @@
         "OgcMapsClient",
         "OgcProcessesClient",
         "OgcTilesClient",
+        "QueryFeature",
+        "QueryProtocol",
         "RefreshableBearerTokenProvider",
         "ReverseGeocodeResult",
         "ServiceSummary",
@@ -2041,6 +2045,10 @@
               "kind": "method",
               "signature": "(self, service_id: 'str | None' = None) -> \"'AsyncGeoServicesImageServerClient'\""
             },
+            "iter_query": {
+              "kind": "method",
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None) -> 'AsyncIterator[QueryFeature]'"
+            },
             "list_service_summaries": {
               "async": true,
               "kind": "method",
@@ -2078,6 +2086,11 @@
             "ogc_tiles": {
               "kind": "method",
               "signature": "(self) -> \"'AsyncOgcTilesClient'\""
+            },
+            "query": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None) -> 'FeatureQueryResult'"
             },
             "query_feature_set": {
               "async": true,
@@ -2960,6 +2973,97 @@
           "type": "UnionType",
           "value": "str | int"
         },
+        "FeatureQuery": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "source"
+            },
+            {
+              "annotation": "QueryProtocol",
+              "default": "'feature-server'",
+              "name": "protocol"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "layer_id"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "where"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "filter"
+            },
+            {
+              "annotation": "str | Sequence[int | float] | None",
+              "default": "None",
+              "name": "bbox"
+            },
+            {
+              "annotation": "str | Sequence[str] | None",
+              "default": "None",
+              "name": "fields"
+            },
+            {
+              "annotation": "bool",
+              "default": "True",
+              "name": "return_geometry"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "page_size"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "limit"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "max_pages"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "extra_params"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.models",
+          "qualname": "FeatureQuery",
+          "signature": "(source: 'str', protocol: 'QueryProtocol' = 'feature-server', layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool' = True, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "FeatureQueryResult": {
+          "fields": [
+            {
+              "annotation": "tuple[QueryFeature, ...]",
+              "name": "features"
+            },
+            {
+              "annotation": "str",
+              "name": "protocol"
+            },
+            {
+              "annotation": "str",
+              "name": "source"
+            },
+            {
+              "annotation": "FeatureQuery",
+              "name": "query"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.models",
+          "qualname": "FeatureQueryResult",
+          "signature": "(features: 'tuple[QueryFeature, ...]', protocol: 'str', source: 'str', query: 'FeatureQuery') -> None"
+        },
         "FeatureSet": {
           "fields": [
             {
@@ -3227,6 +3331,10 @@
               "kind": "method",
               "signature": "(self, service_id: 'str | None' = None) -> \"'GeoServicesImageServerClient'\""
             },
+            "iter_query": {
+              "kind": "method",
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None) -> 'Iterator[QueryFeature]'"
+            },
             "list_service_summaries": {
               "kind": "method",
               "signature": "(self, *, response_format: 'str' = 'json') -> 'list[ServiceSummary]'"
@@ -3262,6 +3370,10 @@
             "ogc_tiles": {
               "kind": "method",
               "signature": "(self) -> \"'OgcTilesClient'\""
+            },
+            "query": {
+              "kind": "method",
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None) -> 'FeatureQueryResult'"
             },
             "query_feature_set": {
               "kind": "method",
@@ -3754,6 +3866,47 @@
           "module": "honua_sdk.protocols",
           "qualname": "OgcTilesClient",
           "signature": "(client: 'Any') -> 'None'"
+        },
+        "QueryFeature": {
+          "fields": [
+            {
+              "annotation": "str | int | None",
+              "name": "id"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "name": "properties"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "geometry"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "protocol"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "source"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.models",
+          "qualname": "QueryFeature",
+          "signature": "(id: 'str | int | None', properties: 'Mapping[str, Any]', geometry: 'Mapping[str, Any] | None' = None, protocol: 'str' = '', source: 'str' = '', raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "QueryProtocol": {
+          "kind": "constant",
+          "type": "_UnionGenericAlias",
+          "value": "typing.Union[typing.Literal['feature-server', 'featureserver', 'ogc-features', 'ogc_features', 'stac', 'odata'], str]"
         },
         "RefreshableBearerTokenProvider": {
           "kind": "class",

--- a/docs/core-client.md
+++ b/docs/core-client.md
@@ -49,6 +49,57 @@ and GeoServices catalog discovery.
 
 ## FeatureServer Queries
 
+For application code that wants the same shape across data protocols, prefer
+the shared feature query API. `query()` collects normalized `QueryFeature`
+entries from FeatureServer, OGC API Features, STAC, or OData; `iter_query()`
+streams the same normalized features:
+
+```python
+from honua_sdk import FeatureQuery, HonuaClient
+
+with HonuaClient("https://honua.example") as client:
+    feature_server = client.query(
+        "parcels",
+        layer_id=0,
+        where="status = 'active'",
+        fields=["objectid", "name", "status"],
+        limit=2000,
+    )
+
+    ogc_features = client.query(
+        "parcels",
+        protocol="ogc-features",
+        filter="status = 'active'",
+        bbox=[-180, -90, 180, 90],
+        fields=["name", "status"],
+        limit=2000,
+    )
+
+    stac_items = client.query(
+        FeatureQuery(
+            source="imagery",
+            protocol="stac",
+            filter="eo:cloud_cover < 10",
+            bbox=[-180, -90, 180, 90],
+            limit=500,
+        )
+    )
+
+    odata_features = client.query(
+        "4",
+        protocol="odata",
+        filter="Status eq 'active'",
+        fields=["ObjectId", "Name"],
+        limit=2000,
+    )
+
+    for feature in feature_server.features:
+        print(feature.id, feature.properties, feature.geometry)
+```
+
+Use the protocol-specific clients below when you need exact native payloads,
+server-specific query options, or endpoint metadata.
+
 `query_features()` returns the raw FeatureServer response. `query_feature_set()`
 wraps the same response in a `FeatureSet` with typed `Feature` entries:
 

--- a/docs/protocol-examples.md
+++ b/docs/protocol-examples.md
@@ -22,6 +22,13 @@ HTTP protocol wrappers, geocoding, and gRPC also have async clients. Async HTTP
 wrappers use the same factory and method names; await methods that issue
 requests.
 
+For application code that wants one feature-query shape across data protocols,
+use `HonuaClient.query()` or `HonuaClient.iter_query()` first. Those helpers
+normalize FeatureServer, OGC API Features, STAC, and OData results into
+`QueryFeature` entries. The protocol wrappers below remain the escape hatch for
+native payloads, exact protocol options, maps, tiles, XML metadata, and response
+headers.
+
 The snippets use these placeholders:
 
 ```python

--- a/docs/protocol-parity.md
+++ b/docs/protocol-parity.md
@@ -5,6 +5,7 @@ protocol adapters.
 
 | Surface | Python SDK | JS SDK parity | Notes |
 | --- | --- | --- | --- |
+| Shared feature query | `client.query(...)`, `client.iter_query(...)` | Python-specific | Normalized `QueryFeature` output spans FeatureServer, OGC API Features, STAC, and OData. |
 | GeoServices FeatureServer | `client.feature_server(id)`, `query_features`, `apply_edits` | Partial | Read/query/edit, metadata, typed query pages, and item iterators are available. |
 | GeoServices MapServer | `client.map_server(id)`, `export_map` | Partial | Metadata, export, identify, and tile helpers are available. |
 | GeoServices ImageServer | `client.image_server(id)` | New in Python | Metadata, exportImage, identify, query, tile, and legend helpers are available. |
@@ -21,13 +22,14 @@ protocol adapters.
 | WMTS | `client.wmts(service_id)` | New in Python | Service-scoped capabilities, tile, and binary metadata helpers are available. |
 | OData v4 | `client.odata()` | New in Python | Service document, metadata, query helpers, layers, layer features, paged iterators, and feature helpers are available. |
 
-The Python clients intentionally keep protocol-native JSON, XML text, and bytes
-as the default return shapes. Additive helpers provide typed FeatureServer pages,
-`ODataQuery` parameter grouping, and `BinaryResponse` metadata for WMS/WMTS
-payloads without forcing heavy local models. That keeps parity focused on
-endpoint coverage, auth, retries, timeouts, and normalized errors while
-preserving standard payloads for GeoPandas, PySTAC, GDAL/OGR, and analyst
-workflows.
+The Python SDK offers a shared query API for application code that wants one
+feature shape across queryable data protocols. The lower-level protocol clients
+intentionally keep protocol-native JSON, XML text, and bytes as their default
+return shapes. Additive helpers provide typed FeatureServer pages, `ODataQuery`
+parameter grouping, and `BinaryResponse` metadata for WMS/WMTS payloads without
+forcing heavy local models. That keeps parity focused on endpoint coverage,
+auth, retries, timeouts, and normalized errors while preserving standard
+payloads for GeoPandas, PySTAC, GDAL/OGR, and analyst workflows.
 
 Sync and async HTTP clients expose the same protocol factory names. The
 compatibility gate snapshots those factories and fails on unallowlisted drift.

--- a/packages/honua-sdk/README.md
+++ b/packages/honua-sdk/README.md
@@ -27,7 +27,7 @@ Requires Python 3.11+.
 from honua_sdk import HonuaClient
 
 with HonuaClient("https://your-honua-server.com") as client:
-    result = client.query_feature_set("natural-earth", layer_id=0)
+    result = client.query("natural-earth", layer_id=0)
     print(f"Found {len(result.features)} features")
 ```
 
@@ -54,50 +54,50 @@ with HonuaClient("https://your-honua-server.com") as client:
     feature = parcels.item("123")
 ```
 
-## Protocol Clients
+## Shared Feature Query
 
 ```python
-from honua_sdk import HonuaClient, ODataQuery
+from honua_sdk import FeatureQuery, HonuaClient
 
 with HonuaClient("https://your-honua-server.com") as client:
-    capabilities = client.capabilities()
-    if capabilities.supports("stac"):
-        stac_items = client.stac().items("imagery")
-        stac_item_list = client.stac().items_all("imagery", page_size=100, limit=500)
-
-    image = client.ogc_maps().collection_map("parcels", bbox=[-180, -90, 180, 90])
-    tile = client.ogc_tiles().tile("WebMercatorQuad", "0", 0, 0, collection_id="parcels")
-    coverage = client.ogc_coverages().coverage("elevation", response_format="tiff")
-    processes = client.ogc_processes().processes()
-    wfs_xml = client.wfs().get_feature(type_names="parcels")
-    wms_capabilities = client.wms("basemap").capabilities()
-    wms_response = client.wms("basemap").map_response(
-        layers="parcels",
-        bbox=[-180, -90, 180, 90],
-        width=512,
-        height=512,
-    )
-    wmts_tile = client.wmts("basemap").tile(
-        layer="parcels",
-        tile_matrix_set="WebMercatorQuad",
-        tile_matrix="0",
-        tile_row=0,
-        tile_col=0,
-    )
-    odata_features = client.odata().features_all(
+    feature_server = client.query(
+        "parcels",
         layer_id=0,
-        query=ODataQuery(select=["ObjectId", "Name"], count=True),
-        page_size=500,
+        where="status = 'active'",
+        fields=["objectid", "name", "status"],
+        limit=2000,
+    )
+    ogc_features = client.query(
+        "parcels",
+        protocol="ogc-features",
+        filter="status = 'active'",
+        bbox=[-180, -90, 180, 90],
+        fields=["name", "status"],
+        limit=2000,
+    )
+    stac_items = client.query(
+        FeatureQuery(
+            source="imagery",
+            protocol="stac",
+            filter="eo:cloud_cover < 10",
+            bbox=[-180, -90, 180, 90],
+            limit=500,
+        )
+    )
+    odata_features = client.query(
+        "4",
+        protocol="odata",
+        filter="Status eq 'active'",
+        fields=["ObjectId", "Name"],
         limit=2000,
     )
 ```
 
-Protocol helpers return protocol-native JSON `dict`, XML `str`, raw `bytes`,
-`BinaryResponse` metadata wrappers for WMS/WMTS payloads, or SDK models for
-geocoding and gRPC. Collection-style surfaces also expose paged iterators and
-collect-all helpers such as `iter_items()`, `query_items()`, `items_all()`, and
-`features_all()`. `client.capabilities()` and `client.supports("stac")` expose
-advertised data-plane capabilities.
+`client.query()` returns normalized `QueryFeature` entries across FeatureServer,
+OGC API Features, STAC, and OData. Use `client.iter_query()` to stream features
+without collecting the full result. Protocol-specific clients remain available
+for native payloads, maps, tiles, WMS/WMTS metadata, OData metadata, geocoding,
+and gRPC.
 
 ## Documentation
 

--- a/packages/honua-sdk/README.md
+++ b/packages/honua-sdk/README.md
@@ -57,12 +57,13 @@ with HonuaClient("https://your-honua-server.com") as client:
 ## Protocol Clients
 
 ```python
-from honua_sdk import HonuaClient
+from honua_sdk import HonuaClient, ODataQuery
 
 with HonuaClient("https://your-honua-server.com") as client:
     capabilities = client.capabilities()
     if capabilities.supports("stac"):
         stac_items = client.stac().items("imagery")
+        stac_item_list = client.stac().items_all("imagery", page_size=100, limit=500)
 
     image = client.ogc_maps().collection_map("parcels", bbox=[-180, -90, 180, 90])
     tile = client.ogc_tiles().tile("WebMercatorQuad", "0", 0, 0, collection_id="parcels")
@@ -70,6 +71,12 @@ with HonuaClient("https://your-honua-server.com") as client:
     processes = client.ogc_processes().processes()
     wfs_xml = client.wfs().get_feature(type_names="parcels")
     wms_capabilities = client.wms("basemap").capabilities()
+    wms_response = client.wms("basemap").map_response(
+        layers="parcels",
+        bbox=[-180, -90, 180, 90],
+        width=512,
+        height=512,
+    )
     wmts_tile = client.wmts("basemap").tile(
         layer="parcels",
         tile_matrix_set="WebMercatorQuad",
@@ -77,12 +84,20 @@ with HonuaClient("https://your-honua-server.com") as client:
         tile_row=0,
         tile_col=0,
     )
-    odata_features = client.odata().features(layer_id=0)
+    odata_features = client.odata().features_all(
+        layer_id=0,
+        query=ODataQuery(select=["ObjectId", "Name"], count=True),
+        page_size=500,
+        limit=2000,
+    )
 ```
 
 Protocol helpers return protocol-native JSON `dict`, XML `str`, raw `bytes`,
-or SDK models for geocoding and gRPC. `client.capabilities()` and
-`client.supports("stac")` expose advertised data-plane capabilities.
+`BinaryResponse` metadata wrappers for WMS/WMTS payloads, or SDK models for
+geocoding and gRPC. Collection-style surfaces also expose paged iterators and
+collect-all helpers such as `iter_items()`, `query_items()`, `items_all()`, and
+`features_all()`. `client.capabilities()` and `client.supports("stac")` expose
+advertised data-plane capabilities.
 
 ## Documentation
 

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -35,7 +35,18 @@ from .geocoding import (
     HonuaGeocodingClient,
     ReverseGeocodeResult,
 )
-from .models import ApplyEditsResult, DataPlaneCapabilities, EditOperationResult, Feature, FeatureSet, ServiceSummary
+from .models import (
+    ApplyEditsResult,
+    DataPlaneCapabilities,
+    EditOperationResult,
+    Feature,
+    FeatureQuery,
+    FeatureQueryResult,
+    FeatureSet,
+    QueryFeature,
+    QueryProtocol,
+    ServiceSummary,
+)
 from .ogc import (
     AsyncHonuaOgcFeatureCollection,
     AsyncHonuaOgcFeatures,
@@ -112,6 +123,8 @@ __all__ = [
     "DataPlaneCapabilities",
     "EditOperationResult",
     "Feature",
+    "FeatureQuery",
+    "FeatureQueryResult",
     "FeatureId",
     "FeatureSet",
     "GeocodeResult",
@@ -138,6 +151,8 @@ __all__ = [
     "OgcMapsClient",
     "OgcProcessesClient",
     "OgcTilesClient",
+    "QueryFeature",
+    "QueryProtocol",
     "RefreshableBearerTokenProvider",
     "ReverseGeocodeResult",
     "ServiceSummary",

--- a/packages/honua-sdk/honua_sdk/_query.py
+++ b/packages/honua-sdk/honua_sdk/_query.py
@@ -1,0 +1,213 @@
+"""Shared feature query helpers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import Any
+
+from .models import Feature, FeatureQuery, QueryFeature, QueryProtocol
+
+
+def resolve_feature_query(
+    source: str | FeatureQuery,
+    *,
+    protocol: QueryProtocol | None = None,
+    layer_id: int | None = None,
+    where: str | None = None,
+    filter: str | None = None,
+    bbox: str | Sequence[int | float] | None = None,
+    fields: str | Sequence[str] | None = None,
+    return_geometry: bool | None = None,
+    page_size: int | None = None,
+    limit: int | None = None,
+    max_pages: int | None = None,
+    extra_params: Mapping[str, Any] | None = None,
+) -> FeatureQuery:
+    if isinstance(source, FeatureQuery):
+        merged_extra_params = dict(source.extra_params)
+        if extra_params:
+            merged_extra_params.update(extra_params)
+        return replace(
+            source,
+            protocol=protocol if protocol is not None else source.protocol,
+            layer_id=layer_id if layer_id is not None else source.layer_id,
+            where=where if where is not None else source.where,
+            filter=filter if filter is not None else source.filter,
+            bbox=bbox if bbox is not None else source.bbox,
+            fields=fields if fields is not None else source.fields,
+            return_geometry=return_geometry if return_geometry is not None else source.return_geometry,
+            page_size=page_size if page_size is not None else source.page_size,
+            limit=limit if limit is not None else source.limit,
+            max_pages=max_pages if max_pages is not None else source.max_pages,
+            extra_params=merged_extra_params,
+        )
+
+    effective_protocol = protocol or "feature-server"
+    effective_layer_id = layer_id
+    if effective_layer_id is None and normalize_query_protocol(effective_protocol) == "feature-server":
+        effective_layer_id = 0
+
+    return FeatureQuery(
+        source=str(source),
+        protocol=effective_protocol,
+        layer_id=effective_layer_id,
+        where=where,
+        filter=filter,
+        bbox=bbox,
+        fields=fields,
+        return_geometry=True if return_geometry is None else return_geometry,
+        page_size=page_size,
+        limit=limit,
+        max_pages=max_pages,
+        extra_params=dict(extra_params or {}),
+    )
+
+
+def normalize_query_protocol(value: QueryProtocol) -> str:
+    normalized = str(value).strip().lower().replace("_", "-")
+    aliases = {
+        "featureserver": "feature-server",
+        "feature-service": "feature-server",
+        "feature-server": "feature-server",
+        "ogc-api-features": "ogc-features",
+        "ogc-features": "ogc-features",
+        "stac": "stac",
+        "odata": "odata",
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        raise ValueError(
+            "Unsupported query protocol. Expected one of: feature-server, ogc-features, stac, odata."
+        ) from exc
+
+
+def field_list(value: str | Sequence[str] | None, *, wildcard: str | None = None) -> str | list[str] | None:
+    if value is None:
+        return wildcard
+    if isinstance(value, str):
+        if value == "*" and wildcard is None:
+            return None
+        return value
+    values = [str(item) for item in value]
+    if values == ["*"] and wildcard is None:
+        return None
+    return values
+
+
+def field_text(value: str | Sequence[str] | None, *, wildcard: str | None = None) -> str | None:
+    fields = field_list(value, wildcard=wildcard)
+    if fields is None:
+        return None
+    if isinstance(fields, str):
+        return fields
+    return ",".join(fields)
+
+
+def bbox_text(value: str | Sequence[int | float] | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return ",".join(str(item) for item in value)
+
+
+def feature_server_extra_params(query: FeatureQuery) -> dict[str, Any]:
+    params = dict(query.extra_params)
+    if query.bbox is not None:
+        bbox = _bbox_values(query.bbox)
+        params.setdefault(
+            "geometry",
+            json.dumps(
+                {
+                    "xmin": bbox[0],
+                    "ymin": bbox[1],
+                    "xmax": bbox[2],
+                    "ymax": bbox[3],
+                    "spatialReference": {"wkid": 4326},
+                },
+                separators=(",", ":"),
+            ),
+        )
+        params.setdefault("geometryType", "esriGeometryEnvelope")
+        params.setdefault("spatialRel", "esriSpatialRelIntersects")
+        params.setdefault("inSR", 4326)
+    return params
+
+
+def odata_layer_id(query: FeatureQuery) -> int | None:
+    if query.layer_id is not None:
+        return query.layer_id
+    try:
+        return int(query.source)
+    except ValueError:
+        return None
+
+
+def query_filter(query: FeatureQuery) -> str | None:
+    return query.filter if query.filter is not None else query.where
+
+
+def query_page_size(query: FeatureQuery, default: int) -> int:
+    return default if query.page_size is None else query.page_size
+
+
+def query_max_pages(query: FeatureQuery, default: int) -> int:
+    return default if query.max_pages is None else query.max_pages
+
+
+def query_feature_from_feature_server(feature: Feature, *, source: str, protocol: str) -> QueryFeature:
+    return QueryFeature(
+        id=feature.object_id,
+        properties=dict(feature.attributes),
+        geometry=dict(feature.geometry) if feature.geometry is not None else None,
+        protocol=protocol,
+        source=source,
+        raw=dict(feature.raw),
+    )
+
+
+def query_feature_from_geojson(feature: Mapping[str, Any], *, source: str, protocol: str) -> QueryFeature:
+    properties = feature.get("properties")
+    geometry = feature.get("geometry")
+    return QueryFeature(
+        id=_first_present(feature, "id", "ID", "objectid", "objectId", "ObjectId"),
+        properties=dict(properties) if isinstance(properties, Mapping) else {},
+        geometry=dict(geometry) if isinstance(geometry, Mapping) else None,
+        protocol=protocol,
+        source=source,
+        raw=dict(feature),
+    )
+
+
+def query_feature_from_mapping(feature: Mapping[str, Any], *, source: str, protocol: str) -> QueryFeature:
+    properties = dict(feature)
+    geometry = _first_present(feature, "geometry", "Geometry", "shape", "Shape")
+    for key in ("geometry", "Geometry", "shape", "Shape"):
+        properties.pop(key, None)
+    return QueryFeature(
+        id=_first_present(feature, "id", "ID", "objectid", "objectId", "ObjectId"),
+        properties=properties,
+        geometry=dict(geometry) if isinstance(geometry, Mapping) else None,
+        protocol=protocol,
+        source=source,
+        raw=dict(feature),
+    )
+
+
+def _bbox_values(value: str | Sequence[int | float]) -> tuple[float, float, float, float]:
+    parts = value.split(",") if isinstance(value, str) else list(value)
+    if len(parts) != 4:
+        raise ValueError("bbox must contain exactly four values: minx, miny, maxx, maxy.")
+    minx, miny, maxx, maxy = (float(part) for part in parts)
+    return minx, miny, maxx, maxy
+
+
+def _first_present(payload: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = payload.get(key)
+        if value is not None:
+            return value
+    return None

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ._async_retry import AsyncRetryTransport
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -19,8 +18,34 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
 )
+from ._async_retry import AsyncRetryTransport
+from ._query import (
+    bbox_text,
+    feature_server_extra_params,
+    field_list,
+    field_text,
+    normalize_query_protocol,
+    odata_layer_id,
+    query_feature_from_feature_server,
+    query_feature_from_geojson,
+    query_feature_from_mapping,
+    query_filter,
+    query_max_pages,
+    query_page_size,
+    resolve_feature_query,
+)
 from .errors import HonuaHttpError
-from .models import ApplyEditsResult, DataPlaneCapabilities, Feature, FeatureSet, ServiceSummary
+from .models import (
+    ApplyEditsResult,
+    DataPlaneCapabilities,
+    Feature,
+    FeatureQuery,
+    FeatureQueryResult,
+    FeatureSet,
+    QueryFeature,
+    QueryProtocol,
+    ServiceSummary,
+)
 
 if TYPE_CHECKING:
     from .auth import AuthProvider
@@ -240,6 +265,155 @@ class AsyncHonuaClient:
         from .protocols import AsyncODataClient
 
         return AsyncODataClient(self)
+
+    async def query(
+        self,
+        source: str | FeatureQuery,
+        *,
+        protocol: QueryProtocol | None = None,
+        layer_id: int | None = None,
+        where: str | None = None,
+        filter: str | None = None,
+        bbox: str | Sequence[int | float] | None = None,
+        fields: str | Sequence[str] | None = None,
+        return_geometry: bool | None = None,
+        page_size: int | None = None,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> FeatureQueryResult:
+        """Run a protocol-neutral feature query and collect normalized features."""
+        query = resolve_feature_query(
+            source,
+            protocol=protocol,
+            layer_id=layer_id,
+            where=where,
+            filter=filter,
+            bbox=bbox,
+            fields=fields,
+            return_geometry=return_geometry,
+            page_size=page_size,
+            limit=limit,
+            max_pages=max_pages,
+            extra_params=extra_params,
+        )
+        normalized_protocol = normalize_query_protocol(query.protocol)
+        return FeatureQueryResult(
+            features=tuple([feature async for feature in self.iter_query(query)]),
+            protocol=normalized_protocol,
+            source=query.source,
+            query=query,
+        )
+
+    async def iter_query(
+        self,
+        source: str | FeatureQuery,
+        *,
+        protocol: QueryProtocol | None = None,
+        layer_id: int | None = None,
+        where: str | None = None,
+        filter: str | None = None,
+        bbox: str | Sequence[int | float] | None = None,
+        fields: str | Sequence[str] | None = None,
+        return_geometry: bool | None = None,
+        page_size: int | None = None,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> AsyncIterator[QueryFeature]:
+        """Stream normalized features from FeatureServer, OGC Features, STAC, or OData."""
+        query = resolve_feature_query(
+            source,
+            protocol=protocol,
+            layer_id=layer_id,
+            where=where,
+            filter=filter,
+            bbox=bbox,
+            fields=fields,
+            return_geometry=return_geometry,
+            page_size=page_size,
+            limit=limit,
+            max_pages=max_pages,
+            extra_params=extra_params,
+        )
+        normalized_protocol = normalize_query_protocol(query.protocol)
+
+        if normalized_protocol == "feature-server":
+            feature_server_layer_id = 0 if query.layer_id is None else query.layer_id
+            where_text = query.where if query.where is not None else (query.filter or "1=1")
+            async for feature in self.feature_server(query.source).query_items(
+                feature_server_layer_id,
+                where=where_text,
+                out_fields=field_text(query.fields, wildcard="*") or "*",
+                return_geometry=query.return_geometry,
+                page_size=query_page_size(query, 1000),
+                limit=query.limit,
+                max_pages=query_max_pages(query, 100),
+                extra_params=feature_server_extra_params(query),
+            ):
+                yield query_feature_from_feature_server(
+                    feature,
+                    source=query.source,
+                    protocol=normalized_protocol,
+                )
+            return
+
+        if normalized_protocol == "ogc-features":
+            properties = field_list(query.fields)
+            async for feature in self.ogc_features().collection(query.source).iter_items(
+                filter=query_filter(query),
+                bbox=query.bbox,
+                properties=properties,
+                page_size=query.page_size,
+                limit=query.limit,
+                max_pages=query.max_pages,
+                extra_params=query.extra_params,
+            ):
+                yield query_feature_from_geojson(
+                    feature,
+                    source=query.source,
+                    protocol=normalized_protocol,
+                )
+            return
+
+        if normalized_protocol == "stac":
+            params = dict(query.extra_params)
+            if query.bbox is not None:
+                params.setdefault("bbox", bbox_text(query.bbox))
+            if query_filter(query) is not None:
+                params.setdefault("filter", query_filter(query))
+            if field_text(query.fields) is not None:
+                params.setdefault("fields", field_text(query.fields))
+            async for feature in self.stac().iter_items(
+                query.source,
+                extra_params=params,
+                page_size=query.page_size,
+                limit=query.limit,
+                max_pages=query.max_pages,
+            ):
+                yield query_feature_from_geojson(
+                    feature,
+                    source=query.source,
+                    protocol=normalized_protocol,
+                )
+            return
+
+        if query.bbox is not None:
+            raise ValueError("bbox is not supported for OData shared queries; express spatial filters in `filter`.")
+        async for feature in self.odata().iter_features(
+            layer_id=odata_layer_id(query),
+            filter=query_filter(query),
+            select=field_list(query.fields),
+            page_size=query.page_size,
+            limit=query.limit,
+            max_pages=query.max_pages,
+            extra_params=query.extra_params,
+        ):
+            yield query_feature_from_mapping(
+                feature,
+                source=query.source,
+                protocol=normalized_protocol,
+            )
 
     async def query_features(
         self,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ._retry import RetryTransport
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -19,8 +18,34 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
 )
+from ._query import (
+    bbox_text,
+    feature_server_extra_params,
+    field_list,
+    field_text,
+    normalize_query_protocol,
+    odata_layer_id,
+    query_feature_from_feature_server,
+    query_feature_from_geojson,
+    query_feature_from_mapping,
+    query_filter,
+    query_max_pages,
+    query_page_size,
+    resolve_feature_query,
+)
+from ._retry import RetryTransport
 from .errors import HonuaHttpError
-from .models import ApplyEditsResult, DataPlaneCapabilities, Feature, FeatureSet, ServiceSummary
+from .models import (
+    ApplyEditsResult,
+    DataPlaneCapabilities,
+    Feature,
+    FeatureQuery,
+    FeatureQueryResult,
+    FeatureSet,
+    QueryFeature,
+    QueryProtocol,
+    ServiceSummary,
+)
 
 if TYPE_CHECKING:
     from .auth import AuthProvider
@@ -240,6 +265,155 @@ class HonuaClient:
         from .protocols import ODataClient
 
         return ODataClient(self)
+
+    def query(
+        self,
+        source: str | FeatureQuery,
+        *,
+        protocol: QueryProtocol | None = None,
+        layer_id: int | None = None,
+        where: str | None = None,
+        filter: str | None = None,
+        bbox: str | Sequence[int | float] | None = None,
+        fields: str | Sequence[str] | None = None,
+        return_geometry: bool | None = None,
+        page_size: int | None = None,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> FeatureQueryResult:
+        """Run a protocol-neutral feature query and collect normalized features."""
+        query = resolve_feature_query(
+            source,
+            protocol=protocol,
+            layer_id=layer_id,
+            where=where,
+            filter=filter,
+            bbox=bbox,
+            fields=fields,
+            return_geometry=return_geometry,
+            page_size=page_size,
+            limit=limit,
+            max_pages=max_pages,
+            extra_params=extra_params,
+        )
+        normalized_protocol = normalize_query_protocol(query.protocol)
+        return FeatureQueryResult(
+            features=tuple(self.iter_query(query)),
+            protocol=normalized_protocol,
+            source=query.source,
+            query=query,
+        )
+
+    def iter_query(
+        self,
+        source: str | FeatureQuery,
+        *,
+        protocol: QueryProtocol | None = None,
+        layer_id: int | None = None,
+        where: str | None = None,
+        filter: str | None = None,
+        bbox: str | Sequence[int | float] | None = None,
+        fields: str | Sequence[str] | None = None,
+        return_geometry: bool | None = None,
+        page_size: int | None = None,
+        limit: int | None = None,
+        max_pages: int | None = None,
+        extra_params: Mapping[str, Any] | None = None,
+    ) -> Iterator[QueryFeature]:
+        """Stream normalized features from FeatureServer, OGC Features, STAC, or OData."""
+        query = resolve_feature_query(
+            source,
+            protocol=protocol,
+            layer_id=layer_id,
+            where=where,
+            filter=filter,
+            bbox=bbox,
+            fields=fields,
+            return_geometry=return_geometry,
+            page_size=page_size,
+            limit=limit,
+            max_pages=max_pages,
+            extra_params=extra_params,
+        )
+        normalized_protocol = normalize_query_protocol(query.protocol)
+
+        if normalized_protocol == "feature-server":
+            feature_server_layer_id = 0 if query.layer_id is None else query.layer_id
+            where_text = query.where if query.where is not None else (query.filter or "1=1")
+            for feature in self.feature_server(query.source).query_items(
+                feature_server_layer_id,
+                where=where_text,
+                out_fields=field_text(query.fields, wildcard="*") or "*",
+                return_geometry=query.return_geometry,
+                page_size=query_page_size(query, 1000),
+                limit=query.limit,
+                max_pages=query_max_pages(query, 100),
+                extra_params=feature_server_extra_params(query),
+            ):
+                yield query_feature_from_feature_server(
+                    feature,
+                    source=query.source,
+                    protocol=normalized_protocol,
+                )
+            return
+
+        if normalized_protocol == "ogc-features":
+            properties = field_list(query.fields)
+            for feature in self.ogc_features().collection(query.source).iter_items(
+                filter=query_filter(query),
+                bbox=query.bbox,
+                properties=properties,
+                page_size=query.page_size,
+                limit=query.limit,
+                max_pages=query.max_pages,
+                extra_params=query.extra_params,
+            ):
+                yield query_feature_from_geojson(
+                    feature,
+                    source=query.source,
+                    protocol=normalized_protocol,
+                )
+            return
+
+        if normalized_protocol == "stac":
+            params = dict(query.extra_params)
+            if query.bbox is not None:
+                params.setdefault("bbox", bbox_text(query.bbox))
+            if query_filter(query) is not None:
+                params.setdefault("filter", query_filter(query))
+            if field_text(query.fields) is not None:
+                params.setdefault("fields", field_text(query.fields))
+            for feature in self.stac().iter_items(
+                query.source,
+                extra_params=params,
+                page_size=query.page_size,
+                limit=query.limit,
+                max_pages=query.max_pages,
+            ):
+                yield query_feature_from_geojson(
+                    feature,
+                    source=query.source,
+                    protocol=normalized_protocol,
+                )
+            return
+
+        if query.bbox is not None:
+            raise ValueError("bbox is not supported for OData shared queries; express spatial filters in `filter`.")
+        for feature in self.odata().iter_features(
+            layer_id=odata_layer_id(query),
+            filter=query_filter(query),
+            select=field_list(query.fields),
+            page_size=query.page_size,
+            limit=query.limit,
+            max_pages=query.max_pages,
+            extra_params=query.extra_params,
+        ):
+            yield query_feature_from_mapping(
+                feature,
+                source=query.source,
+                protocol=normalized_protocol,
+            )
 
     def query_features(
         self,

--- a/packages/honua-sdk/honua_sdk/models.py
+++ b/packages/honua-sdk/honua_sdk/models.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal, TypeAlias
+
+QueryProtocol: TypeAlias = Literal["feature-server", "featureserver", "ogc-features", "ogc_features", "stac", "odata"] | str
 
 
 @dataclass(frozen=True)
@@ -141,6 +143,46 @@ class FeatureSet:
             exceeded_transfer_limit=bool(payload.get("exceededTransferLimit", False)),
             raw=dict(payload),
         )
+
+
+@dataclass(frozen=True)
+class FeatureQuery:
+    """Protocol-neutral feature query request."""
+
+    source: str
+    protocol: QueryProtocol = "feature-server"
+    layer_id: int | None = None
+    where: str | None = None
+    filter: str | None = None
+    bbox: str | Sequence[int | float] | None = None
+    fields: str | Sequence[str] | None = None
+    return_geometry: bool = True
+    page_size: int | None = None
+    limit: int | None = None
+    max_pages: int | None = None
+    extra_params: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class QueryFeature:
+    """Protocol-neutral feature returned by the shared query API."""
+
+    id: str | int | None
+    properties: Mapping[str, Any]
+    geometry: Mapping[str, Any] | None = None
+    protocol: str = ""
+    source: str = ""
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FeatureQueryResult:
+    """Collected result returned by the shared query API."""
+
+    features: tuple[QueryFeature, ...]
+    protocol: str
+    source: str
+    query: FeatureQuery
 
 
 @dataclass(frozen=True)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
-from honua_sdk import CallableAuthProvider
+from honua_sdk import CallableAuthProvider, FeatureQuery
 from honua_sdk.async_client import AsyncHonuaClient
 from honua_sdk.errors import HonuaHttpError
 
@@ -164,6 +164,117 @@ async def test_query_features_all_returns_typed_paginated_features() -> None:
 
     assert [feature.object_id for feature in features] == [1, 2, 3]
     assert seen == [("0", "2"), ("2", "1")]
+
+
+async def test_shared_query_feature_server_normalizes_common_args() -> None:
+    seen: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(dict(request.url.params.multi_items()))
+        assert request.url.path == "/rest/services/parcels/FeatureServer/0/query"
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {
+                        "attributes": {"objectid": 10, "name": "A"},
+                        "geometry": {"x": -157.8, "y": 21.3},
+                    }
+                ],
+                "exceededTransferLimit": False,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        result = await client.query(
+            FeatureQuery(
+                source="parcels",
+                where="status = 'active'",
+                fields=["objectid", "name"],
+                bbox=[-158, 21, -157, 22],
+                limit=1,
+            )
+        )
+
+    assert result.protocol == "feature-server"
+    assert len(result.features) == 1
+    feature = result.features[0]
+    assert feature.id == 10
+    assert feature.properties == {"objectid": 10, "name": "A"}
+    assert feature.geometry == {"x": -157.8, "y": 21.3}
+    assert seen["where"] == "status = 'active'"
+    assert seen["outFields"] == "objectid,name"
+    assert seen["resultRecordCount"] == "1"
+    assert seen["geometryType"] == "esriGeometryEnvelope"
+
+
+async def test_shared_query_routes_async_ogc_and_odata() -> None:
+    seen: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raw_path = request.url.raw_path.decode("ascii").split("?")[0]
+        query = dict(request.url.params.multi_items())
+        seen.append({"path": raw_path, "query": query})
+        if raw_path == "/ogc/features/collections/parcels/items":
+            return httpx.Response(
+                200,
+                json={
+                    "type": "FeatureCollection",
+                    "features": [{"type": "Feature", "id": "p1", "properties": {"name": "Parcel 1"}}],
+                },
+            )
+        if raw_path == "/odata/Layers(4)/Features":
+            return httpx.Response(200, json={"value": [{"ObjectId": 7, "Name": "Road"}]})
+        raise AssertionError(f"unexpected path {raw_path}")
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        ogc_items = [
+            item
+            async for item in client.iter_query(
+                "parcels",
+                protocol="ogc-features",
+                filter="status = 'active'",
+                fields=["name"],
+                limit=1,
+            )
+        ]
+        odata = await client.query(
+            FeatureQuery(
+                source="4",
+                protocol="odata",
+                filter="Status eq 'active'",
+                fields=["ObjectId", "Name"],
+                limit=1,
+            )
+        )
+
+    assert ogc_items[0].id == "p1"
+    assert ogc_items[0].properties == {"name": "Parcel 1"}
+    assert odata.features[0].id == 7
+    assert odata.features[0].properties == {"ObjectId": 7, "Name": "Road"}
+    assert seen == [
+        {
+            "path": "/ogc/features/collections/parcels/items",
+            "query": {
+                "f": "json",
+                "limit": "1",
+                "offset": "0",
+                "filter": "status = 'active'",
+                "properties": "name",
+            },
+        },
+        {
+            "path": "/odata/Layers(4)/Features",
+            "query": {
+                "$filter": "Status eq 'active'",
+                "$select": "ObjectId,Name",
+                "$top": "1",
+                "$skip": "0",
+            },
+        },
+    ]
 
 
 async def test_ogc_features_items_builds_expected_request() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
-from honua_sdk import CallableAuthProvider, DataPlaneCapabilities, HonuaClient, HonuaHttpError
+from honua_sdk import CallableAuthProvider, DataPlaneCapabilities, FeatureQuery, HonuaClient, HonuaHttpError
 
 
 def test_query_features_builds_expected_request() -> None:
@@ -210,6 +210,164 @@ def test_query_features_all_pages_until_transfer_limit_clears() -> None:
 
     assert [feature.object_id for feature in features] == [1, 2, 3]
     assert seen == [("0", "2"), ("2", "1")]
+
+
+def test_shared_query_feature_server_normalizes_common_args() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(dict(request.url.params.multi_items()))
+        assert request.url.path == "/rest/services/parcels/FeatureServer/0/query"
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {
+                        "attributes": {"objectid": 10, "name": "A"},
+                        "geometry": {"x": -157.8, "y": 21.3},
+                    }
+                ],
+                "exceededTransferLimit": False,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        result = client.query(
+            "parcels",
+            where="status = 'active'",
+            fields=["objectid", "name"],
+            bbox=[-158, 21, -157, 22],
+            limit=1,
+        )
+
+    assert result.protocol == "feature-server"
+    assert result.source == "parcels"
+    assert len(result.features) == 1
+    feature = result.features[0]
+    assert feature.id == 10
+    assert feature.properties == {"objectid": 10, "name": "A"}
+    assert feature.geometry == {"x": -157.8, "y": 21.3}
+    assert feature.protocol == "feature-server"
+    assert seen["where"] == "status = 'active'"
+    assert seen["outFields"] == "objectid,name"
+    assert seen["returnGeometry"] == "true"
+    assert seen["resultOffset"] == "0"
+    assert seen["resultRecordCount"] == "1"
+    assert seen["geometryType"] == "esriGeometryEnvelope"
+    assert seen["spatialRel"] == "esriSpatialRelIntersects"
+
+
+def test_shared_query_routes_ogc_stac_and_odata() -> None:
+    seen: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raw_path = request.url.raw_path.decode("ascii").split("?")[0]
+        query = dict(request.url.params.multi_items())
+        seen.append({"path": raw_path, "query": query})
+        if raw_path == "/ogc/features/collections/parcels/items":
+            return httpx.Response(
+                200,
+                json={
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "id": "p1",
+                            "properties": {"name": "Parcel 1"},
+                            "geometry": {"type": "Point", "coordinates": [0, 0]},
+                        }
+                    ],
+                },
+            )
+        if raw_path == "/stac/collections/imagery/items":
+            return httpx.Response(
+                200,
+                json={
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "id": "scene-1",
+                            "properties": {"datetime": "2026-01-01T00:00:00Z"},
+                            "geometry": {"type": "Point", "coordinates": [1, 1]},
+                        }
+                    ],
+                },
+            )
+        if raw_path == "/odata/Layers(4)/Features":
+            return httpx.Response(200, json={"value": [{"ObjectId": 7, "Name": "Road", "Geometry": {"x": 1}}]})
+        raise AssertionError(f"unexpected path {raw_path}")
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        ogc = client.query(
+            "parcels",
+            protocol="ogc-features",
+            filter="status = 'active'",
+            fields=["name"],
+            bbox=[-158, 21, -157, 22],
+            limit=1,
+        )
+        stac = client.query(
+            FeatureQuery(
+                source="imagery",
+                protocol="stac",
+                filter="eo:cloud_cover < 10",
+                bbox=[-158, 21, -157, 22],
+                fields=["datetime"],
+                limit=1,
+            )
+        )
+        odata = client.query(
+            FeatureQuery(
+                source="4",
+                protocol="odata",
+                filter="Status eq 'active'",
+                fields=["ObjectId", "Name"],
+                limit=1,
+            )
+        )
+
+    assert ogc.features[0].id == "p1"
+    assert ogc.features[0].properties == {"name": "Parcel 1"}
+    assert stac.features[0].id == "scene-1"
+    assert stac.features[0].properties == {"datetime": "2026-01-01T00:00:00Z"}
+    assert odata.features[0].id == 7
+    assert odata.features[0].properties == {"ObjectId": 7, "Name": "Road"}
+    assert odata.features[0].geometry == {"x": 1}
+    assert seen == [
+        {
+            "path": "/ogc/features/collections/parcels/items",
+            "query": {
+                "f": "json",
+                "limit": "1",
+                "offset": "0",
+                "bbox": "-158,21,-157,22",
+                "filter": "status = 'active'",
+                "properties": "name",
+            },
+        },
+        {
+            "path": "/stac/collections/imagery/items",
+            "query": {
+                "filter": "eo:cloud_cover < 10",
+                "bbox": "-158,21,-157,22",
+                "fields": "datetime",
+                "limit": "1",
+                "offset": "0",
+            },
+        },
+        {
+            "path": "/odata/Layers(4)/Features",
+            "query": {
+                "$filter": "Status eq 'active'",
+                "$select": "ObjectId,Name",
+                "$top": "1",
+                "$skip": "0",
+            },
+        },
+    ]
 
 
 def test_ogc_features_metadata_and_items_build_expected_requests() -> None:


### PR DESCRIPTION
## Summary

- Adds `HonuaClient.query()` / `iter_query()` and async equivalents as a shared feature-query API across FeatureServer, OGC API Features, STAC, and OData.
- Adds public `FeatureQuery`, `FeatureQueryResult`, `QueryFeature`, and `QueryProtocol` exports with normalized feature output (`id`, `properties`, `geometry`, `protocol`, `source`, `raw`).
- Routes common query controls (`where`/`filter`, `bbox`, `fields`, `limit`, `page_size`, `max_pages`) to each protocol-specific backend while preserving protocol clients as escape hatches.
- Updates README/core/protocol docs and refreshes the public API snapshot.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests -q -p no:cacheprovider`
- `.venv/bin/ruff check .`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python scripts/compatibility_gate.py`
- `git diff --check`
- `../../.venv/bin/hatch build` in `packages/honua-sdk` and `packages/honua-admin`
- `../../.venv/bin/twine check dist/honua_sdk-0.0.2.tar.gz dist/honua_sdk-0.0.2-py3-none-any.whl`
- `../../.venv/bin/twine check dist/honua_admin-0.0.2.tar.gz dist/honua_admin-0.0.2-py3-none-any.whl`