### PR TITLE
feat: add Python analyst demo suite

### DIFF
--- a/docs/demo-suite.md
+++ b/docs/demo-suite.md
@@ -1,0 +1,27 @@
+# Python Analyst Demo Suite
+
+The Python SDK demo suite is designed around workflows where Python is the best fit: GeoPandas ETL, data quality reporting, spatial query exploration, and async API services.
+
+## Environment
+
+Use the shared demo contract from [../examples/README.md](../examples/README.md):
+
+- `HONUA_BASE_URL`
+- `HONUA_API_KEY`
+- `HONUA_SERVICE_ID`
+- `HONUA_LAYER_ID`
+- `HONUA_COLLECTION_ID`
+- `HONUA_STAC_COLLECTION_ID`
+
+Cloud demos should use fixture services with stable schemas and stable record counts. Demos that write data must filter their own slice, such as the ETL demo's `uid LIKE 'demo-etl-%'` target filter.
+
+## Current Coverage
+
+- GeoPandas ETL: clean, validate, query, upsert, re-query, and write deterministic artifacts.
+- Data quality report: validate the same source contract and emit JSON and HTML findings before load.
+- Spatial query cookbook: exercise FeatureServer bbox/filter queries, OGC API Features, STAC item search, WFS, WMS, WMTS, and OData response shapes.
+- FastAPI service: expose async `/features` and `/summary` routes backed by `AsyncHonuaClient`.
+
+## Optional STAC And Imagery
+
+STAC calls are included in the cookbook when `HONUA_STAC_COLLECTION_ID` points at a fixture collection. Imagery scoring is intentionally gated until the server fixture includes stable scene metadata and imagery assets. A runnable imagery pipeline should state the required collection id, asset keys, cloud cover field, and expected item count before adding scoring logic.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# Python Analyst Demo Suite
+
+This directory contains runnable examples for Python-first Honua workflows. The demos are script-first so notebooks and services can reuse shared modules instead of carrying duplicate business logic.
+
+## Cloud Environment Contract
+
+All demos that call Honua use the same environment variables:
+
+- `HONUA_BASE_URL`: Honua deployment URL. Defaults to `http://localhost:8080` for local demos.
+- `HONUA_API_KEY`: optional API key for deployments that require API-key auth.
+- `HONUA_SERVICE_ID`: FeatureServer service id. Defaults to `test_service`.
+- `HONUA_LAYER_ID`: FeatureServer layer id. Defaults to `0`.
+- `HONUA_COLLECTION_ID`: OGC API Features collection id for protocol demos. Defaults to the service id.
+- `HONUA_STAC_COLLECTION_ID`: optional STAC collection id for imagery demos.
+
+The checked-in examples target the seeded `test_service` layer used by local Honua server development. Cloud runs should point the variables at an equivalent writable or readable fixture.
+
+## Demos
+
+| Demo | Target user | Extras | Entry point | Artifacts |
+| --- | --- | --- | --- | --- |
+| GeoPandas ETL | Analyst loading cleaned point data into Honua | `honua-sdk[geopandas]`, `matplotlib` | `python examples/geospatial_etl/run_etl.py` | `load-summary.json`, `post-load-preview.png` |
+| Data quality report | Analyst reviewing source defects before load | `honua-sdk[geopandas]` | `python examples/data_quality_report.py` | `data-quality-report.json`, `data-quality-report.html` |
+| Spatial query cookbook | Developer or analyst comparing protocol query patterns | core SDK, optional `honua-sdk[geopandas]` for conversions | `python examples/spatial_query_cookbook.py` | printed response-shape summary |
+| FastAPI spatial service | App developer exposing async Honua-backed API routes | `fastapi`, `uvicorn` | `uvicorn examples.fastapi_spatial_service:create_app --factory --reload` | local `/features` and `/summary` routes |
+| Protocol clients | SDK developer checking protocol wrappers | core SDK, optional `honua-sdk[grpc]` and `honua-sdk[geopandas]` | `python examples/protocol_clients.py` | printed protocol response examples |
+
+## Validation
+
+Run the focused example tests from the repo root:
+
+```bash
+pytest tests/test_geospatial_etl_example.py tests/test_python_analyst_demos.py
+```
+
+For cloud validation, set the environment variables above and run the scripts manually against a fixture service before attaching artifacts to issue or PR notes.

