### PR TITLE
Align Python shared query API with source contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,15 @@ with HonuaClient("https://your-honua-server.com") as client:
     # List available services
     services = client.list_services()
 
-    # Query features through the shared feature-query API
-    result = client.query(
-        "natural-earth",
-        layer_id=0,
-        where="status = 'active'",
-        fields=["*"],
+    # Query features through the shared Source/Query/Result API
+    source = client.source(
+        {
+            "id": "natural-earth",
+            "protocol": "geoservices-feature-service",
+            "locator": {"serviceId": "natural-earth", "layerId": 0},
+        }
     )
+    result = source.query(where="status = 'active'", out_fields=["*"])
 
     features = result.features
     print(f"Found {len(features)} features")
@@ -67,18 +69,25 @@ with HonuaClient("https://your-honua-server.com") as client:
     feature = parcels.item("123")
 ```
 
-### Shared feature query
+### Shared Source/Query API
 
 ```python
-from honua_sdk import FeatureQuery, HonuaClient
+from honua_sdk import FeatureQuery, HonuaClient, Query, SourceDescriptor, SourceLocator
 
 with HonuaClient("https://your-honua-server.com") as client:
-    feature_server = client.query(
-        "parcels",
-        layer_id=0,
-        where="status = 'active'",
-        fields=["objectid", "name", "status"],
-        limit=2000,
+    parcels = client.source(
+        SourceDescriptor(
+            id="parcels",
+            protocol="feature-server",
+            locator=SourceLocator(service_id="parcels", layer_id=0),
+        )
+    )
+    result = parcels.query(
+        Query(
+            where="status = 'active'",
+            out_fields=["objectid", "name", "status"],
+            pagination={"limit": 2000},
+        )
     )
 
     ogc_features = client.query(
@@ -109,14 +118,19 @@ with HonuaClient("https://your-honua-server.com") as client:
     )
 ```
 
-`client.query()` returns a `FeatureQueryResult` with normalized `QueryFeature`
-entries: `id`, `properties`, `geometry`, `protocol`, `source`, and `raw`.
-Use `client.iter_query()` to stream normalized features without collecting the
-full result. Protocol-specific clients are still available for native payloads,
-map and tile bytes, OData metadata, WMS/WMTS `BinaryResponse` metadata, and
-advanced protocol options. See [Protocol Examples](docs/protocol-examples.md)
-for every wrapper and [Protocol Parity](docs/protocol-parity.md) for the
-Python/JS coverage map.
+`client.source(...)` accepts a `SourceDescriptor` and returns a source-bound
+facade with `query()`, `query_all()`, `stream()`/`iter_features()`,
+`apply_edits()`, and `protocol(...)`. `source.query()` returns a canonical
+`Result` with normalized `QueryFeature` entries: `id`, `properties`, `geometry`,
+`protocol`, `source`, and `raw`.
+
+The older `client.query()` and `client.iter_query()` helpers remain available as
+the compact FeatureServer, OGC Features, STAC, and OData path. Protocol-specific
+clients are still available through `source.protocol(...)` or direct factories
+for native payloads, map and tile bytes, OData metadata, WMS/WMTS
+`BinaryResponse` metadata, and advanced protocol options. See
+[Protocol Examples](docs/protocol-examples.md) for every wrapper and
+[Protocol Parity](docs/protocol-parity.md) for the Python/JS coverage map.
 
 ### Admin client
 

--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -1747,6 +1747,7 @@
         "AsyncOgcMapsClient",
         "AsyncOgcProcessesClient",
         "AsyncOgcTilesClient",
+        "AsyncSource",
         "AsyncStacClient",
         "AsyncWfsClient",
         "AsyncWmsClient",
@@ -1755,9 +1756,13 @@
         "BboxValue",
         "BearerToken",
         "BinaryResponse",
+        "CAPABILITIES",
         "CallableAuthProvider",
+        "Capability",
         "CsvValue",
+        "DEFAULT_CAPABILITIES",
         "DataPlaneCapabilities",
+        "DegradedReason",
         "EditOperationResult",
         "Feature",
         "FeatureId",
@@ -1770,6 +1775,7 @@
         "GeoServicesMapServerClient",
         "GeocodeResult",
         "GeocodeSuggestion",
+        "HonuaCapabilityNotSupportedError",
         "HonuaClient",
         "HonuaError",
         "HonuaGeocodingClient",
@@ -1788,11 +1794,20 @@
         "OgcMapsClient",
         "OgcProcessesClient",
         "OgcTilesClient",
+        "PROTOCOLS",
+        "PROTOCOL_ALIASES",
+        "Pagination",
+        "Protocol",
+        "Query",
         "QueryFeature",
         "QueryProtocol",
         "RefreshableBearerTokenProvider",
+        "Result",
         "ReverseGeocodeResult",
         "ServiceSummary",
+        "Source",
+        "SourceDescriptor",
+        "SourceLocator",
         "StacClient",
         "StaticAuthProvider",
         "TokenStore",
@@ -1802,7 +1817,11 @@
         "WmsVersion",
         "WmtsClient",
         "WmtsVersion",
-        "__version__"
+        "__version__",
+        "capability_set",
+        "default_capabilities",
+        "normalize_capability",
+        "normalize_protocol"
       ],
       "symbols": {
         "ApplyEditsResult": {
@@ -2111,6 +2130,10 @@
               "async": true,
               "kind": "method",
               "signature": "(self) -> 'dict[str, Any]'"
+            },
+            "source": {
+              "kind": "method",
+              "signature": "(self, descriptor: \"'SourceDescriptor | Mapping[str, Any]'\") -> \"'AsyncSource'\""
             },
             "stac": {
               "kind": "method",
@@ -2557,6 +2580,51 @@
           "qualname": "AsyncOgcTilesClient",
           "signature": "(client: 'Any') -> 'None'"
         },
+        "AsyncSource": {
+          "kind": "class",
+          "methods": {
+            "apply_edits": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, **kwargs: 'Any') -> 'ApplyEditsResult'"
+            },
+            "id": {
+              "kind": "property"
+            },
+            "iter_features": {
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'AsyncIterator[QueryFeature]'"
+            },
+            "protocol": {
+              "kind": "method",
+              "signature": "(self, kind: 'Protocol | None' = None) -> 'Any'"
+            },
+            "protocol_id": {
+              "kind": "property"
+            },
+            "query": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'Result'"
+            },
+            "query_all": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'tuple[QueryFeature, ...]'"
+            },
+            "stream": {
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'AsyncIterator[QueryFeature]'"
+            },
+            "supports": {
+              "kind": "method",
+              "signature": "(self, capability: 'Capability') -> 'bool'"
+            }
+          },
+          "module": "honua_sdk.source",
+          "qualname": "AsyncSource",
+          "signature": "(client: 'Any', descriptor: 'SourceDescriptor | Mapping[str, Any]') -> 'None'"
+        },
         "AsyncStacClient": {
           "kind": "class",
           "methods": {
@@ -2835,6 +2903,11 @@
           "qualname": "BinaryResponse",
           "signature": "(content: 'bytes', content_type: 'str | None' = None, cache_control: 'str | None' = None, etag: 'str | None' = None, last_modified: 'str | None' = None, expires: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, status_code: 'int' = 200) -> None"
         },
+        "CAPABILITIES": {
+          "kind": "constant",
+          "type": "tuple",
+          "value": "('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'applyEdits', 'attachments', 'render', 'tiles', 'sql', 'stream', 'pbf', 'connect', 'image', 'geometry', 'geoprocess', 'processes')"
+        },
         "CallableAuthProvider": {
           "kind": "class",
           "methods": {
@@ -2847,10 +2920,20 @@
           "qualname": "CallableAuthProvider",
           "signature": "(callback: 'Callable[[], Mapping[str, str]]') -> 'None'"
         },
+        "Capability": {
+          "kind": "constant",
+          "type": "_UnionGenericAlias",
+          "value": "typing.Union[typing.Literal['query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'applyEdits', 'attachments', 'render', 'tiles', 'sql', 'stream', 'pbf', 'connect', 'image', 'geometry', 'geoprocess', 'processes'], str]"
+        },
         "CsvValue": {
           "kind": "constant",
           "type": "UnionType",
           "value": "str | collections.abc.Sequence[str | int | float]"
+        },
+        "DEFAULT_CAPABILITIES": {
+          "kind": "constant",
+          "type": "dict",
+          "value": "{'geoservices-feature-service': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'applyEdits', 'attachments', 'sql', 'stream', 'pbf', 'connect'), 'geoservices-map-service': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'render', 'tiles', 'sql', 'stream'), 'geoservices-image-service': ('query', 'queryExtent', 'queryObjectIds', 'image', 'render', 'tiles', 'connect'), 'geoservices-geometry-service': ('geometry', 'connect'), 'geoservices-gp-service': ('geoprocess', 'connect'), 'ogc-features': ('query', 'queryObjectIds', 'applyEdits', 'stream'), 'ogc-tiles': ('render', 'tiles'), 'ogc-maps': ('render',), 'stac': ('query', 'queryObjectIds', 'stream'), 'wfs': ('query', 'queryExtent', 'queryObjectIds', 'applyEdits', 'stream'), 'wms': ('render', 'tiles', 'query'), 'wmts': ('render', 'tiles'), 'odata': ('query', 'queryObjectIds', 'stream', 'applyEdits'), 'maplibre-vector': ('render', 'tiles'), 'maplibre-raster': ('render', 'tiles'), 'maplibre-geojson': ('render',)}"
         },
         "DataPlaneCapabilities": {
           "fields": [
@@ -2898,6 +2981,32 @@
           "module": "honua_sdk.models",
           "qualname": "DataPlaneCapabilities",
           "signature": "(server_version: 'str | None' = None, release_channel: 'str | None' = None, protocols: 'frozenset[str]' = frozenset(), features: 'Mapping[str, bool]' = <factory>, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "DegradedReason": {
+          "fields": [
+            {
+              "annotation": "Capability",
+              "name": "capability"
+            },
+            {
+              "annotation": "Protocol",
+              "name": "protocol"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "source_id"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "reason"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.models",
+          "qualname": "DegradedReason",
+          "signature": "(capability: 'Capability', protocol: 'Protocol', source_id: 'str | None' = None, reason: 'str' = '') -> None"
         },
         "EditOperationResult": {
           "fields": [
@@ -3292,6 +3401,12 @@
           "qualname": "GeocodeSuggestion",
           "signature": "(text: 'str', magic_key: 'str', is_collection: 'bool') -> None"
         },
+        "HonuaCapabilityNotSupportedError": {
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "HonuaCapabilityNotSupportedError",
+          "signature": "(capability: 'str', protocol: 'str', *, source_id: 'str | None' = None, reason: 'str | None' = None) -> 'None'"
+        },
         "HonuaClient": {
           "kind": "class",
           "methods": {
@@ -3390,6 +3505,10 @@
             "readiness": {
               "kind": "method",
               "signature": "(self) -> 'dict[str, Any]'"
+            },
+            "source": {
+              "kind": "method",
+              "signature": "(self, descriptor: \"'SourceDescriptor | Mapping[str, Any]'\") -> \"'Source'\""
             },
             "stac": {
               "kind": "method",
@@ -3867,6 +3986,131 @@
           "qualname": "OgcTilesClient",
           "signature": "(client: 'Any') -> 'None'"
         },
+        "PROTOCOLS": {
+          "kind": "constant",
+          "type": "tuple",
+          "value": "('geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson')"
+        },
+        "PROTOCOL_ALIASES": {
+          "kind": "constant",
+          "type": "dict",
+          "value": "{'feature-server': 'geoservices-feature-service', 'featureserver': 'geoservices-feature-service', 'feature-service': 'geoservices-feature-service', 'geoservices-featureserver': 'geoservices-feature-service', 'map-server': 'geoservices-map-service', 'mapserver': 'geoservices-map-service', 'image-server': 'geoservices-image-service', 'imageserver': 'geoservices-image-service', 'geometry-server': 'geoservices-geometry-service', 'geometryserver': 'geoservices-geometry-service', 'gp-server': 'geoservices-gp-service', 'gpserver': 'geoservices-gp-service', 'ogc-api-features': 'ogc-features', 'ogc_features': 'ogc-features', 'odata-v4': 'odata', 'wfs-2.0': 'wfs', 'wms-1.3.0': 'wms', 'wmts-1.0.0': 'wmts'}"
+        },
+        "Pagination": {
+          "fields": [
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "limit"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "page_size"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "max_pages"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "offset"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'Pagination'\""
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "Pagination",
+          "signature": "(limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, offset: 'int | None' = None) -> None"
+        },
+        "Protocol": {
+          "kind": "constant",
+          "type": "_UnionGenericAlias",
+          "value": "typing.Union[typing.Literal['geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson'], str]"
+        },
+        "Query": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "where"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "spatial_filter"
+            },
+            {
+              "annotation": "str | Sequence[int | float] | None",
+              "default": "None",
+              "name": "bbox"
+            },
+            {
+              "annotation": "str | Sequence[str] | None",
+              "default": "None",
+              "name": "out_fields"
+            },
+            {
+              "annotation": "str | Sequence[str] | None",
+              "default": "None",
+              "name": "order_by"
+            },
+            {
+              "annotation": "Pagination",
+              "defaultFactory": "honua_sdk.models.Pagination",
+              "name": "pagination"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "aggregation"
+            },
+            {
+              "annotation": "bool",
+              "default": "True",
+              "name": "return_geometry"
+            },
+            {
+              "annotation": "int | str | None",
+              "default": "None",
+              "name": "out_sr"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "extra_params"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'Query'\""
+            },
+            "limit": {
+              "kind": "property"
+            },
+            "max_pages": {
+              "kind": "property"
+            },
+            "offset": {
+              "kind": "property"
+            },
+            "page_size": {
+              "kind": "property"
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "Query",
+          "signature": "(where: 'str | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, bbox: 'str | Sequence[int | float] | None' = None, out_fields: 'str | Sequence[str] | None' = None, order_by: 'str | Sequence[str] | None' = None, pagination: 'Pagination' = <factory>, aggregation: 'Mapping[str, Any] | None' = None, return_geometry: 'bool' = True, out_sr: 'int | str | None' = None, extra_params: 'Mapping[str, Any]' = <factory>) -> None"
+        },
         "QueryFeature": {
           "fields": [
             {
@@ -3906,7 +4150,7 @@
         "QueryProtocol": {
           "kind": "constant",
           "type": "_UnionGenericAlias",
-          "value": "typing.Union[typing.Literal['feature-server', 'featureserver', 'ogc-features', 'ogc_features', 'stac', 'odata'], str]"
+          "value": "typing.Union[typing.Literal['geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson'], str]"
         },
         "RefreshableBearerTokenProvider": {
           "kind": "class",
@@ -3931,6 +4175,69 @@
           "module": "honua_sdk.auth",
           "qualname": "RefreshableBearerTokenProvider",
           "signature": "(refresh: 'Callable[[], BearerToken | Mapping[str, Any] | str]', *, initial_token: 'BearerToken | Mapping[str, Any] | str | None' = None, token_store: 'TokenStore | None' = None, refresh_window_seconds: 'int | float' = 60, revoke: 'Callable[[BearerToken], None] | None' = None) -> 'None'"
+        },
+        "Result": {
+          "fields": [
+            {
+              "annotation": "tuple['QueryFeature', ...]",
+              "default": "()",
+              "name": "features"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "exceeded_transfer_limit"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "total_count"
+            },
+            {
+              "annotation": "tuple[Mapping[str, Any], ...]",
+              "default": "()",
+              "name": "aggregate_rows"
+            },
+            {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "extent"
+            },
+            {
+              "annotation": "tuple[Mapping[str, Any], ...]",
+              "default": "()",
+              "name": "fields"
+            },
+            {
+              "annotation": "tuple[DegradedReason, ...]",
+              "default": "()",
+              "name": "degraded"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "protocol"
+            },
+            {
+              "annotation": "str",
+              "default": "''",
+              "name": "source_id"
+            },
+            {
+              "annotation": "Query | None",
+              "default": "None",
+              "name": "query"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.models",
+          "qualname": "Result",
+          "signature": "(features: \"tuple['QueryFeature', ...]\" = (), exceeded_transfer_limit: 'bool' = False, total_count: 'int | None' = None, aggregate_rows: 'tuple[Mapping[str, Any], ...]' = (), extent: 'Mapping[str, Any] | None' = None, fields: 'tuple[Mapping[str, Any], ...]' = (), degraded: 'tuple[DegradedReason, ...]' = (), protocol: 'str' = '', source_id: 'str' = '', query: 'Query | None' = None, raw: 'Mapping[str, Any]' = <factory>) -> None"
         },
         "ReverseGeocodeResult": {
           "fields": [
@@ -3988,6 +4295,128 @@
           "module": "honua_sdk.models",
           "qualname": "ServiceSummary",
           "signature": "(name: 'str', type: 'str | None' = None, url: 'str | None' = None, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "Source": {
+          "kind": "class",
+          "methods": {
+            "apply_edits": {
+              "kind": "method",
+              "signature": "(self, **kwargs: 'Any') -> 'ApplyEditsResult'"
+            },
+            "id": {
+              "kind": "property"
+            },
+            "iter_features": {
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'Iterator[QueryFeature]'"
+            },
+            "protocol": {
+              "kind": "method",
+              "signature": "(self, kind: 'Protocol | None' = None) -> 'Any'"
+            },
+            "protocol_id": {
+              "kind": "property"
+            },
+            "query": {
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'Result'"
+            },
+            "query_all": {
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'tuple[QueryFeature, ...]'"
+            },
+            "stream": {
+              "kind": "method",
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, **kwargs: 'Any') -> 'Iterator[QueryFeature]'"
+            },
+            "supports": {
+              "kind": "method",
+              "signature": "(self, capability: 'Capability') -> 'bool'"
+            }
+          },
+          "module": "honua_sdk.source",
+          "qualname": "Source",
+          "signature": "(client: 'Any', descriptor: 'SourceDescriptor | Mapping[str, Any]') -> 'None'"
+        },
+        "SourceDescriptor": {
+          "fields": [
+            {
+              "annotation": "str",
+              "name": "id"
+            },
+            {
+              "annotation": "Protocol",
+              "name": "protocol"
+            },
+            {
+              "annotation": "SourceLocator",
+              "defaultFactory": "honua_sdk.models.SourceLocator",
+              "name": "locator"
+            },
+            {
+              "annotation": "frozenset[str]",
+              "defaultFactory": "frozenset",
+              "name": "capabilities"
+            },
+            {
+              "annotation": "Mapping[str, Any]",
+              "defaultFactory": "dict",
+              "name": "raw"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'SourceDescriptor'\""
+            },
+            "supports": {
+              "kind": "method",
+              "signature": "(self, capability: 'Capability') -> 'bool'"
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "SourceDescriptor",
+          "signature": "(id: 'str', protocol: 'Protocol', locator: 'SourceLocator' = <factory>, capabilities: 'frozenset[str]' = <factory>, raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "SourceLocator": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "service_id"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "layer_id"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "collection_id"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "entity_set"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "type_name"
+            }
+          ],
+          "kind": "class",
+          "methods": {
+            "from_dict": {
+              "kind": "classmethod",
+              "signature": "(cls, payload: 'Mapping[str, Any]') -> \"'SourceLocator'\""
+            }
+          },
+          "module": "honua_sdk.models",
+          "qualname": "SourceLocator",
+          "signature": "(service_id: 'str | None' = None, layer_id: 'int | None' = None, collection_id: 'str | None' = None, entity_set: 'str | None' = None, type_name: 'str | None' = None) -> None"
         },
         "StacClient": {
           "kind": "class",
@@ -4187,6 +4616,30 @@
         "__version__": {
           "kind": "constant",
           "type": "str"
+        },
+        "capability_set": {
+          "kind": "function",
+          "module": "honua_sdk.models",
+          "qualname": "capability_set",
+          "signature": "(values: 'Iterable[Capability] | None') -> 'frozenset[str]'"
+        },
+        "default_capabilities": {
+          "kind": "function",
+          "module": "honua_sdk.models",
+          "qualname": "default_capabilities",
+          "signature": "(protocol: 'Protocol') -> 'frozenset[str]'"
+        },
+        "normalize_capability": {
+          "kind": "function",
+          "module": "honua_sdk.models",
+          "qualname": "normalize_capability",
+          "signature": "(value: 'Capability') -> 'str'"
+        },
+        "normalize_protocol": {
+          "kind": "function",
+          "module": "honua_sdk.models",
+          "qualname": "normalize_protocol",
+          "signature": "(value: 'Protocol') -> 'str'"
         }
       }
     },

--- a/docs/core-client.md
+++ b/docs/core-client.md
@@ -47,31 +47,74 @@ with HonuaClient("https://honua.example") as client:
 Older servers that do not expose `/api/v1/capabilities` fall back to readiness
 and GeoServices catalog discovery.
 
-## FeatureServer Queries
+## Shared Source Queries
 
 For application code that wants the same shape across data protocols, prefer
-the shared feature query API. `query()` collects normalized `QueryFeature`
-entries from FeatureServer, OGC API Features, STAC, or OData; `iter_query()`
-streams the same normalized features:
+the shared Source/Query/Result API. `client.source(...)` binds a
+`SourceDescriptor` to a reusable facade; `source.query()` collects normalized
+`QueryFeature` entries, and `source.stream()`/`source.iter_features()` streams
+the same normalized features:
+
+```python
+from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
+
+with HonuaClient("https://honua.example") as client:
+    parcels = client.source(
+        SourceDescriptor(
+            id="parcels",
+            protocol="geoservices-feature-service",
+            locator=SourceLocator(service_id="parcels", layer_id=0),
+        )
+    )
+
+    result = parcels.query(
+        Query(
+            where="status = 'active'",
+            out_fields=["objectid", "name", "status"],
+            pagination={"limit": 2000},
+        )
+    )
+
+    for feature in result.features:
+        print(feature.id, feature.properties, feature.geometry)
+
+    native = parcels.protocol()
+    metadata = native.layer_metadata(0)
+```
+
+The source facade uses canonical cross-SDK protocol ids such as
+`geoservices-feature-service`, `ogc-features`, `stac`, and `odata`; common
+aliases such as `feature-server` and `ogc_api_features` are accepted. Python
+uses snake_case for query fields (`out_fields`, `return_geometry`,
+`query_all()`), while TypeScript and .NET use their idiomatic casing.
+`SourceDescriptor.supports(...)` reflects protocol-advertised capabilities;
+`source.supports(...)` reflects the normalized operations this Python facade can
+execute directly. Use `source.protocol(...)` for native protocol operations that
+are advertised but not normalized by the shared facade.
+
+The compact client-level helpers remain available for existing callers and for
+one-off queries. `client.query()` returns a `FeatureQueryResult`; `iter_query()`
+streams normalized features from FeatureServer, OGC API Features, STAC, or
+OData:
 
 ```python
 from honua_sdk import FeatureQuery, HonuaClient
 
 with HonuaClient("https://honua.example") as client:
-    feature_server = client.query(
-        "parcels",
-        layer_id=0,
-        where="status = 'active'",
-        fields=["objectid", "name", "status"],
-        limit=2000,
-    )
-
     ogc_features = client.query(
         "parcels",
         protocol="ogc-features",
         filter="status = 'active'",
         bbox=[-180, -90, 180, 90],
         fields=["name", "status"],
+        limit=2000,
+    )
+
+    odata_features = client.query(
+        "4",
+        protocol="odata",
+        filter="Status eq 'active'",
+        fields=["ObjectId", "Name"],
         limit=2000,
     )
 
@@ -84,17 +127,6 @@ with HonuaClient("https://honua.example") as client:
             limit=500,
         )
     )
