### PR TITLE
[codex] Prepare Python packages for 0.1.0 release

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "packages/honua-sdk": "0.0.2",
-  "packages/honua-admin": "0.0.2"
+  "packages/honua-sdk": "0.1.0",
+  "packages/honua-admin": "0.1.0"
 }

--- a/packages/honua-admin/CHANGELOG.md
+++ b/packages/honua-admin/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.0](https://github.com/honua-io/honua-sdk-python/compare/python-admin-vv0.0.2...python-admin-vv0.1.0) (2026-04-28)
+
+
+### Features
+
+* add package-scoped compatibility gate coverage and release validation for admin packaging ([#28](https://github.com/honua-io/honua-sdk-python/pull/28))
+* stabilize the shared SDK/admin utility boundary and update admin to depend on the matching SDK release floor ([#41](https://github.com/honua-io/honua-sdk-python/pull/41))
+
+
+### Bug Fixes
+
+* fix SDK/admin review findings before the 0.1.0 packaging pass ([#29](https://github.com/honua-io/honua-sdk-python/pull/29))
+
 ## [0.0.2](https://github.com/honua-io/honua-sdk-python/compare/python-admin-vv0.0.1...python-admin-vv0.0.2) (2026-04-25)
 
 

--- a/packages/honua-admin/pyproject.toml
+++ b/packages/honua-admin/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "honua-admin"
-version = "0.0.2"
+version = "0.1.0"
 description = "Admin / control-plane client for Honua geospatial server"
 readme = "README.md"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-  "honua-sdk>=0.0.1a0",
+  "honua-sdk>=0.1.0",
 ]
 
 [project.urls]

--- a/packages/honua-sdk/CHANGELOG.md
+++ b/packages/honua-sdk/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.0](https://github.com/honua-io/honua-sdk-python/compare/python-sdk-vv0.0.2...python-sdk-vv0.1.0) (2026-04-28)
+
+
+### Features
+
+* add unified feature query API across FeatureServer, OGC API Features, STAC, and OData ([#42](https://github.com/honua-io/honua-sdk-python/pull/42))
+* add protocol iterators, public protocol typing helpers, OData query helpers, and WMS/WMTS response metadata wrappers ([#41](https://github.com/honua-io/honua-sdk-python/pull/41))
+* add SDK/admin compatibility gate, protocol factory snapshots, and CI release gates ([#28](https://github.com/honua-io/honua-sdk-python/pull/28))
+* add typed core endpoint helpers, refreshable auth providers, expanded protocol clients, and protocol smoke coverage ([#23](https://github.com/honua-io/honua-sdk-python/pull/23), [#24](https://github.com/honua-io/honua-sdk-python/pull/24), [#26](https://github.com/honua-io/honua-sdk-python/pull/26), [#27](https://github.com/honua-io/honua-sdk-python/pull/27), [#40](https://github.com/honua-io/honua-sdk-python/pull/40))
+
+
+### Bug Fixes
+
+* fix SDK review findings before the 0.1.0 packaging pass ([#29](https://github.com/honua-io/honua-sdk-python/pull/29))
+
 ## [0.0.2](https://github.com/honua-io/honua-sdk-python/compare/python-sdk-vv0.0.1...python-sdk-vv0.0.2) (2026-04-25)
 
 

--- a/packages/honua-sdk/pyproject.toml
+++ b/packages/honua-sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "honua-sdk"
-version = "0.0.2"
+version = "0.1.0"
 description = "Python SDK for Honua geospatial server -- feature queries, geocoding, and protocol clients"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_publish_tag_validation.py
+++ b/tests/test_publish_tag_validation.py
@@ -19,8 +19,8 @@ SPEC.loader.exec_module(validate_publish_tag)
 @pytest.mark.parametrize(
     "tag_name",
     [
-        "python-sdk-v0.0.2",
-        "python-sdk-vv0.0.2",
+        "python-sdk-v0.1.0",
+        "python-sdk-vv0.1.0",
     ],
 )
 def test_validate_publish_tag_accepts_single_or_double_v_prefix(tag_name: str) -> None:


### PR DESCRIPTION
## Summary

- Bumps `honua-sdk` and `honua-admin` package metadata and Release Please manifest to `0.1.0`.
- Updates package changelogs for the post-0.0.2 SDK/admin work.
- Raises `honua-admin` dependency floor to `honua-sdk>=0.1.0` so admin cannot install against an SDK release missing the shared SDK/admin utility boundary.
- Updates publish tag validation tests for the next release tag version.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests -q -p no:cacheprovider`
- `.venv/bin/ruff check .`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python scripts/compatibility_gate.py`
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/validate_publish_tag.py --pyproject packages/honua-sdk/pyproject.toml --tag python-sdk-vv0.1.0 --prefix python-sdk-v`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/validate_publish_tag.py --pyproject packages/honua-admin/pyproject.toml --tag python-admin-vv0.1.0 --prefix python-admin-v`
- `../../.venv/bin/hatch build` in `packages/honua-sdk` and `packages/honua-admin`
- `../../.venv/bin/twine check dist/honua_sdk-0.1.0.tar.gz dist/honua_sdk-0.1.0-py3-none-any.whl`
- `../../.venv/bin/twine check dist/honua_admin-0.1.0.tar.gz dist/honua_admin-0.1.0-py3-none-any.whl`