--- a/examples/data_quality_report.py
+++ b/examples/data_quality_report.py
@@ -1,0 +1,143 @@
+"""Data quality report demo for the geospatial ETL source contract."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass
+import html
+from pathlib import Path
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.geospatial_etl import workflow
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+DEFAULT_INPUT_PATH = EXAMPLE_DIR / "geospatial_etl" / "data" / "demo_sites.csv"
+DEFAULT_OUTPUT_DIR = EXAMPLE_DIR / "geospatial_etl" / "output"
+
+
+@dataclass(slots=True)
+class DataQualityReport:
+    summary: dict[str, Any]
+    json_path: Path
+    html_path: Path
+
+
+def build_data_quality_report(
+    *,
+    input_path: str | Path = DEFAULT_INPUT_PATH,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    target_crs: str = workflow.DEFAULT_TARGET_CRS,
+) -> DataQualityReport:
+    output_path = Path(output_dir).expanduser().resolve()
+    output_path.mkdir(parents=True, exist_ok=True)
+    json_path = output_path / "data-quality-report.json"
+    html_path = output_path / "data-quality-report.html"
+
+    source_frame = workflow.load_source_dataframe(input_path)
+    source_gdf = workflow.dataframe_to_source_geodataframe(source_frame)
+    normalized = workflow.normalize_source_geodataframe(source_gdf, target_crs=target_crs)
+    validation = workflow.validate_source_geodataframe(normalized)
+
+    reason_counts = Counter(reason for issue in validation.rejected_rows for reason in issue.reasons)
+    missing_columns = [
+        column for column in workflow.REQUIRED_SOURCE_COLUMNS
+        if column not in source_frame.columns
+    ]
+    unexpected_columns = [
+        column for column in source_frame.columns
+        if column not in {*workflow.REQUIRED_SOURCE_COLUMNS, "_source_row"}
+    ]
+
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "input_path": str(Path(input_path).expanduser().resolve()),
+        "target_crs": target_crs,
+        "source_row_count": validation.source_row_count,
+        "valid_row_count": validation.valid_count,
+        "rejected_row_count": validation.rejected_count,
+        "reason_counts": dict(sorted(reason_counts.items())),
+        "schema": {
+            "required_columns": list(workflow.REQUIRED_SOURCE_COLUMNS),
+            "missing_columns": missing_columns,
+            "unexpected_columns": unexpected_columns,
+        },
+        "rejected_rows": [issue.to_dict() for issue in validation.rejected_rows],
+        "artifacts": {
+            "json": str(json_path),
+            "html": str(html_path),
+        },
+    }
+
+    workflow.write_summary_artifact(summary, json_path)
+    _write_html_report(summary, html_path)
+    return DataQualityReport(summary=summary, json_path=json_path, html_path=html_path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Write deterministic data quality artifacts for the ETL source CSV.")
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--target-crs", default=workflow.DEFAULT_TARGET_CRS)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    report = build_data_quality_report(
+        input_path=args.input,
+        output_dir=args.output_dir,
+        target_crs=args.target_crs,
+    )
+    print(
+        f"Validated {report.summary['source_row_count']} rows: "
+        f"{report.summary['valid_row_count']} valid, "
+        f"{report.summary['rejected_row_count']} rejected"
+    )
+    print(f"JSON artifact: {report.json_path}")
+    print(f"HTML artifact: {report.html_path}")
+    return 0 if report.summary["rejected_row_count"] == 0 else 1
+
+
+def _write_html_report(summary: dict[str, Any], output_path: str | Path) -> Path:
+    path = Path(output_path).expanduser().resolve()
+    reasons = "\n".join(
+        f"<li>{html.escape(reason)}: {count}</li>"
+        for reason, count in summary["reason_counts"].items()
+    ) or "<li>None</li>"
+    rejected_rows = "\n".join(
+        "<tr>"
+        f"<td>{issue['source_row']}</td>"
+        f"<td>{html.escape(str(issue.get('uid') or ''))}</td>"
+        f"<td>{html.escape(', '.join(issue['reasons']))}</td>"
+        "</tr>"
+        for issue in summary["rejected_rows"]
+    ) or "<tr><td colspan=\"3\">No rejected rows</td></tr>"
+    path.write_text(
+        "<!doctype html>\n"
+        "<html lang=\"en\">\n"
+        "<head><meta charset=\"utf-8\"><title>Honua Data Quality Report</title></head>\n"
+        "<body>\n"
+        "<h1>Honua Data Quality Report</h1>\n"
+        f"<p>Input: {html.escape(summary['input_path'])}</p>\n"
+        f"<p>Rows: {summary['source_row_count']} source, "
+        f"{summary['valid_row_count']} valid, {summary['rejected_row_count']} rejected</p>\n"
+        "<h2>Reason Counts</h2>\n"
+        f"<ul>{reasons}</ul>\n"
+        "<h2>Rejected Rows</h2>\n"
+        "<table><thead><tr><th>Source row</th><th>UID</th><th>Reasons</th></tr></thead><tbody>\n"
+        f"{rejected_rows}\n"
+        "</tbody></table>\n"
+        "</body></html>\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/fastapi_spatial_service.py
+++ b/examples/fastapi_spatial_service.py
@@ -1,0 +1,129 @@
+"""FastAPI scaffold backed by AsyncHonuaClient spatial queries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any
+
+from honua_sdk import AsyncHonuaClient
+
+DEFAULT_BASE_URL = "http://localhost:8080"
+DEFAULT_SERVICE_ID = "test_service"
+DEFAULT_LAYER_ID = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceSettings:
+    base_url: str = DEFAULT_BASE_URL
+    service_id: str = DEFAULT_SERVICE_ID
+    layer_id: int = DEFAULT_LAYER_ID
+    api_key: str | None = None
+
+
+async def fetch_features(
+    client: Any,
+    settings: ServiceSettings,
+    *,
+    bbox: tuple[float, float, float, float] | None = None,
+    where: str = "1=1",
+    limit: int = 100,
+) -> dict[str, Any]:
+    extra_params: dict[str, Any] = {"resultRecordCount": str(limit)}
+    if bbox is not None:
+        extra_params.update(
+            {
+                "geometry": ",".join(str(value) for value in bbox),
+                "geometryType": "esriGeometryEnvelope",
+                "inSR": "4326",
+                "spatialRel": "esriSpatialRelIntersects",
+            }
+        )
+    return await client.query_features(
+        settings.service_id,
+        settings.layer_id,
+        where=where,
+        out_fields=["*"],
+        return_geometry=True,
+        extra_params=extra_params,
+    )
+
+
+def summarize_feature_response(response: dict[str, Any]) -> dict[str, Any]:
+    features = response.get("features", [])
+    statuses: dict[str, int] = {}
+    if isinstance(features, list):
+        for feature in features:
+            attributes = feature.get("attributes", {}) if isinstance(feature, dict) else {}
+            status = attributes.get("status")
+            if status is not None:
+                statuses[str(status)] = statuses.get(str(status), 0) + 1
+    return {
+        "feature_count": len(features) if isinstance(features, list) else 0,
+        "status_counts": dict(sorted(statuses.items())),
+    }
+
+
+def settings_from_env() -> ServiceSettings:
+    return ServiceSettings(
+        base_url=os.getenv("HONUA_BASE_URL", DEFAULT_BASE_URL),
+        service_id=os.getenv("HONUA_SERVICE_ID", DEFAULT_SERVICE_ID),
+        layer_id=int(os.getenv("HONUA_LAYER_ID", str(DEFAULT_LAYER_ID))),
+        api_key=os.getenv("HONUA_API_KEY"),
+    )
+
+
+def create_app(settings: ServiceSettings | None = None) -> Any:
+    from fastapi import FastAPI, Query
+
+    app_settings = settings or settings_from_env()
+    app = FastAPI(title="Honua Spatial Service Demo")
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/features")
+    async def features(
+        bbox: str | None = Query(default=None, description="minx,miny,maxx,maxy in EPSG:4326"),
+        where: str = "1=1",
+        limit: int = Query(default=100, ge=1, le=1000),
+    ) -> dict[str, Any]:
+        parsed_bbox = _parse_bbox(bbox) if bbox is not None else None
+        async with AsyncHonuaClient(app_settings.base_url, api_key=app_settings.api_key) as client:
+            return await fetch_features(
+                client,
+                app_settings,
+                bbox=parsed_bbox,
+                where=where,
+                limit=limit,
+            )
+
+    @app.get("/summary")
+    async def summary(
+        bbox: str | None = Query(default=None, description="minx,miny,maxx,maxy in EPSG:4326"),
+        where: str = "1=1",
+        limit: int = Query(default=100, ge=1, le=1000),
+    ) -> dict[str, Any]:
+        parsed_bbox = _parse_bbox(bbox) if bbox is not None else None
+        async with AsyncHonuaClient(app_settings.base_url, api_key=app_settings.api_key) as client:
+            response = await fetch_features(
+                client,
+                app_settings,
+                bbox=parsed_bbox,
+                where=where,
+                limit=limit,
+            )
+        return summarize_feature_response(response)
+
+    return app
+
+
+def _parse_bbox(value: str) -> tuple[float, float, float, float]:
+    parts = [float(part.strip()) for part in value.split(",")]
+    if len(parts) != 4:
+        raise ValueError("bbox must have four comma-separated numbers: minx,miny,maxx,maxy")
+    minx, miny, maxx, maxy = parts
+    if minx >= maxx or miny >= maxy:
+        raise ValueError("bbox minimums must be less than maximums")
+    return minx, miny, maxx, maxy