-
-    odata_features = client.query(
-        "4",
-        protocol="odata",
-        filter="Status eq 'active'",
-        fields=["ObjectId", "Name"],
-        limit=2000,
-    )
-
-    for feature in feature_server.features:
-        print(feature.id, feature.properties, feature.geometry)
 ```
 
 Use the protocol-specific clients below when you need exact native payloads,

--- a/docs/protocol-parity.md
+++ b/docs/protocol-parity.md
@@ -5,7 +5,8 @@ protocol adapters.
 
 | Surface | Python SDK | JS SDK parity | Notes |
 | --- | --- | --- | --- |
-| Shared feature query | `client.query(...)`, `client.iter_query(...)` | Python-specific | Normalized `QueryFeature` output spans FeatureServer, OGC API Features, STAC, and OData. |
+| Shared Source/Query/Result | `client.source(...)`, `SourceDescriptor`, `Query`, `Result` | Aligned by fixture | Canonical source-bound facade with Pythonic snake_case names and protocol escape hatch. |
+| Shared feature query | `client.query(...)`, `client.iter_query(...)` | Legacy compact helper | Normalized `QueryFeature` output spans FeatureServer, OGC API Features, STAC, and OData. |
 | GeoServices FeatureServer | `client.feature_server(id)`, `query_features`, `apply_edits` | Partial | Read/query/edit, metadata, typed query pages, and item iterators are available. |
 | GeoServices MapServer | `client.map_server(id)`, `export_map` | Partial | Metadata, export, identify, and tile helpers are available. |
 | GeoServices ImageServer | `client.image_server(id)` | New in Python | Metadata, exportImage, identify, query, tile, and legend helpers are available. |
@@ -22,14 +23,17 @@ protocol adapters.
 | WMTS | `client.wmts(service_id)` | New in Python | Service-scoped capabilities, tile, and binary metadata helpers are available. |
 | OData v4 | `client.odata()` | New in Python | Service document, metadata, query helpers, layers, layer features, paged iterators, and feature helpers are available. |
 
-The Python SDK offers a shared query API for application code that wants one
-feature shape across queryable data protocols. The lower-level protocol clients
-intentionally keep protocol-native JSON, XML text, and bytes as their default
-return shapes. Additive helpers provide typed FeatureServer pages, `ODataQuery`
-parameter grouping, and `BinaryResponse` metadata for WMS/WMTS payloads without
-forcing heavy local models. That keeps parity focused on endpoint coverage,
-auth, retries, timeouts, and normalized errors while preserving standard
-payloads for GeoPandas, PySTAC, GDAL/OGR, and analyst workflows.
+The Python SDK offers a source-bound shared query API for application code that
+wants one feature shape across queryable data protocols. `SourceDescriptor`,
+`Query`, and `Result` follow the cross-SDK fixture while keeping Python naming
+conventions such as `out_fields`, `return_geometry`, and `query_all()`. The
+lower-level protocol clients intentionally keep protocol-native JSON, XML text,
+and bytes as their default return shapes. Additive helpers provide typed
+FeatureServer pages, `ODataQuery` parameter grouping, and `BinaryResponse`
+metadata for WMS/WMTS payloads without forcing heavy local models. That keeps
+parity focused on endpoint coverage, auth, retries, timeouts, and normalized
+errors while preserving standard payloads for GeoPandas, PySTAC, GDAL/OGR, and
+analyst workflows.
 
 Sync and async HTTP clients expose the same protocol factory names. The
 compatibility gate snapshots those factories and fails on unallowlisted drift.

--- a/packages/honua-sdk/README.md
+++ b/packages/honua-sdk/README.md
@@ -54,18 +54,25 @@ with HonuaClient("https://your-honua-server.com") as client:
     feature = parcels.item("123")
 ```
 
