### PR TITLE
Add gRPC to the shared canonical contract

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -2933,7 +2933,7 @@
         "DEFAULT_CAPABILITIES": {
           "kind": "constant",
           "type": "dict",
-          "value": "{'geoservices-feature-service': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'applyEdits', 'attachments', 'sql', 'stream', 'pbf', 'connect'), 'geoservices-map-service': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'render', 'tiles', 'sql', 'stream'), 'geoservices-image-service': ('query', 'queryExtent', 'queryObjectIds', 'image', 'render', 'tiles', 'connect'), 'geoservices-geometry-service': ('geometry', 'connect'), 'geoservices-gp-service': ('geoprocess', 'connect'), 'ogc-features': ('query', 'queryObjectIds', 'applyEdits', 'stream'), 'ogc-tiles': ('render', 'tiles'), 'ogc-maps': ('render',), 'stac': ('query', 'queryObjectIds', 'stream'), 'wfs': ('query', 'queryExtent', 'queryObjectIds', 'applyEdits', 'stream'), 'wms': ('render', 'tiles', 'query'), 'wmts': ('render', 'tiles'), 'odata': ('query', 'queryObjectIds', 'stream', 'applyEdits'), 'maplibre-vector': ('render', 'tiles'), 'maplibre-raster': ('render', 'tiles'), 'maplibre-geojson': ('render',)}"
+          "value": "{'grpc': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'applyEdits', 'stream'), 'geoservices-feature-service': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'applyEdits', 'attachments', 'sql', 'stream', 'pbf', 'connect'), 'geoservices-map-service': ('query', 'queryAggregate', 'queryExtent', 'queryObjectIds', 'queryRelated', 'render', 'tiles', 'sql', 'stream'), 'geoservices-image-service': ('query', 'queryExtent', 'queryObjectIds', 'image', 'render', 'tiles', 'connect'), 'geoservices-geometry-service': ('geometry', 'connect'), 'geoservices-gp-service': ('geoprocess', 'connect'), 'ogc-features': ('query', 'queryObjectIds', 'applyEdits', 'stream'), 'ogc-tiles': ('render', 'tiles'), 'ogc-maps': ('render',), 'stac': ('query', 'queryObjectIds', 'stream'), 'wfs': ('query', 'queryExtent', 'queryObjectIds', 'applyEdits', 'stream'), 'wms': ('render', 'tiles', 'query'), 'wmts': ('render', 'tiles'), 'odata': ('query', 'queryObjectIds', 'stream', 'applyEdits'), 'maplibre-vector': ('render', 'tiles'), 'maplibre-raster': ('render', 'tiles'), 'maplibre-geojson': ('render',)}"
         },
         "DataPlaneCapabilities": {
           "fields": [
@@ -3989,7 +3989,7 @@
         "PROTOCOLS": {
           "kind": "constant",
           "type": "tuple",
-          "value": "('geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson')"
+          "value": "('grpc', 'geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson')"
         },
         "PROTOCOL_ALIASES": {
           "kind": "constant",
@@ -4033,7 +4033,7 @@
         "Protocol": {
           "kind": "constant",
           "type": "_UnionGenericAlias",
-          "value": "typing.Union[typing.Literal['geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson'], str]"
+          "value": "typing.Union[typing.Literal['grpc', 'geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson'], str]"
         },
         "Query": {
           "fields": [
@@ -4150,7 +4150,7 @@
         "QueryProtocol": {
           "kind": "constant",
           "type": "_UnionGenericAlias",
-          "value": "typing.Union[typing.Literal['geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson'], str]"
+          "value": "typing.Union[typing.Literal['grpc', 'geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson'], str]"
         },
         "RefreshableBearerTokenProvider": {
           "kind": "class",

--- a/docs/core-client.md
+++ b/docs/core-client.md
@@ -83,8 +83,8 @@ with HonuaClient("https://honua.example") as client:
 ```
 
 The source facade uses canonical cross-SDK protocol ids such as
-`geoservices-feature-service`, `ogc-features`, `stac`, and `odata`; common
-aliases such as `feature-server` and `ogc_api_features` are accepted. Python
+`grpc`, `geoservices-feature-service`, `ogc-features`, `stac`, and `odata`;
+common aliases such as `feature-server` and `ogc_api_features` are accepted. Python
 uses snake_case for query fields (`out_fields`, `return_geometry`,
 `query_all()`), while TypeScript and .NET use their idiomatic casing.
 `SourceDescriptor.supports(...)` reflects protocol-advertised capabilities;

--- a/docs/protocol-parity.md
+++ b/docs/protocol-parity.md
@@ -7,6 +7,7 @@ protocol adapters.
 | --- | --- | --- | --- |
 | Shared Source/Query/Result | `client.source(...)`, `SourceDescriptor`, `Query`, `Result` | Aligned by fixture | Canonical source-bound facade with Pythonic snake_case names and protocol escape hatch. |
 | Shared feature query | `client.query(...)`, `client.iter_query(...)` | Legacy compact helper | Normalized `QueryFeature` output spans FeatureServer, OGC API Features, STAC, and OData. |
+| gRPC FeatureService | `honua_sdk.grpc.HonuaGrpcClient`, `HonuaGrpcAsyncClient` | Canonical shared protocol id | Generated FeatureService client with unary and streaming query helpers; `grpc` is included in the shared semantic fixture/default capability registry. |
 | GeoServices FeatureServer | `client.feature_server(id)`, `query_features`, `apply_edits` | Partial | Read/query/edit, metadata, typed query pages, and item iterators are available. |
 | GeoServices MapServer | `client.map_server(id)`, `export_map` | Partial | Metadata, export, identify, and tile helpers are available. |
 | GeoServices ImageServer | `client.image_server(id)` | New in Python | Metadata, exportImage, identify, query, tile, and legend helpers are available. |

--- a/packages/honua-sdk/honua_sdk/models.py
+++ b/packages/honua-sdk/honua_sdk/models.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, TypeAlias
 
 Protocol: TypeAlias = Literal[
+    "grpc",
     "geoservices-feature-service",
     "geoservices-map-service",
     "geoservices-image-service",
@@ -46,6 +47,7 @@ Capability: TypeAlias = Literal[
 QueryProtocol: TypeAlias = Protocol
 
 PROTOCOLS = (
+    "grpc",
     "geoservices-feature-service",
     "geoservices-map-service",
     "geoservices-image-service",
@@ -106,6 +108,14 @@ CAPABILITIES = (
 )
 
 DEFAULT_CAPABILITIES: Mapping[str, tuple[str, ...]] = {
+    "grpc": (
+        "query",
+        "queryAggregate",
+        "queryExtent",
+        "queryObjectIds",
+        "applyEdits",
+        "stream",
+    ),
     "geoservices-feature-service": (
         "query",
         "queryAggregate",

--- a/tests/fixtures/sdk-contract/semantic-contract.v1.json
+++ b/tests/fixtures/sdk-contract/semantic-contract.v1.json
@@ -60,6 +60,7 @@
     }
   ],
   "protocols": [
+    "grpc",
     "geoservices-feature-service",
     "geoservices-map-service",
     "geoservices-image-service",
@@ -117,6 +118,14 @@
     "processes"
   ],
   "defaultCapabilities": {
+    "grpc": [
+      "query",
+      "queryAggregate",
+      "queryExtent",
+      "queryObjectIds",
+      "applyEdits",
+      "stream"
+    ],
     "geoservices-feature-service": [
       "query",
       "queryAggregate",


### PR DESCRIPTION
Closes #51.\n\n## Summary\n- adds grpc to the canonical Protocol type, PROTOCOLS tuple, and semantic contract fixture\n- mirrors the shared default capability set from honua-io/honua-sdk-dotnet#145\n- updates core-client and protocol parity docs for the dedicated gRPC client\n\n## Tests\n- PYTHONPATH=packages/honua-sdk /home/makani/.local/bin/python3.11 -m pytest tests/test_sdk_contract.py