--- a/examples/geospatial_etl/README.md
+++ b/examples/geospatial_etl/README.md
@@ -1,6 +1,6 @@
 # Geospatial ETL Demo
 
-This example shows the buyer-facing ETL loop for the Python SDK:
+This example shows the analyst-facing ETL loop for the Python SDK:
 
 1. Extract a tabular CSV source into a `GeoDataFrame`
 2. Normalize it to the target layer CRS
@@ -10,7 +10,7 @@ This example shows the buyer-facing ETL loop for the Python SDK:
 6. Re-query the same slice and emit demo artifacts
 
 The script is the canonical fast path. The notebook reuses the same workflow module for analyst walkthroughs.
-See [../../docs/troubleshooting.md](../../docs/troubleshooting.md) for staging base URL, auth, seeded contract, and cleanup guidance.
+See [../README.md](../README.md) for the shared demo-suite cloud environment contract, and [../../docs/troubleshooting.md](../../docs/troubleshooting.md) for staging base URL, auth, seeded contract, and cleanup guidance.
 
 ## Prerequisites
 
@@ -141,6 +141,21 @@ Exit behavior is also fixed:
 - exit code `1` on source/setup failures before the first network call
 - exit code `1` when the pre-load query, `apply_edits`, or post-load query raises `HonuaHttpError`
 - exit code `1` when `apply_edits` returns but none of its result entries are successful