-## Shared Feature Query
+## Shared Source Query
 
 ```python
-from honua_sdk import FeatureQuery, HonuaClient
+from honua_sdk import FeatureQuery, HonuaClient, Query, SourceDescriptor, SourceLocator
 
 with HonuaClient("https://your-honua-server.com") as client:
-    feature_server = client.query(
-        "parcels",
-        layer_id=0,
-        where="status = 'active'",
-        fields=["objectid", "name", "status"],
-        limit=2000,
+    parcels = client.source(
+        SourceDescriptor(
+            id="parcels",
+            protocol="geoservices-feature-service",
+            locator=SourceLocator(service_id="parcels", layer_id=0),
+        )
+    )
+    result = parcels.query(
+        Query(
+            where="status = 'active'",
+            out_fields=["objectid", "name", "status"],
+            pagination={"limit": 2000},
+        )
     )
     ogc_features = client.query(
         "parcels",
@@ -93,11 +100,13 @@ with HonuaClient("https://your-honua-server.com") as client:
     )
 ```
 
-`client.query()` returns normalized `QueryFeature` entries across FeatureServer,
-OGC API Features, STAC, and OData. Use `client.iter_query()` to stream features
-without collecting the full result. Protocol-specific clients remain available
-for native payloads, maps, tiles, WMS/WMTS metadata, OData metadata, geocoding,
-and gRPC.
+`client.source(...)` returns a canonical source facade with `query()`,
+`query_all()`, `stream()`/`iter_features()`, `apply_edits()`, and
+`protocol(...)`. `source.query()` returns a `Result` with normalized
+`QueryFeature` entries. The compact `client.query()` helper remains available
+across FeatureServer, OGC API Features, STAC, and OData. Protocol-specific
+clients remain available for native payloads, maps, tiles, WMS/WMTS metadata,
+OData metadata, geocoding, and gRPC.
 
 ## Documentation
 

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -28,7 +28,7 @@ from .auth import (
 from .async_client import AsyncHonuaClient
 from .async_geocoding import AsyncHonuaGeocodingClient
 from .client import HonuaClient
-from .errors import HonuaError, HonuaGrpcError, HonuaHttpError
+from .errors import HonuaCapabilityNotSupportedError, HonuaError, HonuaGrpcError, HonuaHttpError
 from .geocoding import (
     GeocodeResult,
     GeocodeSuggestion,
@@ -37,15 +37,31 @@ from .geocoding import (
 )
 from .models import (
     ApplyEditsResult,
+    CAPABILITIES,
+    DEFAULT_CAPABILITIES,
+    PROTOCOLS,
+    PROTOCOL_ALIASES,
+    Capability,
     DataPlaneCapabilities,
+    DegradedReason,
     EditOperationResult,
     Feature,
     FeatureQuery,
     FeatureQueryResult,
     FeatureSet,
+    Pagination,
+    Protocol,
+    Query,
     QueryFeature,
     QueryProtocol,
+    Result,
     ServiceSummary,
+    SourceDescriptor,
+    SourceLocator,
+    capability_set,
+    default_capabilities,
+    normalize_capability,
+    normalize_protocol,
 )
 from .ogc import (
     AsyncHonuaOgcFeatureCollection,
@@ -93,6 +109,7 @@ from .protocols import (
     WmtsClient,
     WmtsVersion,
 )
+from .source import AsyncSource, Source
 
 __all__ = [
     "__version__",
@@ -110,6 +127,7 @@ __all__ = [
     "AsyncOgcMapsClient",
     "AsyncOgcProcessesClient",
     "AsyncOgcTilesClient",
+    "AsyncSource",
     "AsyncStacClient",
     "AsyncWfsClient",
     "AsyncWmsClient",
@@ -118,9 +136,13 @@ __all__ = [
     "BboxValue",
     "BearerToken",
     "BinaryResponse",
+    "CAPABILITIES",
+    "DEFAULT_CAPABILITIES",
+    "Capability",
     "CallableAuthProvider",
     "CsvValue",
     "DataPlaneCapabilities",
+    "DegradedReason",
     "EditOperationResult",
     "Feature",
     "FeatureQuery",
@@ -134,6 +156,7 @@ __all__ = [
     "GeoServicesImageServerClient",
     "GeoServicesMapServerClient",
     "HonuaClient",
+    "HonuaCapabilityNotSupportedError",
     "HonuaError",
     "HonuaGrpcError",
     "HonuaHttpError",
@@ -151,11 +174,20 @@ __all__ = [
     "OgcMapsClient",
     "OgcProcessesClient",
     "OgcTilesClient",
+    "PROTOCOLS",
+    "PROTOCOL_ALIASES",
+    "Pagination",
+    "Protocol",
+    "Query",
     "QueryFeature",
     "QueryProtocol",
     "RefreshableBearerTokenProvider",
     "ReverseGeocodeResult",
+    "Result",
     "ServiceSummary",
+    "Source",
+    "SourceDescriptor",
+    "SourceLocator",
     "StacClient",
     "StaticAuthProvider",
     "TokenStore",
@@ -165,4 +197,8 @@ __all__ = [
     "WmsVersion",
     "WmtsClient",
     "WmtsVersion",
+    "capability_set",
+    "default_capabilities",
+    "normalize_capability",
+    "normalize_protocol",
 ]

--- a/packages/honua-sdk/honua_sdk/_query.py
+++ b/packages/honua-sdk/honua_sdk/_query.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from typing import Any
 
-from .models import Feature, FeatureQuery, QueryFeature, QueryProtocol
+from .models import Feature, FeatureQuery, QueryFeature, QueryProtocol, normalize_protocol
 
 
 def resolve_feature_query(
@@ -66,12 +66,9 @@ def resolve_feature_query(
 
 
 def normalize_query_protocol(value: QueryProtocol) -> str:
-    normalized = str(value).strip().lower().replace("_", "-")
+    normalized = normalize_protocol(value)
     aliases = {
-        "featureserver": "feature-server",
-        "feature-service": "feature-server",
-        "feature-server": "feature-server",
-        "ogc-api-features": "ogc-features",
+        "geoservices-feature-service": "feature-server",
         "ogc-features": "ogc-features",
         "stac": "stac",
         "odata": "odata",
@@ -80,7 +77,7 @@ def normalize_query_protocol(value: QueryProtocol) -> str:
         return aliases[normalized]
     except KeyError as exc:
         raise ValueError(
-            "Unsupported query protocol. Expected one of: feature-server, ogc-features, stac, odata."
+            "Unsupported query protocol. Expected one of: geoservices-feature-service, ogc-features, stac, odata."
         ) from exc
 
 

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -66,6 +66,8 @@ if TYPE_CHECKING:
         AsyncWmsClient,
         AsyncWmtsClient,
     )
+    from .models import SourceDescriptor
+    from .source import AsyncSource
 
 
 def _bool_text(value: bool) -> str:
@@ -159,6 +161,12 @@ class AsyncHonuaClient:
     async def supports(self, capability: str) -> bool:
         """Return whether a data-plane protocol or feature is advertised."""
         return (await self.capabilities()).supports(capability)
+
+    def source(self, descriptor: "SourceDescriptor | Mapping[str, Any]") -> "AsyncSource":
+        """Return an async source-bound facade for canonical Source/Query/Result workflows."""
+        from .source import AsyncSource
+
+        return AsyncSource(self, descriptor)
 
     async def list_services(self, *, response_format: str = "json") -> dict[str, Any]:
         """List services from the GeoServices catalog endpoint."""

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -66,6 +66,8 @@ if TYPE_CHECKING:
         WmsClient,
         WmtsClient,
     )
+    from .models import SourceDescriptor
+    from .source import Source
 
 
 def _bool_text(value: bool) -> str:
@@ -159,6 +161,12 @@ class HonuaClient:
     def supports(self, capability: str) -> bool:
         """Return whether a data-plane protocol or feature is advertised."""
         return self.capabilities().supports(capability)
+
+    def source(self, descriptor: "SourceDescriptor | Mapping[str, Any]") -> "Source":
+        """Return a source-bound facade for canonical Source/Query/Result workflows."""
+        from .source import Source
+
+        return Source(self, descriptor)
 
     def list_services(self, *, response_format: str = "json") -> dict[str, Any]:
         """List services from the GeoServices catalog endpoint."""

--- a/packages/honua-sdk/honua_sdk/errors.py
+++ b/packages/honua-sdk/honua_sdk/errors.py
@@ -9,6 +9,29 @@ class HonuaError(Exception):
     """Base exception for SDK failures."""
 
 
+class HonuaCapabilityNotSupportedError(HonuaError):
+    """Raised when a source protocol does not support a requested capability."""
+
+    def __init__(
+        self,
+        capability: str,
+        protocol: str,
+        *,
+        source_id: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        message = f"Capability {capability!r} is not supported for protocol {protocol!r}"
+        if source_id is not None:
+            message = f"{message} on source {source_id!r}"
+        if reason:
+            message = f"{message}: {reason}"
+        super().__init__(message)
+        self.capability = capability
+        self.protocol = protocol
+        self.source_id = source_id
+        self.reason = reason
+
+
 class HonuaHttpError(HonuaError):
     """Raised when an API request returns a non-success response."""
 

--- a/packages/honua-sdk/honua_sdk/models.py
+++ b/packages/honua-sdk/honua_sdk/models.py
@@ -2,11 +2,192 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeAlias
 
-QueryProtocol: TypeAlias = Literal["feature-server", "featureserver", "ogc-features", "ogc_features", "stac", "odata"] | str
+Protocol: TypeAlias = Literal[
+    "geoservices-feature-service",
+    "geoservices-map-service",
+    "geoservices-image-service",
+    "geoservices-geometry-service",
+    "geoservices-gp-service",
+    "ogc-features",
+    "ogc-tiles",
+    "ogc-maps",
+    "stac",
+    "wfs",
+    "wms",
+    "wmts",
+    "odata",
+    "maplibre-vector",
+    "maplibre-raster",
+    "maplibre-geojson",
+] | str
+Capability: TypeAlias = Literal[
+    "query",
+    "queryAggregate",
+    "queryExtent",
+    "queryObjectIds",
+    "queryRelated",
+    "applyEdits",
+    "attachments",
+    "render",
+    "tiles",
+    "sql",
+    "stream",
+    "pbf",
+    "connect",
+    "image",
+    "geometry",
+    "geoprocess",
+    "processes",
+] | str
+QueryProtocol: TypeAlias = Protocol
+
+PROTOCOLS = (
+    "geoservices-feature-service",
+    "geoservices-map-service",
+    "geoservices-image-service",
+    "geoservices-geometry-service",
+    "geoservices-gp-service",
+    "ogc-features",
+    "ogc-tiles",
+    "ogc-maps",
+    "stac",
+    "wfs",
+    "wms",
+    "wmts",
+    "odata",
+    "maplibre-vector",
+    "maplibre-raster",
+    "maplibre-geojson",
+)
+
+PROTOCOL_ALIASES: Mapping[str, str] = {
+    "feature-server": "geoservices-feature-service",
+    "featureserver": "geoservices-feature-service",
+    "feature-service": "geoservices-feature-service",
+    "geoservices-featureserver": "geoservices-feature-service",
+    "map-server": "geoservices-map-service",
+    "mapserver": "geoservices-map-service",
+    "image-server": "geoservices-image-service",
+    "imageserver": "geoservices-image-service",
+    "geometry-server": "geoservices-geometry-service",
+    "geometryserver": "geoservices-geometry-service",
+    "gp-server": "geoservices-gp-service",
+    "gpserver": "geoservices-gp-service",
+    "ogc-api-features": "ogc-features",
+    "ogc_features": "ogc-features",
+    "odata-v4": "odata",
+    "wfs-2.0": "wfs",
+    "wms-1.3.0": "wms",
+    "wmts-1.0.0": "wmts",
+}
+
+CAPABILITIES = (
+    "query",
+    "queryAggregate",
+    "queryExtent",
+    "queryObjectIds",
+    "queryRelated",
+    "applyEdits",
+    "attachments",
+    "render",
+    "tiles",
+    "sql",
+    "stream",
+    "pbf",
+    "connect",
+    "image",
+    "geometry",
+    "geoprocess",
+    "processes",
+)
+
+DEFAULT_CAPABILITIES: Mapping[str, tuple[str, ...]] = {
+    "geoservices-feature-service": (
+        "query",
+        "queryAggregate",
+        "queryExtent",
+        "queryObjectIds",
+        "queryRelated",
+        "applyEdits",
+        "attachments",
+        "sql",
+        "stream",
+        "pbf",
+        "connect",
+    ),
+    "geoservices-map-service": (
+        "query",
+        "queryAggregate",
+        "queryExtent",
+        "queryObjectIds",
+        "queryRelated",
+        "render",
+        "tiles",
+        "sql",
+        "stream",
+    ),
+    "geoservices-image-service": (
+        "query",
+        "queryExtent",
+        "queryObjectIds",
+        "image",
+        "render",
+        "tiles",
+        "connect",
+    ),
+    "geoservices-geometry-service": ("geometry", "connect"),
+    "geoservices-gp-service": ("geoprocess", "connect"),
+    "ogc-features": ("query", "queryObjectIds", "applyEdits", "stream"),
+    "ogc-tiles": ("render", "tiles"),
+    "ogc-maps": ("render",),
+    "stac": ("query", "queryObjectIds", "stream"),
+    "wfs": ("query", "queryExtent", "queryObjectIds", "applyEdits", "stream"),
+    "wms": ("render", "tiles", "query"),
+    "wmts": ("render", "tiles"),
+    "odata": ("query", "queryObjectIds", "stream", "applyEdits"),
+    "maplibre-vector": ("render", "tiles"),
+    "maplibre-raster": ("render", "tiles"),
+    "maplibre-geojson": ("render",),
+}
+
+_NORMALIZED_PROTOCOL_ALIASES = {key.lower().replace("_", "-"): value for key, value in PROTOCOL_ALIASES.items()}
+_CAPABILITY_BY_KEY = {"".join(ch for ch in capability.lower() if ch.isalnum()): capability for capability in CAPABILITIES}
+
+
+def normalize_protocol(value: Protocol) -> str:
+    """Return the canonical cross-SDK protocol id for a protocol name or alias."""
+    normalized = str(value).strip().lower().replace("_", "-")
+    protocol = _NORMALIZED_PROTOCOL_ALIASES.get(normalized, normalized)
+    if protocol in PROTOCOLS:
+        return protocol
+    expected = ", ".join(sorted(PROTOCOLS))
+    raise ValueError(f"Unsupported protocol {value!r}. Expected one of: {expected}.")
+
+
+def normalize_capability(value: Capability) -> str:
+    """Return the canonical cross-SDK capability id for a capability name."""
+    key = "".join(ch for ch in str(value).strip().lower() if ch.isalnum())
+    try:
+        return _CAPABILITY_BY_KEY[key]
+    except KeyError as exc:
+        expected = ", ".join(sorted(CAPABILITIES))
+        raise ValueError(f"Unsupported capability {value!r}. Expected one of: {expected}.") from exc
+
+
+def capability_set(values: Iterable[Capability] | None) -> frozenset[str]:
+    """Normalize a capability iterable into canonical capability ids."""
+    if values is None:
+        return frozenset()
+    return frozenset(normalize_capability(value) for value in values)
+
+
+def default_capabilities(protocol: Protocol) -> frozenset[str]:
+    """Return the default capabilities advertised for a canonical protocol id."""
+    return frozenset(DEFAULT_CAPABILITIES.get(normalize_protocol(protocol), ()))
 
 
 @dataclass(frozen=True)
@@ -69,7 +250,7 @@ class DataPlaneCapabilities:
                     continue
                 service_type = _optional_str(service.get("type"))
                 if service_type is not None:
-                    protocols.add(_normalize_capability_name(service_type))
+                    protocols.add(_normalize_advertised_name(service_type))
 
         return cls(
             server_version=_optional_str(_first_present(readiness, "serverVersion", "server_version", "version")),
@@ -84,8 +265,179 @@ class DataPlaneCapabilities:
 
     def supports(self, capability: str) -> bool:
         """Return whether a named protocol or feature is advertised."""
-        key = _normalize_capability_name(capability)
-        return key in self.protocols or bool(self.features.get(key, False))
+        keys = _normalized_surface_keys(capability)
+        return any(key in self.protocols or bool(self.features.get(key, False)) for key in keys)
+
+
+@dataclass(frozen=True)
+class SourceLocator:
+    """Protocol-specific source address using Pythonic field names."""
+
+    service_id: str | None = None
+    layer_id: int | None = None
+    collection_id: str | None = None
+    entity_set: str | None = None
+    type_name: str | None = None
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SourceLocator":
+        return cls(
+            service_id=_optional_str(_first_present(payload, "serviceId", "service_id")),
+            layer_id=_optional_int(_first_present(payload, "layerId", "layer_id")),
+            collection_id=_optional_str(_first_present(payload, "collectionId", "collection_id")),
+            entity_set=_optional_str(_first_present(payload, "entitySet", "entity_set")),
+            type_name=_optional_str(_first_present(payload, "typeName", "type_name")),
+        )
+
+
+@dataclass(frozen=True)
+class SourceDescriptor:
+    """Cross-SDK source description used by the source facade."""
+
+    id: str
+    protocol: Protocol
+    locator: SourceLocator = field(default_factory=SourceLocator)
+    capabilities: frozenset[str] = field(default_factory=frozenset)
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        protocol = normalize_protocol(self.protocol)
+        capabilities = capability_set(self.capabilities) or default_capabilities(protocol)
+        object.__setattr__(self, "protocol", protocol)
+        object.__setattr__(self, "capabilities", capabilities)
+        object.__setattr__(self, "raw", dict(self.raw))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SourceDescriptor":
+        locator = payload.get("locator")
+        return cls(
+            id=str(payload.get("id") or ""),
+            protocol=_optional_str(payload.get("protocol")) or "geoservices-feature-service",
+            locator=SourceLocator.from_dict(locator) if isinstance(locator, Mapping) else SourceLocator(),
+            capabilities=capability_set(_sequence_value(payload.get("capabilities"))),
+            raw=dict(payload),
+        )
+
+    def supports(self, capability: Capability) -> bool:
+        """Return whether the source descriptor advertises a capability."""
+        return normalize_capability(capability) in self.capabilities
+
+
+@dataclass(frozen=True)
+class Pagination:
+    """Pagination options shared by queryable source protocols."""
+
+    limit: int | None = None
+    page_size: int | None = None
+    max_pages: int | None = None
+    offset: int | None = None
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Pagination":
+        return cls(
+            limit=_optional_int(payload.get("limit")),
+            page_size=_optional_int(_first_present(payload, "pageSize", "page_size")),
+            max_pages=_optional_int(_first_present(payload, "maxPages", "max_pages")),
+            offset=_optional_int(payload.get("offset")),
+        )
+
+
+@dataclass(frozen=True)
+class Query:
+    """Cross-SDK query model with Pythonic field names."""
+
+    where: str | None = None
+    spatial_filter: Mapping[str, Any] | None = None
+    bbox: str | Sequence[int | float] | None = None
+    out_fields: str | Sequence[str] | None = None
+    order_by: str | Sequence[str] | None = None
+    pagination: Pagination = field(default_factory=Pagination)
+    aggregation: Mapping[str, Any] | None = None
+    return_geometry: bool = True
+    out_sr: int | str | None = None
+    extra_params: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        pagination = self.pagination
+        if isinstance(pagination, Mapping):
+            pagination = Pagination.from_dict(pagination)
+        object.__setattr__(self, "pagination", pagination)
+        object.__setattr__(self, "spatial_filter", dict(self.spatial_filter) if self.spatial_filter else None)
+        object.__setattr__(self, "aggregation", dict(self.aggregation) if self.aggregation else None)
+        object.__setattr__(self, "extra_params", dict(self.extra_params))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Query":
+        pagination = _first_present(payload, "pagination", "page")
+        return cls(
+            where=_optional_str(payload.get("where")),
+            spatial_filter=_mapping_value(_first_present(payload, "spatialFilter", "spatial_filter")),
+            bbox=_first_present(payload, "bbox", "boundingBox", "bounding_box"),
+            out_fields=_first_present(payload, "outFields", "out_fields", "fields"),
+            order_by=_first_present(payload, "orderBy", "order_by"),
+            pagination=Pagination.from_dict(pagination) if isinstance(pagination, Mapping) else Pagination(),
+            aggregation=_mapping_value(payload.get("aggregation")),
+            return_geometry=bool(_first_present(payload, "returnGeometry", "return_geometry"))
+            if _first_present(payload, "returnGeometry", "return_geometry") is not None
+            else True,
+            out_sr=_first_present(payload, "outSr", "out_sr"),
+            extra_params=_mapping_value(_first_present(payload, "extraParams", "extra_params")) or {},
+        )
+
+    @property
+    def limit(self) -> int | None:
+        return self.pagination.limit
+
+    @property
+    def page_size(self) -> int | None:
+        return self.pagination.page_size
+
+    @property
+    def max_pages(self) -> int | None:
+        return self.pagination.max_pages
+
+    @property
+    def offset(self) -> int | None:
+        return self.pagination.offset
+
+
+@dataclass(frozen=True)
+class DegradedReason:
+    """Reason a result used a lower-fidelity path for a requested capability."""
+
+    capability: Capability
+    protocol: Protocol
+    source_id: str | None = None
+    reason: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "capability", normalize_capability(self.capability))
+        object.__setattr__(self, "protocol", normalize_protocol(self.protocol))
+
+
+@dataclass(frozen=True)
+class Result:
+    """Collected result returned by the canonical Source/Query API."""
+
+    features: tuple["QueryFeature", ...] = ()
+    exceeded_transfer_limit: bool = False
+    total_count: int | None = None
+    aggregate_rows: tuple[Mapping[str, Any], ...] = ()
+    extent: Mapping[str, Any] | None = None
+    fields: tuple[Mapping[str, Any], ...] = ()
+    degraded: tuple[DegradedReason, ...] = ()
+    protocol: str = ""
+    source_id: str = ""
+    query: Query | None = None
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "features", tuple(self.features))
+        object.__setattr__(self, "aggregate_rows", tuple(dict(row) for row in self.aggregate_rows))
+        object.__setattr__(self, "fields", tuple(dict(field) for field in self.fields))
+        object.__setattr__(self, "extent", dict(self.extent) if self.extent is not None else None)
+        object.__setattr__(self, "degraded", tuple(self.degraded))
+        object.__setattr__(self, "raw", dict(self.raw))
 
 
 @dataclass(frozen=True)
@@ -236,6 +588,18 @@ def _edit_results(value: Any) -> tuple[EditOperationResult, ...]:
     return tuple(EditOperationResult.from_dict(item) for item in value if isinstance(item, Mapping))
 
 
+def _sequence_value(value: Any) -> Sequence[Any] | None:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return value
+    return None
+
+
+def _mapping_value(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return None
+
+
 def _optional_str(value: Any) -> str | None:
     return str(value) if value is not None else None
 
@@ -254,14 +618,14 @@ def _first_present(payload: Mapping[str, Any], *keys: str) -> Any:
 def _capability_flags(value: Any) -> dict[str, bool]:
     if not isinstance(value, Mapping):
         return {}
-    return {_normalize_capability_name(str(key)): bool(flag) for key, flag in value.items()}
+    return {_normalize_advertised_name(str(key)): bool(flag) for key, flag in value.items()}
 
 
 def _capability_names(value: Any) -> set[str]:
     if not isinstance(value, Sequence) or isinstance(value, str):
         if isinstance(value, Mapping):
             return {
-                _normalize_capability_name(str(key))
+                _normalize_advertised_name(str(key))
                 for key, enabled in value.items()
                 if _capability_enabled(enabled)
             }
@@ -270,13 +634,13 @@ def _capability_names(value: Any) -> set[str]:
     names: set[str] = set()
     for item in value:
         if isinstance(item, str):
-            names.add(_normalize_capability_name(item))
+            names.add(_normalize_advertised_name(item))
             continue
         if not isinstance(item, Mapping) or not _capability_enabled(item):
             continue
         name = _first_present(item, "id", "name", "protocol", "surface")
         if name is not None:
-            names.add(_normalize_capability_name(str(name)))
+            names.add(_normalize_advertised_name(str(name)))
     return names
 
 
@@ -310,3 +674,27 @@ def _normalize_capability_name(value: str) -> str:
         "ogc-api-processes": "ogc-processes",
     }
     return aliases.get(normalized, normalized)
+
+
+def _normalize_advertised_name(value: str) -> str:
+    try:
+        return normalize_protocol(value)
+    except ValueError:
+        pass
+    try:
+        return normalize_capability(value)
+    except ValueError:
+        return _normalize_capability_name(value)
+
+
+def _normalized_surface_keys(value: str) -> set[str]:
+    keys = {_normalize_capability_name(value)}
+    try:
+        keys.add(normalize_protocol(value))
+    except ValueError:
+        pass
+    try:
+        keys.add(normalize_capability(value))
+    except ValueError:
+        pass
+    return keys

--- a/packages/honua-sdk/honua_sdk/source.py
+++ b/packages/honua-sdk/honua_sdk/source.py
@@ -1,0 +1,370 @@
+"""Canonical Source/Query/Result facade shared across SDKs."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from dataclasses import fields as dataclass_fields
+from dataclasses import replace
+from typing import Any
+
+from .errors import HonuaCapabilityNotSupportedError
+from .models import (
+    ApplyEditsResult,
+    Capability,
+    FeatureQuery,
+    Pagination,
+    Protocol,
+    Query,
+    QueryFeature,
+    Result,
+    SourceDescriptor,
+    SourceLocator,
+    normalize_capability,
+    normalize_protocol,
+)
+
+_NORMALIZED_QUERY_PROTOCOLS = frozenset(("geoservices-feature-service", "ogc-features", "stac", "odata"))
+_FACADE_CAPABILITY_PROTOCOLS = {
+    "query": _NORMALIZED_QUERY_PROTOCOLS,
+    "stream": _NORMALIZED_QUERY_PROTOCOLS,
+    "applyEdits": frozenset(("geoservices-feature-service",)),
+}
+_QUERY_FIELD_NAMES = frozenset(field.name for field in dataclass_fields(Query))
+
+
+class Source:
+    """Source-bound facade over the shared query API and protocol escape hatches."""
+
+    def __init__(self, client: Any, descriptor: SourceDescriptor | Mapping[str, Any]) -> None:
+        self._client = client
+        self.descriptor = _coerce_descriptor(descriptor)
+
+    @property
+    def id(self) -> str:
+        return self.descriptor.id
+
+    @property
+    def protocol_id(self) -> str:
+        return self.descriptor.protocol
+
+    def supports(self, capability: Capability) -> bool:
+        return _source_facade_supports(self.descriptor, capability)
+
+    def query(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> Result:
+        """Run a canonical source query and collect normalized features."""
+        query_model = _coerce_query(query, kwargs)
+        self._require("query")
+        feature_query = _feature_query_for_source(self.descriptor, query_model)
+        legacy_result = self._client.query(feature_query)
+        return _result_from_legacy(legacy_result.features, self.descriptor, query_model, raw={"legacy": legacy_result})
+
+    def query_all(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> tuple[QueryFeature, ...]:
+        """Return all normalized features for a canonical source query."""
+        return self.query(query, **kwargs).features
+
+    def stream(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> Iterator[QueryFeature]:
+        """Stream normalized features for a canonical source query."""
+        query_model = _coerce_query(query, kwargs)
+        self._require("stream")
+        feature_query = _feature_query_for_source(self.descriptor, query_model)
+        for feature in self._client.iter_query(feature_query):
+            yield replace(feature, protocol=self.descriptor.protocol, source=self.descriptor.id)
+
+    def iter_features(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> Iterator[QueryFeature]:
+        """Alias for ``stream()`` using a Python iterator name."""
+        yield from self.stream(query, **kwargs)
+
+    def apply_edits(self, **kwargs: Any) -> ApplyEditsResult:
+        """Apply edits for source protocols that expose a normalized edit helper."""
+        self._require("applyEdits")
+        return self._client.apply_edits_result(_service_id(self.descriptor), _layer_id(self.descriptor), **kwargs)
+
+    def protocol(self, kind: Protocol | None = None) -> Any:
+        """Return the native protocol client for source-specific operations."""
+        return _protocol_client(self._client, self.descriptor, kind)
+
+    def _require(self, capability: Capability) -> None:
+        normalized = normalize_capability(capability)
+        if not self.supports(normalized):
+            raise HonuaCapabilityNotSupportedError(
+                normalized,
+                self.descriptor.protocol,
+                source_id=self.descriptor.id,
+                reason=_unsupported_facade_reason(self.descriptor, normalized),
+            )
+
+
+class AsyncSource:
+    """Async source-bound facade over the shared query API and protocol escape hatches."""
+
+    def __init__(self, client: Any, descriptor: SourceDescriptor | Mapping[str, Any]) -> None:
+        self._client = client
+        self.descriptor = _coerce_descriptor(descriptor)
+
+    @property
+    def id(self) -> str:
+        return self.descriptor.id
+
+    @property
+    def protocol_id(self) -> str:
+        return self.descriptor.protocol
+
+    def supports(self, capability: Capability) -> bool:
+        return _source_facade_supports(self.descriptor, capability)
+
+    async def query(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> Result:
+        """Run a canonical source query and collect normalized features."""
+        query_model = _coerce_query(query, kwargs)
+        self._require("query")
+        feature_query = _feature_query_for_source(self.descriptor, query_model)
+        legacy_result = await self._client.query(feature_query)
+        return _result_from_legacy(legacy_result.features, self.descriptor, query_model, raw={"legacy": legacy_result})
+
+    async def query_all(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> tuple[QueryFeature, ...]:
+        """Return all normalized features for a canonical source query."""
+        return (await self.query(query, **kwargs)).features
+
+    async def stream(self, query: Query | Mapping[str, Any] | None = None, **kwargs: Any) -> AsyncIterator[QueryFeature]:
+        """Stream normalized features for a canonical source query."""
+        query_model = _coerce_query(query, kwargs)
+        self._require("stream")
+        feature_query = _feature_query_for_source(self.descriptor, query_model)
+        async for feature in self._client.iter_query(feature_query):
+            yield replace(feature, protocol=self.descriptor.protocol, source=self.descriptor.id)
+
+    async def iter_features(
+        self,
+        query: Query | Mapping[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[QueryFeature]:
+        """Alias for ``stream()`` using a Python iterator name."""
+        async for feature in self.stream(query, **kwargs):
+            yield feature
+
+    async def apply_edits(self, **kwargs: Any) -> ApplyEditsResult:
+        """Apply edits for source protocols that expose a normalized edit helper."""
+        self._require("applyEdits")
+        return await self._client.apply_edits_result(
+            _service_id(self.descriptor),
+            _layer_id(self.descriptor),
+            **kwargs,
+        )
+
+    def protocol(self, kind: Protocol | None = None) -> Any:
+        """Return the native protocol client for source-specific operations."""
+        return _protocol_client(self._client, self.descriptor, kind)
+
+    def _require(self, capability: Capability) -> None:
+        normalized = normalize_capability(capability)
+        if not self.supports(normalized):
+            raise HonuaCapabilityNotSupportedError(
+                normalized,
+                self.descriptor.protocol,
+                source_id=self.descriptor.id,
+                reason=_unsupported_facade_reason(self.descriptor, normalized),
+            )
+
+
+def _source_facade_supports(descriptor: SourceDescriptor, capability: Capability) -> bool:
+    normalized = normalize_capability(capability)
+    if not descriptor.supports(normalized):
+        return False
+    protocols = _FACADE_CAPABILITY_PROTOCOLS.get(normalized)
+    if protocols is None:
+        return True
+    return descriptor.protocol in protocols
+
+
+def _unsupported_facade_reason(descriptor: SourceDescriptor, capability: str) -> str | None:
+    if not descriptor.supports(capability):
+        return None
+    return (
+        f"The Python source facade does not expose normalized {capability} "
+        f"for protocol {descriptor.protocol!r}; use source.protocol(...) for native operations."
+    )
+
+
+def _coerce_descriptor(value: SourceDescriptor | Mapping[str, Any]) -> SourceDescriptor:
+    if isinstance(value, SourceDescriptor):
+        return value
+    if isinstance(value, Mapping):
+        return SourceDescriptor.from_dict(value)
+    raise TypeError("descriptor must be a SourceDescriptor or mapping.")
+
+
+def _coerce_query(value: Query | Mapping[str, Any] | None, overrides: Mapping[str, Any]) -> Query:
+    if value is None:
+        query = Query()
+    elif isinstance(value, Query):
+        query = value
+    elif isinstance(value, Mapping):
+        query = Query.from_dict(value)
+    else:
+        raise TypeError("query must be a Query, mapping, or None.")
+
+    if not overrides:
+        return query
+
+    data = {field_name: getattr(query, field_name) for field_name in _QUERY_FIELD_NAMES}
+    updates = dict(overrides)
+    if "fields" in updates and "out_fields" not in updates:
+        updates["out_fields"] = updates.pop("fields")
+    if "filter" in updates and "where" not in updates:
+        updates["where"] = updates.pop("filter")
+
+    pagination_updates = {}
+    for key in ("limit", "page_size", "max_pages", "offset"):
+        if key in updates:
+            pagination_updates[key] = updates.pop(key)
+
+    pagination = updates.pop("pagination", query.pagination)
+    if isinstance(pagination, Mapping):
+        pagination = Pagination.from_dict(pagination)
+    if pagination_updates:
+        pagination = replace(pagination, **pagination_updates)
+    data["pagination"] = pagination
+
+    unknown = sorted(set(updates) - _QUERY_FIELD_NAMES)
+    if unknown:
+        raise TypeError(f"Unexpected query option(s): {', '.join(unknown)}.")
+    data.update(updates)
+    return Query(**data)
+
+
+def _feature_query_for_source(descriptor: SourceDescriptor, query: Query) -> FeatureQuery:
+    protocol = descriptor.protocol
+    if protocol not in _NORMALIZED_QUERY_PROTOCOLS:
+        raise HonuaCapabilityNotSupportedError(
+            "query",
+            protocol,
+            source_id=descriptor.id,
+            reason="Normalized Source.query is currently implemented for FeatureServer, OGC Features, STAC, and OData.",
+        )
+
+    return FeatureQuery(
+        source=_query_source(descriptor),
+        protocol=protocol,
+        layer_id=_query_layer_id(descriptor),
+        where=query.where,
+        filter=query.where,
+        bbox=query.bbox,
+        fields=query.out_fields,
+        return_geometry=query.return_geometry,
+        page_size=query.page_size,
+        limit=query.limit,
+        max_pages=query.max_pages,
+        extra_params=_extra_params_for_query(protocol, query),
+    )
+
+
+def _result_from_legacy(
+    features: Sequence[QueryFeature],
+    descriptor: SourceDescriptor,
+    query: Query,
+    *,
+    raw: Mapping[str, Any],
+) -> Result:
+    normalized_features = tuple(
+        replace(feature, protocol=descriptor.protocol, source=descriptor.id)
+        for feature in features
+    )
+    return Result(
+        features=normalized_features,
+        exceeded_transfer_limit=False,
+        total_count=len(normalized_features),
+        protocol=descriptor.protocol,
+        source_id=descriptor.id,
+        query=query,
+        raw=raw,
+    )
+
+
+def _query_source(descriptor: SourceDescriptor) -> str:
+    locator = descriptor.locator
+    if descriptor.protocol == "geoservices-feature-service":
+        return locator.service_id or descriptor.id
+    if descriptor.protocol in {"ogc-features", "stac"}:
+        return locator.collection_id or descriptor.id
+    if descriptor.protocol == "odata":
+        if locator.layer_id is not None:
+            return str(locator.layer_id)
+        return locator.entity_set or descriptor.id
+    return descriptor.id
+
+
+def _query_layer_id(descriptor: SourceDescriptor) -> int | None:
+    if descriptor.protocol in {"geoservices-feature-service", "odata"}:
+        return descriptor.locator.layer_id
+    return None
+
+
+def _extra_params_for_query(protocol: str, query: Query) -> dict[str, Any]:
+    params = dict(query.extra_params)
+    if query.offset is not None:
+        if protocol == "geoservices-feature-service":
+            params.setdefault("resultOffset", query.offset)
+        elif protocol == "odata":
+            params.setdefault("$skip", query.offset)
+        else:
+            params.setdefault("offset", query.offset)
+    if query.out_sr is not None and protocol == "geoservices-feature-service":
+        params.setdefault("outSR", query.out_sr)
+    if query.order_by is not None:
+        value = _csv(query.order_by)
+        if protocol == "geoservices-feature-service":
+            params.setdefault("orderByFields", value)
+        elif protocol == "odata":
+            params.setdefault("$orderby", value)
+        else:
+            params.setdefault("sortby", value)
+    return params
+
+
+def _protocol_client(client: Any, descriptor: SourceDescriptor, kind: Protocol | None) -> Any:
+    protocol = normalize_protocol(kind or descriptor.protocol)
+    locator = descriptor.locator
+    if protocol == "geoservices-feature-service":
+        return client.feature_server(locator.service_id or descriptor.id)
+    if protocol == "geoservices-map-service":
+        return client.map_server(locator.service_id or descriptor.id)
+    if protocol == "geoservices-image-service":
+        return client.image_server(locator.service_id or descriptor.id)
+    if protocol == "geoservices-geometry-service":
+        return client.geometry_server()
+    if protocol == "ogc-features":
+        ogc = client.ogc_features()
+        return ogc.collection(locator.collection_id) if locator.collection_id is not None else ogc
+    if protocol == "ogc-tiles":
+        return client.ogc_tiles()
+    if protocol == "ogc-maps":
+        return client.ogc_maps()
+    if protocol == "stac":
+        return client.stac()
+    if protocol == "wfs":
+        return client.wfs()
+    if protocol == "wms":
+        return client.wms(locator.service_id or descriptor.id)
+    if protocol == "wmts":
+        return client.wmts(locator.service_id or descriptor.id)
+    if protocol == "odata":
+        return client.odata()
+    raise HonuaCapabilityNotSupportedError(
+        "connect",
+        protocol,
+        source_id=descriptor.id,
+        reason="No native protocol client is available for this source protocol.",
+    )
+
+
+def _service_id(descriptor: SourceDescriptor) -> str:
+    return descriptor.locator.service_id or descriptor.id
+
+
+def _layer_id(descriptor: SourceDescriptor) -> int:
+    return 0 if descriptor.locator.layer_id is None else descriptor.locator.layer_id
+
+
+def _csv(value: str | Sequence[str]) -> str:
+    if isinstance(value, str):
+        return value
+    return ",".join(str(item) for item in value)

--- a/tests/fixtures/sdk-contract/README.md
+++ b/tests/fixtures/sdk-contract/README.md
@@ -1,0 +1,20 @@
+# SDK Contract Fixtures
+
+These JSON fixtures define cross-SDK semantics for the Honua shared source and
+query contract. They are meant to be consumed by JavaScript, Python, and .NET
+tests.
+
+The fixtures validate behavior and envelopes, not exact method spelling. Each
+SDK should map the same concepts into idiomatic local names.
+
+Current fixture:
+
+- `semantic-contract.v1.json`: protocol and capability registries, common
+  language binding names, result-envelope scenarios, unsupported-capability
+  expectations, and degraded-result expectations.
+
+When this fixture changes, update:
+
+- The source/query section in `docs/core-client.md`
+- The parity notes in `docs/protocol-parity.md`
+- The JavaScript and .NET fixture consumers in their SDK repositories

--- a/tests/fixtures/sdk-contract/semantic-contract.v1.json
+++ b/tests/fixtures/sdk-contract/semantic-contract.v1.json
@@ -1,0 +1,592 @@
+{
+  "schemaVersion": 1,
+  "status": "draft",
+  "tracker": "https://github.com/honua-io/honua-sdk-js/issues/44",
+  "description": "Cross-SDK semantic fixture pack for Honua Dataset/Source/Query/Result behavior. Language bindings may use idiomatic names and casing.",
+  "canonicalNouns": [
+    "Dataset",
+    "SourceDescriptor",
+    "Source",
+    "Protocol",
+    "Capability",
+    "Query",
+    "Result",
+    "EditEnvelope",
+    "EditResult",
+    "MapBinding"
+  ],
+  "languageBindings": [
+    {
+      "concept": "queryAll",
+      "typescript": "queryAll()",
+      "python": "query_all()",
+      "dotnet": "QueryAllAsync()"
+    },
+    {
+      "concept": "stream",
+      "typescript": "stream()",
+      "python": "stream() or iter_*()",
+      "dotnet": "StreamAsync() or QueryPagesAsync()"
+    },
+    {
+      "concept": "queryObjectIds",
+      "typescript": "queryObjectIds()",
+      "python": "query_object_ids()",
+      "dotnet": "QueryObjectIdsAsync()"
+    },
+    {
+      "concept": "applyEdits",
+      "typescript": "applyEdits()",
+      "python": "apply_edits()",
+      "dotnet": "ApplyEditsAsync()"
+    },
+    {
+      "concept": "returnGeometry",
+      "typescript": "returnGeometry",
+      "python": "return_geometry",
+      "dotnet": "ReturnGeometry"
+    },
+    {
+      "concept": "outFields",
+      "typescript": "outFields",
+      "python": "out_fields",
+      "dotnet": "OutFields"
+    },
+    {
+      "concept": "protocolEscapeHatch",
+      "typescript": "source.protocol(...)",
+      "python": "source.protocol(...)",
+      "dotnet": "source.Protocol(...)"
+    }
+  ],
+  "protocols": [
+    "geoservices-feature-service",
+    "geoservices-map-service",
+    "geoservices-image-service",
+    "geoservices-geometry-service",
+    "geoservices-gp-service",
+    "ogc-features",
+    "ogc-tiles",
+    "ogc-maps",
+    "stac",
+    "wfs",
+    "wms",
+    "wmts",
+    "odata",
+    "maplibre-vector",
+    "maplibre-raster",
+    "maplibre-geojson"
+  ],
+  "protocolAliases": {
+    "feature-server": "geoservices-feature-service",
+    "featureserver": "geoservices-feature-service",
+    "feature-service": "geoservices-feature-service",
+    "geoservices-featureserver": "geoservices-feature-service",
+    "map-server": "geoservices-map-service",
+    "mapserver": "geoservices-map-service",
+    "image-server": "geoservices-image-service",
+    "imageserver": "geoservices-image-service",
+    "geometry-server": "geoservices-geometry-service",
+    "geometryserver": "geoservices-geometry-service",
+    "gp-server": "geoservices-gp-service",
+    "gpserver": "geoservices-gp-service",
+    "ogc-api-features": "ogc-features",
+    "ogc_features": "ogc-features",
+    "odata-v4": "odata",
+    "wfs-2.0": "wfs",
+    "wms-1.3.0": "wms",
+    "wmts-1.0.0": "wmts"
+  },
+  "capabilities": [
+    "query",
+    "queryAggregate",
+    "queryExtent",
+    "queryObjectIds",
+    "queryRelated",
+    "applyEdits",
+    "attachments",
+    "render",
+    "tiles",
+    "sql",
+    "stream",
+    "pbf",
+    "connect",
+    "image",
+    "geometry",
+    "geoprocess",
+    "processes"
+  ],
+  "defaultCapabilities": {
+    "geoservices-feature-service": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "queryRelated",
+      "applyEdits",
+      "attachments",
+      "sql",
+      "stream",
+      "pbf",
+      "connect"
+    ],
+    "geoservices-map-service": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "queryRelated",
+      "render",
+      "tiles",
+      "sql",
+      "stream"
+    ],
+    "geoservices-image-service": [
+      "query",
+      "queryExtent",
+      "queryObjectIds",
+      "image",
+      "render",
+      "tiles",
+      "connect"
+    ],
+    "geoservices-geometry-service": [
+      "geometry",
+      "connect"
+    ],
+    "geoservices-gp-service": [
+      "geoprocess",
+      "connect"
+    ],
+    "ogc-features": [
+      "query",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
+    "ogc-tiles": [
+      "render",
+      "tiles"
+    ],
+    "ogc-maps": [
+      "render"
+    ],
+    "stac": [
+      "query",
+      "queryObjectIds",
+      "stream"
+    ],
+    "wfs": [
+      "query",
+      "queryExtent",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
+    "wms": [
+      "render",
+      "tiles",
+      "query"
+    ],
+    "wmts": [
+      "render",
+      "tiles"
+    ],
+    "odata": [
+      "query",
+      "queryObjectIds",
+      "stream",
+      "applyEdits"
+    ],
+    "maplibre-vector": [
+      "render",
+      "tiles"
+    ],
+    "maplibre-raster": [
+      "render",
+      "tiles"
+    ],
+    "maplibre-geojson": [
+      "render"
+    ]
+  },
+  "resultScenarios": [
+    {
+      "id": "featureserver-page",
+      "protocol": "geoservices-feature-service",
+      "sourceDescriptor": {
+        "id": "parcels-fs",
+        "protocol": "geoservices-feature-service",
+        "locator": {
+          "serviceId": "Parcels",
+          "layerId": 0
+        },
+        "capabilities": [
+          "query",
+          "queryExtent",
+          "queryObjectIds"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "outFields": [
+          "OBJECTID",
+          "NAME",
+          "STATUS"
+        ],
+        "pagination": {
+          "limit": 2
+        },
+        "returnGeometry": true,
+        "outSr": 4326
+      },
+      "result": {
+        "features": [
+          {
+            "id": 1,
+            "attributes": {
+              "OBJECTID": 1,
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "x": -157.836,
+              "y": 21.284
+            }
+          },
+          {
+            "id": 2,
+            "attributes": {
+              "OBJECTID": 2,
+              "NAME": "Kapiolani",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "x": -157.82,
+              "y": 21.267
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 2,
+        "fields": [
+          {
+            "name": "OBJECTID",
+            "type": "oid"
+          },
+          {
+            "name": "NAME",
+            "type": "string"
+          },
+          {
+            "name": "STATUS",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    {
+      "id": "ogc-features-page",
+      "protocol": "ogc-features",
+      "sourceDescriptor": {
+        "id": "parcels-ogc",
+        "protocol": "ogc-features",
+        "locator": {
+          "collectionId": "parcels"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "outFields": [
+          "NAME",
+          "STATUS"
+        ],
+        "pagination": {
+          "limit": 2
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "ogc-1",
+            "attributes": {
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "stac-search-page",
+      "protocol": "stac",
+      "sourceDescriptor": {
+        "id": "imagery-stac",
+        "protocol": "stac",
+        "locator": {
+          "collectionId": "imagery"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "eo:cloud_cover < 10",
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "scene-001",
+            "attributes": {
+              "collection": "imagery",
+              "eo:cloud_cover": 4.2
+            },
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -158,
+                    21
+                  ],
+                  [
+                    -157,
+                    21
+                  ],
+                  [
+                    -157,
+                    22
+                  ],
+                  [
+                    -158,
+                    22
+                  ],
+                  [
+                    -158,
+                    21
+                  ]
+                ]
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "odata-page",
+      "protocol": "odata",
+      "sourceDescriptor": {
+        "id": "features-odata",
+        "protocol": "odata",
+        "locator": {
+          "entitySet": "Features"
+        },
+        "capabilities": [
+          "query",
+          "queryObjectIds",
+          "stream",
+          "applyEdits"
+        ]
+      },
+      "query": {
+        "where": "Status eq 'ACTIVE'",
+        "outFields": [
+          "ObjectId",
+          "Name",
+          "Status"
+        ],
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": 42,
+            "attributes": {
+              "ObjectId": 42,
+              "Name": "Ala Wai",
+              "Status": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "wfs-geojson-page",
+      "protocol": "wfs",
+      "sourceDescriptor": {
+        "id": "parcels-wfs",
+        "protocol": "wfs",
+        "locator": {
+          "typeName": "parcels"
+        },
+        "capabilities": [
+          "query",
+          "queryExtent",
+          "queryObjectIds",
+          "stream"
+        ]
+      },
+      "query": {
+        "where": "STATUS = 'ACTIVE'",
+        "pagination": {
+          "limit": 1
+        },
+        "returnGeometry": true
+      },
+      "result": {
+        "features": [
+          {
+            "id": "parcels.1",
+            "attributes": {
+              "NAME": "Ala Wai",
+              "STATUS": "ACTIVE"
+            },
+            "geometry": {
+              "type": "Point",
+              "coordinates": [
+                -157.836,
+                21.284
+              ]
+            }
+          }
+        ],
+        "exceededTransferLimit": false,
+        "totalCount": 1
+      }
+    },
+    {
+      "id": "empty-page",
+      "protocol": "geoservices-feature-service",
+      "query": {
+        "where": "1 = 0",
+        "pagination": {
+          "limit": 10
+        }
+      },
+      "result": {
+        "features": [],
+        "exceededTransferLimit": false,
+        "totalCount": 0
+      }
+    },
+    {
+      "id": "exceeded-transfer-page",
+      "protocol": "geoservices-feature-service",
+      "query": {
+        "where": "1 = 1",
+        "pagination": {
+          "limit": 1
+        }
+      },
+      "result": {
+        "features": [
+          {
+            "id": 1,
+            "attributes": {
+              "OBJECTID": 1
+            },
+            "geometry": null
+          }
+        ],
+        "exceededTransferLimit": true,
+        "totalCount": 2
+      }
+    },
+    {
+      "id": "ogc-features-aggregate-degraded",
+      "protocol": "ogc-features",
+      "operation": "queryAggregate",
+      "query": {
+        "aggregation": {
+          "groupBy": [
+            "STATUS"
+          ],
+          "metrics": [
+            {
+              "fn": "count",
+              "field": "OBJECTID",
+              "alias": "COUNT_OBJECTID"
+            }
+          ]
+        }
+      },
+      "result": {
+        "features": [],
+        "exceededTransferLimit": false,
+        "aggregateRows": [
+          {
+            "STATUS": "ACTIVE",
+            "COUNT_OBJECTID": 2
+          }
+        ],
+        "degraded": [
+          {
+            "capability": "queryAggregate",
+            "protocol": "ogc-features",
+            "sourceId": "parcels-ogc",
+            "reason": "Server-side aggregation is unavailable; result was computed client-side over drained pages."
+          }
+        ]
+      }
+    }
+  ],
+  "unsupportedCapabilityScenarios": [
+    {
+      "id": "wmts-query-unsupported",
+      "protocol": "wmts",
+      "operation": "query",
+      "requiredCapability": "query",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "query",
+        "protocol": "wmts"
+      }
+    },
+    {
+      "id": "ogc-tiles-apply-edits-unsupported",
+      "protocol": "ogc-tiles",
+      "operation": "applyEdits",
+      "requiredCapability": "applyEdits",
+      "expectedError": {
+        "name": "HonuaCapabilityNotSupportedError",
+        "capability": "applyEdits",
+        "protocol": "ogc-tiles"
+      }
+    }
+  ]
+}

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -6,7 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
-from honua_sdk import CallableAuthProvider, FeatureQuery
+from honua_sdk import CallableAuthProvider, FeatureQuery, Pagination, Query, SourceDescriptor, SourceLocator
 from honua_sdk.async_client import AsyncHonuaClient
 from honua_sdk.errors import HonuaHttpError
 
@@ -207,6 +207,47 @@ async def test_shared_query_feature_server_normalizes_common_args() -> None:
     assert seen["outFields"] == "objectid,name"
     assert seen["resultRecordCount"] == "1"
     assert seen["geometryType"] == "esriGeometryEnvelope"
+
+
+async def test_source_query_facade_returns_canonical_async_result() -> None:
+    seen: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(dict(request.url.params.multi_items()))
+        assert request.url.path == "/rest/services/Parcels/FeatureServer/0/query"
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {
+                        "attributes": {"OBJECTID": 1, "NAME": "Ala Wai"},
+                        "geometry": {"x": -157.836, "y": 21.284},
+                    }
+                ],
+                "exceededTransferLimit": False,
+            },
+        )
+
+    descriptor = SourceDescriptor(
+        id="parcels-fs",
+        protocol="geoservices-feature-service",
+        locator=SourceLocator(service_id="Parcels", layer_id=0),
+        capabilities=frozenset(("query", "stream")),
+    )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        result = await client.source(descriptor).query(
+            Query(where="1=1", out_fields=["OBJECTID", "NAME"], pagination=Pagination(limit=1))
+        )
+
+    assert result.protocol == "geoservices-feature-service"
+    assert result.source_id == "parcels-fs"
+    assert result.features[0].protocol == "geoservices-feature-service"
+    assert result.features[0].source == "parcels-fs"
+    assert result.features[0].properties == {"OBJECTID": 1, "NAME": "Ala Wai"}
+    assert seen["outFields"] == "OBJECTID,NAME"
+    assert seen["resultRecordCount"] == "1"
 
 
 async def test_shared_query_routes_async_ogc_and_odata() -> None:

--- a/tests/test_sdk_contract.py
+++ b/tests/test_sdk_contract.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from honua_sdk import (
+    CAPABILITIES,
+    DEFAULT_CAPABILITIES,
+    PROTOCOLS,
+    PROTOCOL_ALIASES,
+    HonuaCapabilityNotSupportedError,
+    HonuaClient,
+    Pagination,
+    Query,
+    Source,
+    SourceDescriptor,
+    SourceLocator,
+    default_capabilities,
+    normalize_capability,
+    normalize_protocol,
+)
+
+CONTRACT_PATH = Path(__file__).parent / "fixtures" / "sdk-contract" / "semantic-contract.v1.json"
+
+
+def _contract() -> dict[str, Any]:
+    return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_semantic_contract_protocols_and_capabilities_match_fixture() -> None:
+    contract = _contract()
+
+    assert PROTOCOLS == tuple(contract["protocols"])
+    assert dict(PROTOCOL_ALIASES) == contract["protocolAliases"]
+    assert CAPABILITIES == tuple(contract["capabilities"])
+    assert {key: list(value) for key, value in DEFAULT_CAPABILITIES.items()} == contract["defaultCapabilities"]
+
+    for alias, protocol in contract["protocolAliases"].items():
+        assert normalize_protocol(alias) == protocol
+    for protocol, capabilities in contract["defaultCapabilities"].items():
+        assert default_capabilities(protocol) == frozenset(capabilities)
+
+
+def test_semantic_contract_python_bindings_are_present() -> None:
+    contract = _contract()
+    python_bindings = {
+        binding["concept"]: binding["python"]
+        for binding in contract["languageBindings"]
+        if "python" in binding
+    }
+
+    assert python_bindings["queryAll"] == "query_all()"
+    assert python_bindings["applyEdits"] == "apply_edits()"
+    assert python_bindings["returnGeometry"] == "return_geometry"
+    assert python_bindings["outFields"] == "out_fields"
+    assert python_bindings["protocolEscapeHatch"] == "source.protocol(...)"
+    assert hasattr(Source, "query_all")
+    assert hasattr(Source, "apply_edits")
+    assert hasattr(Source, "protocol")
+    assert normalize_capability("apply_edits") == "applyEdits"
+    assert normalize_capability("query_object_ids") == "queryObjectIds"
+
+
+def test_source_query_facade_uses_canonical_descriptor_and_returns_result() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.update(dict(request.url.params.multi_items()))
+        assert request.url.path == "/rest/services/Parcels/FeatureServer/0/query"
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {
+                        "attributes": {"OBJECTID": 1, "NAME": "Ala Wai", "STATUS": "ACTIVE"},
+                        "geometry": {"x": -157.836, "y": 21.284},
+                    },
+                    {
+                        "attributes": {"OBJECTID": 2, "NAME": "Kapiolani", "STATUS": "ACTIVE"},
+                        "geometry": {"x": -157.82, "y": 21.267},
+                    },
+                ],
+                "exceededTransferLimit": False,
+            },
+        )
+
+    descriptor = SourceDescriptor(
+        id="parcels-fs",
+        protocol="feature-server",
+        locator=SourceLocator(service_id="Parcels", layer_id=0),
+        capabilities=frozenset(("query", "queryObjectIds")),
+    )
+    query = Query(
+        where="STATUS = 'ACTIVE'",
+        out_fields=["OBJECTID", "NAME", "STATUS"],
+        pagination=Pagination(limit=2),
+        return_geometry=True,
+        out_sr=4326,
+    )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        source = client.source(descriptor)
+        assert source.supports("query") is True
+        assert source.supports("stream") is False
+        assert source.supports("apply_edits") is False
+        result = source.query(query)
+
+    assert result.protocol == "geoservices-feature-service"
+    assert result.source_id == "parcels-fs"
+    assert result.total_count == 2
+    assert [feature.id for feature in result.features] == [1, 2]
+    assert result.features[0].protocol == "geoservices-feature-service"
+    assert result.features[0].source == "parcels-fs"
+    assert result.features[0].properties == {"OBJECTID": 1, "NAME": "Ala Wai", "STATUS": "ACTIVE"}
+    assert seen["where"] == "STATUS = 'ACTIVE'"
+    assert seen["outFields"] == "OBJECTID,NAME,STATUS"
+    assert seen["returnGeometry"] == "true"
+    assert seen["resultRecordCount"] == "2"
+    assert seen["outSR"] == "4326"
+
+
+def test_source_protocol_escape_hatch_returns_native_client() -> None:
+    descriptor = SourceDescriptor(
+        id="parcels",
+        protocol="geoservices-feature-service",
+        locator=SourceLocator(service_id="Parcels", layer_id=0),
+    )
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(lambda request: httpx.Response(200))) as client:
+        native = client.source(descriptor).protocol()
+
+    assert native.service_id == "Parcels"
+    assert native.path == "/rest/services/Parcels/FeatureServer"
+
+
+def test_source_raises_contract_error_for_unsupported_capability() -> None:
+    descriptor = SourceDescriptor(id="map", protocol="wms", locator=SourceLocator(service_id="BaseMap"))
+    assert descriptor.supports("query") is True
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(lambda request: httpx.Response(200))) as client:
+        source = client.source(descriptor)
+        assert source.supports("query") is False
+        with pytest.raises(HonuaCapabilityNotSupportedError) as exc_info:
+            source.query(where="1=1")
+
+    assert exc_info.value.capability == "query"
+    assert exc_info.value.protocol == "wms"
+    assert exc_info.value.source_id == "map"
+
+
+def test_source_raises_contract_error_for_unsupported_edit_operation() -> None:
+    descriptor = SourceDescriptor.from_dict(
+        {
+            "id": "parcels-ogc",
+            "protocol": "ogc-features",
+            "locator": {"collectionId": "parcels"},
+        }
+    )
+    assert descriptor.supports("applyEdits") is True
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(lambda request: httpx.Response(200))) as client:
+        source = client.source(descriptor)
+        assert source.supports("applyEdits") is False
+        with pytest.raises(HonuaCapabilityNotSupportedError) as exc_info:
+            source.apply_edits(adds=[])
+
+    assert exc_info.value.capability == "applyEdits"
+    assert exc_info.value.protocol == "ogc-features"


### PR DESCRIPTION
## Summary
- adds canonical SourceDescriptor, Query, Result, protocol/capability registries, and source-bound sync/async facades
- accepts canonical protocol ids and aliases while preserving the existing FeatureQuery client helpers
- imports the shared SDK contract fixture pack with tests and updates docs/API snapshot

Closes #45.

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python -m pytest tests -q -p no:cacheprovider
- .venv/bin/ruff check .
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=packages/honua-sdk:packages/honua-admin .venv/bin/python scripts/compatibility_gate.py
- git diff --check