+
+## Data Quality Report
+
+Run the companion report before loading when you only need source diagnostics:
+
+```bash
+python examples/data_quality_report.py
+```
+
+It uses the same GeoPandas conversion and validation functions as the ETL workflow, then writes:
+
+- `data-quality-report.json`
+- `data-quality-report.html`
+
+The report covers duplicate `uid` values, missing required attributes, missing coordinates / null geometries, invalid geometries, and schema drift against the source CSV contract.
 
 ## Artifacts And Response Shape
 

--- a/examples/spatial_query_cookbook.py
+++ b/examples/spatial_query_cookbook.py
@@ -1,0 +1,160 @@
+"""Async spatial query cookbook for Honua protocol surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from honua_sdk import AsyncHonuaClient
+
+DEFAULT_BASE_URL = "http://localhost:8080"
+DEFAULT_SERVICE_ID = "test_service"
+DEFAULT_LAYER_ID = 0
+DEFAULT_BBOX = (-180.0, -90.0, 180.0, 90.0)
+
+
+@dataclass(frozen=True, slots=True)
+class CookbookConfig:
+    service_id: str = DEFAULT_SERVICE_ID
+    layer_id: int = DEFAULT_LAYER_ID
+    collection_id: str = DEFAULT_SERVICE_ID
+    map_service_id: str = DEFAULT_SERVICE_ID
+    stac_collection_id: str | None = None
+    bbox: tuple[float, float, float, float] = DEFAULT_BBOX
+    where: str = "1=1"
+    limit: int = 10
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeResult:
+    name: str
+    protocol: str
+    response_shape: str
+    row_count: int | None
+
+
+async def run_spatial_query_cookbook(client: Any, config: CookbookConfig) -> list[RecipeResult]:
+    results: list[RecipeResult] = []
+
+    feature_bbox = await client.query_features(
+        config.service_id,
+        config.layer_id,
+        where=config.where,
+        out_fields=["*"],
+        return_geometry=True,
+        extra_params={
+            "geometry": ",".join(str(value) for value in config.bbox),
+            "geometryType": "esriGeometryEnvelope",
+            "inSR": "4326",
+            "spatialRel": "esriSpatialRelIntersects",
+            "resultRecordCount": str(config.limit),
+        },
+    )
+    results.append(_json_result("feature-server-bbox", "FeatureServer", feature_bbox, "features"))
+
+    feature_summary = await client.query_features(
+        config.service_id,
+        config.layer_id,
+        where=config.where,
+        out_fields=["objectid"],
+        return_geometry=False,
+        extra_params={"returnCountOnly": "true"},
+    )
+    results.append(_json_result("feature-server-filter-summary", "FeatureServer", feature_summary, "features"))
+
+    ogc_items = await client.ogc_features().collection(config.collection_id).items(
+        limit=config.limit,
+        bbox=list(config.bbox),
+    )
+    results.append(_json_result("ogc-api-features-items", "OGC API Features", ogc_items, "features"))
+
+    if config.stac_collection_id:
+        stac_items = await client.stac().items(
+            config.stac_collection_id,
+            extra_params={"limit": config.limit},
+        )
+        results.append(_json_result("stac-items", "STAC", stac_items, "features"))
+
+    wfs_xml = await client.wfs().get_feature(
+        type_names=config.collection_id,
+        extra_params={"count": config.limit, "bbox": ",".join(str(value) for value in config.bbox)},
+    )
+    results.append(RecipeResult("wfs-get-feature", "WFS", f"xml:{len(wfs_xml)}", None))
+
+    wms_png = await client.wms(config.map_service_id).map(
+        layers=config.collection_id,
+        bbox=list(config.bbox),
+        width=512,
+        height=512,
+    )
+    results.append(RecipeResult("wms-map-export", "WMS", f"bytes:{len(wms_png)}", None))
+
+    wmts_tile = await client.wmts(config.map_service_id).tile(
+        layer=config.collection_id,
+        tile_matrix_set="WebMercatorQuad",
+        tile_matrix="0",
+        tile_row=0,
+        tile_col=0,
+    )
+    results.append(RecipeResult("wmts-tile", "WMTS", f"bytes:{len(wmts_tile)}", None))
+
+    odata_rows = await client.odata().features(
+        layer_id=config.layer_id,
+        extra_params={"$top": str(config.limit)},
+    )
+    results.append(_json_result("odata-features", "OData", odata_rows, "value"))
+
+    return results
+
+
+def build_config_from_env() -> CookbookConfig:
+    service_id = os.getenv("HONUA_SERVICE_ID", DEFAULT_SERVICE_ID)
+    return CookbookConfig(
+        service_id=service_id,
+        layer_id=int(os.getenv("HONUA_LAYER_ID", str(DEFAULT_LAYER_ID))),
+        collection_id=os.getenv("HONUA_COLLECTION_ID", service_id),
+        map_service_id=os.getenv("HONUA_MAP_SERVICE_ID", service_id),
+        stac_collection_id=os.getenv("HONUA_STAC_COLLECTION_ID"),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Honua spatial query cookbook.")
+    parser.add_argument("--base-url", default=os.getenv("HONUA_BASE_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--api-key", default=os.getenv("HONUA_API_KEY"))
+    return parser
+
+
+async def async_main() -> int:
+    args = build_parser().parse_args()
+    config = build_config_from_env()
+    async with AsyncHonuaClient(args.base_url, api_key=args.api_key) as client:
+        results = await run_spatial_query_cookbook(client, config)
+
+    for result in results:
+        count = "n/a" if result.row_count is None else str(result.row_count)
+        print(f"{result.name}: {result.protocol}; {result.response_shape}; rows={count}")
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(async_main())
+
+
+def _json_result(name: str, protocol: str, payload: dict[str, Any], rows_key: str) -> RecipeResult:
+    rows = payload.get(rows_key)
+    row_count = len(rows) if isinstance(rows, list) else None
+    return RecipeResult(name=name, protocol=protocol, response_shape="json", row_count=row_count)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_python_analyst_demos.py
+++ b/tests/test_python_analyst_demos.py
@@ -1,0 +1,152 @@
+"""Tests for Python analyst demo scaffolds."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("geopandas")
+
+from examples import data_quality_report, fastapi_spatial_service, spatial_query_cookbook
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1] / "examples"
+DEMO_CSV = EXAMPLE_DIR / "geospatial_etl" / "data" / "demo_sites.csv"
+
+
+def test_data_quality_report_writes_deterministic_artifacts(tmp_path: Path) -> None:
+    report = data_quality_report.build_data_quality_report(
+        input_path=DEMO_CSV,
+        output_dir=tmp_path,
+    )
+
+    assert report.summary["source_row_count"] == 9
+    assert report.summary["valid_row_count"] == 6
+    assert report.summary["rejected_row_count"] == 3
+    assert report.summary["reason_counts"] == {
+        "duplicate_uid": 1,
+        "missing_coordinates": 1,
+        "missing_required_field:name": 1,
+    }
+    assert report.json_path.exists()
+    assert report.html_path.exists()
+    assert "Honua Data Quality Report" in report.html_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_spatial_query_cookbook_exercises_protocol_patterns() -> None:
+    class FeatureServerClient:
+        async def query_features(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"features": [{"attributes": {"objectid": 1}}]}
+
+    class OgcCollection:
+        async def items(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"features": [{"id": "ogc-1"}]}
+
+    class OgcFeatures:
+        def collection(self, collection_id: str) -> OgcCollection:
+            assert collection_id == "test_service"
+            return OgcCollection()
+
+    class Stac:
+        async def items(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"features": [{"id": "scene-1"}]}
+
+    class Wfs:
+        async def get_feature(self, *args: Any, **kwargs: Any) -> str:
+            return "<wfs />"
+
+    class Wms:
+        async def map(self, *args: Any, **kwargs: Any) -> bytes:
+            return b"png"
+
+    class Wmts:
+        async def tile(self, *args: Any, **kwargs: Any) -> bytes:
+            return b"tile"
+
+    class OData:
+        async def features(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"value": [{"ObjectId": 1}]}
+
+    class FakeClient(FeatureServerClient):
+        def ogc_features(self) -> OgcFeatures:
+            return OgcFeatures()
+
+        def stac(self) -> Stac:
+            return Stac()
+
+        def wfs(self) -> Wfs:
+            return Wfs()
+
+        def wms(self, service_id: str) -> Wms:
+            assert service_id == "test_service"
+            return Wms()
+
+        def wmts(self, service_id: str) -> Wmts:
+            assert service_id == "test_service"
+            return Wmts()
+
+        def odata(self) -> OData:
+            return OData()
+
+    results = await spatial_query_cookbook.run_spatial_query_cookbook(
+        FakeClient(),
+        spatial_query_cookbook.CookbookConfig(stac_collection_id="imagery"),
+    )
+
+    assert [result.name for result in results] == [
+        "feature-server-bbox",
+        "feature-server-filter-summary",
+        "ogc-api-features-items",
+        "stac-items",
+        "wfs-get-feature",
+        "wms-map-export",
+        "wmts-tile",
+        "odata-features",
+    ]
+    assert results[0].row_count == 1
+    assert results[5].response_shape == "bytes:3"
+
+
+@pytest.mark.anyio
+async def test_fastapi_service_helpers_build_query_and_summary() -> None:
+    seen: dict[str, Any] = {}
+
+    class FakeClient:
+        async def query_features(self, service_id: str, layer_id: int, **kwargs: Any) -> dict[str, Any]:
+            seen["service_id"] = service_id
+            seen["layer_id"] = layer_id
+            seen.update(kwargs)
+            return {
+                "features": [
+                    {"attributes": {"status": "active"}},
+                    {"attributes": {"status": "active"}},
+                    {"attributes": {"status": "needs review"}},
+                ]
+            }
+
+    settings = fastapi_spatial_service.ServiceSettings(service_id="incidents", layer_id=2)
+    response = await fastapi_spatial_service.fetch_features(
+        FakeClient(),
+        settings,
+        bbox=(-158.0, 21.0, -157.0, 22.0),
+        where="status <> 'closed'",
+        limit=25,
+    )
+
+    assert seen["service_id"] == "incidents"
+    assert seen["layer_id"] == 2
+    assert seen["where"] == "status <> 'closed'"
+    assert seen["extra_params"]["geometry"] == "-158.0,21.0,-157.0,22.0"
+    assert seen["extra_params"]["resultRecordCount"] == "25"
+    assert fastapi_spatial_service.summarize_feature_response(response) == {
+        "feature_count": 3,
+        "status_counts": {"active": 2, "needs review": 1},
+    }
+
+
+def test_fastapi_bbox_parser_validates_shape() -> None:
+    assert fastapi_spatial_service._parse_bbox("-158,21,-157,22") == (-158.0, 21.0, -157.0, 22.0)
+    with pytest.raises(ValueError, match="four comma-separated"):
+        fastapi_spatial_service._parse_bbox("-158,21,-157")


### PR DESCRIPTION
## Summary

- adds a Python analyst demo-suite index and docs
- adds GeoPandas data quality report scaffold with JSON/HTML artifacts
- adds spatial query cookbook scaffold across FeatureServer, OGC, STAC, WFS, WMS, WMTS, and OData
- adds FastAPI async service scaffold backed by `AsyncHonuaClient`
- adds focused tests for the new examples

## User Impact

Python users get analyst-first demos for ETL, data quality, protocol exploration, and async service development without forcing JS/mobile feature parity.

Refs honua-sdk-python#47
Refs honua-sdk-js#55

## Validation

- `python3.11 -m pytest tests/test_geospatial_etl_example.py tests/test_python_analyst_demos.py`
- `python3.11 -m ruff check examples/data_quality_report.py examples/spatial_query_cookbook.py examples/fastapi_spatial_service.py tests/test_python_analyst_demos.py`
- `python3.11 -m py_compile examples/data_quality_report.py examples/spatial_query_cookbook.py examples/fastapi_spatial_service.py`
- `git diff --check`

## Notes

STAC/imagery scoring remains gated on stable fixture data.
