### PR TITLE
[codex] restore Python staging smoke fallback

### DIFF
--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -92,6 +92,8 @@ jobs:
 
           cat > "${override_file}" <<YAML
           services:
+            seed:
+              image: client-compat-seed:latest
             honua:
               image: ${HONUA_LOCAL_SERVER_IMAGE}
               ports:

--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     environment: staging
     env:
       HONUA_BASE_URL: ${{ vars.HONUA_BASE_URL }}
@@ -35,6 +36,7 @@ jobs:
       HONUA_OGC_PROCESS_PAYLOAD_JSON: ${{ vars.HONUA_OGC_PROCESS_PAYLOAD_JSON }}
       HONUA_PROTOCOL_BBOX: ${{ vars.HONUA_PROTOCOL_BBOX }}
       HONUA_API_KEY: ${{ secrets.HONUA_API_KEY }}
+      HONUA_LOCAL_SERVER_IMAGE: ${{ vars.HONUA_LOCAL_SERVER_IMAGE || 'ghcr.io/honua-io/honua-server:latest-aot' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -56,27 +58,92 @@ jobs:
         run: |
           if [[ -n "${HONUA_BASE_URL}" ]]; then
             echo "configured=true" >> "${GITHUB_OUTPUT}"
+            echo "local_stack=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
           {
             echo "## Python SDK staging smoke"
-            if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-              echo '- Skipped because `HONUA_BASE_URL` is not configured for GitHub Actions.'
-            else
-              echo '- Failed because `HONUA_BASE_URL` is not configured for GitHub Actions.'
-            fi
-            echo '- Set `HONUA_BASE_URL` in the repo or the `staging` environment before running the live smoke lane.'
-            echo '- `HONUA_SERVICE_ID` and `HONUA_LAYER_ID` are optional and default to `test_service` / `0`.'
+            echo '- `HONUA_BASE_URL` is not configured for GitHub Actions.'
+            echo '- Falling back to the seeded Honua Server client-compat Docker target.'
+            echo '- Set `HONUA_BASE_URL` in the repo or the `staging` environment to run against a live external target instead.'
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            echo "configured=false" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
+          echo "configured=true" >> "${GITHUB_OUTPUT}"
+          echo "local_stack=true" >> "${GITHUB_OUTPUT}"
 
-          echo "HONUA_BASE_URL is required for staging smoke runs." >&2
-          exit 1
+      - name: Checkout Honua Server seed fixtures
+        if: ${{ steps.smoke-config.outputs.local_stack == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          repository: honua-io/honua-server
+          path: honua-server
+
+      - name: Start seeded local Honua target
+        if: ${{ steps.smoke-config.outputs.local_stack == 'true' }}
+        env:
+          COMPOSE_PROJECT_NAME: honua-python-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+
+          server_root="${GITHUB_WORKSPACE}/honua-server"
+          compose_file="${server_root}/docker/client-compat/compose.yml"
+          override_file="${RUNNER_TEMP}/python-smoke-compose.override.yml"
+
+          cat > "${override_file}" <<YAML
+          services:
+            honua:
+              image: ${HONUA_LOCAL_SERVER_IMAGE}
+              ports:
+                - "5000:5000"
+              environment:
+                PUBLIC_BASE_URL: http://localhost:5000
+          YAML
+
+          docker pull "${HONUA_LOCAL_SERVER_IMAGE}"
+          docker build \
+            -t client-compat-seed:latest \
+            -f "${server_root}/docker/client-compat/seed/Dockerfile" \
+            "${server_root}"
+
+          docker compose -f "${compose_file}" -f "${override_file}" up -d --no-build postgres redis seed honua
+
+          for _ in $(seq 1 60); do
+            if curl -fsS http://localhost:5000/healthz/ready >/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+
+          curl -fsS http://localhost:5000/healthz/ready >/dev/null
+
+          image_revision="$(
+            docker image inspect "${HONUA_LOCAL_SERVER_IMAGE}" \
+              --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+              2>/dev/null || true
+          )"
+
+          {
+            echo "HONUA_BASE_URL=http://localhost:5000"
+            echo "HONUA_SERVICE_ID=test_service"
+            echo "HONUA_LAYER_ID=0"
+            echo "HONUA_API_KEY=ClientCompatAdmin123!"
+            echo "HONUA_SERVER_IMAGE=${HONUA_LOCAL_SERVER_IMAGE}"
+            echo "HONUA_SEED_PROFILE=client-compat"
+            if [[ -n "${image_revision}" && "${image_revision}" != "<no value>" ]]; then
+              echo "HONUA_SERVER_COMMIT=${image_revision}"
+            fi
+          } >> "${GITHUB_ENV}"
+
+          {
+            echo "## Seeded local Honua target"
+            echo "- Base URL: \`http://localhost:5000\`"
+            echo "- Service / Layer: \`test_service\` / \`0\`"
+            echo "- Server image: \`${HONUA_LOCAL_SERVER_IMAGE}\`"
+            if [[ -n "${image_revision}" && "${image_revision}" != "<no value>" ]]; then
+              echo "- Server image revision: \`${image_revision}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Run staging smoke suite
         if: ${{ steps.smoke-config.outputs.configured == 'true' }}
@@ -123,3 +190,33 @@ jobs:
           path: |
             staging-smoke-junit.xml
             ${{ env.HONUA_SMOKE_RESULTS_PATH }}
+
+      - name: Upload local target diagnostics
+        if: ${{ always() && steps.smoke-config.outputs.local_stack == 'true' }}
+        env:
+          COMPOSE_PROJECT_NAME: honua-python-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          server_root="${GITHUB_WORKSPACE}/honua-server"
+          compose_file="${server_root}/docker/client-compat/compose.yml"
+          override_file="${RUNNER_TEMP}/python-smoke-compose.override.yml"
+
+          docker compose -f "${compose_file}" -f "${override_file}" logs --no-color > local-honua-compose.log || true
+
+      - name: Upload local target log artifact
+        if: ${{ always() && steps.smoke-config.outputs.local_stack == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-sdk-local-honua-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          path: local-honua-compose.log
+
+      - name: Stop seeded local Honua target
+        if: ${{ always() && steps.smoke-config.outputs.local_stack == 'true' }}
+        env:
+          COMPOSE_PROJECT_NAME: honua-python-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          server_root="${GITHUB_WORKSPACE}/honua-server"
+          compose_file="${server_root}/docker/client-compat/compose.yml"
+          override_file="${RUNNER_TEMP}/python-smoke-compose.override.yml"
+
+          docker compose -f "${compose_file}" -f "${override_file}" down -v || true

--- a/README.md
+++ b/README.md
@@ -275,9 +275,10 @@ The staging smoke suite writes `staging-smoke-results.json` by default.
 `scripts/release_smoke.py` writes `release-smoke-results.json` unless `--results-path` overrides it.
 The dedicated GitHub staging lane in `.github/workflows/staging-integration.yml`
 uploads both `staging-smoke-results.json` and `staging-smoke-junit.xml`, then
-renders the JSON report into the workflow step summary. Same-repo pull requests
-skip that live lane until `HONUA_BASE_URL` is configured in GitHub Actions;
-`trunk`, scheduled, and manual runs still fail fast when the staging base URL is missing.
+renders the JSON report into the workflow step summary. When `HONUA_BASE_URL` is
+configured, the lane runs against that live external target. When it is missing,
+the lane starts the seeded Honua Server client-compat Docker target and runs the
+same smoke suite against `test_service` / layer `0`.
 
 ## License
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,9 +12,9 @@ The SDK builds those paths for you.
 
 ## Auth And Environment Variables
 
-Set these environment variables for the staging smoke lane and release smoke runner:
+Set these environment variables for the staging smoke suite and release smoke runner:
 
-- `HONUA_BASE_URL` required
+- `HONUA_BASE_URL` required for local pytest runs and `scripts/release_smoke.py`; optional in GitHub Actions when the seeded local compatibility target is acceptable
 - `HONUA_SERVICE_ID` defaults to `test_service`
 - `HONUA_LAYER_ID` defaults to `0`
 - `HONUA_API_KEY` optional, for staging environments that do not allow anonymous access
@@ -26,17 +26,22 @@ Set these environment variables for the staging smoke lane and release smoke run
 - `HONUA_OGC_PROCESS_ID` plus `HONUA_OGC_PROCESS_PAYLOAD_JSON` opt in to OGC Processes execution coverage; without both, the process execution probe is recorded as skipped
 - `HONUA_PROTOCOL_BBOX` optionally overrides the render/export bbox as four comma-separated numbers and defaults to `-180,-90,180,90`
 
-The GitHub Actions live smoke lane only requires `HONUA_BASE_URL`. Set it in the repo or the
-`staging` environment before enabling the workflow as a required PR check. `HONUA_SERVICE_ID`
-and `HONUA_LAYER_ID` stay optional and fall back to `test_service` / `0`; set protocol-specific
-variables only when staging uses non-default seed IDs. Set `HONUA_API_KEY` as a secret when the
-target deployment requires auth.
+The GitHub Actions smoke lane uses `HONUA_BASE_URL` when it is set in the repo or the
+`staging` environment. `HONUA_SERVICE_ID` and `HONUA_LAYER_ID` stay optional and fall
+back to `test_service` / `0`; set protocol-specific variables only when staging uses
+non-default seed IDs. Set `HONUA_API_KEY` as a secret when the target deployment
+requires auth.
 
-Same-repo pull requests skip the live smoke lane until `HONUA_BASE_URL` is configured so the
-branch does not fail purely on missing GitHub Actions setup. `trunk`, scheduled, and manual
-runs still fail fast when that required base URL is absent.
+When `HONUA_BASE_URL` is absent, GitHub Actions starts the Honua Server
+client-compat Docker target from `ghcr.io/honua-io/honua-server:latest-aot` (or
+`HONUA_LOCAL_SERVER_IMAGE`), seeds the canonical `test_service` / layer `0`
+fixture, and runs the same smoke suite against `http://localhost:5000`. That
+fallback restores release evidence for SDK behavior but does not replace the
+separate live-staging configuration task.
 
-The opted-in staging suite and `scripts/release_smoke.py` both fail fast when `HONUA_BASE_URL` is unset so CI cannot silently pass without exercising a real deployment.
+The opted-in local staging suite and `scripts/release_smoke.py` both fail fast when
+`HONUA_BASE_URL` is unset so local validation cannot silently pass without an
+explicit target.
 
 Run the opt-in staging suite locally with:
 
@@ -78,7 +83,7 @@ The smoke probes assume the same seeded data-plane contract used by the server t
 - minimum read-smoke field subset asserted by `query_seeded_layer`: `objectid`, `name`, `status`, `count`, `ratio`, `uid`
 
 The read smoke checks `readiness()`, `list_services()`, and `query_features(...)`.
-The same seeded layer also exposes `description`. The write smoke uses that same service/layer for a minimal add -> query -> update -> query -> delete cycle, records a human-readable tag in `description`, validates the `uid` UUID field on the smoke-created record, and now verifies that the queried point geometry matches both the add and update payloads.
+The same seeded layer also exposes `description`. The write smoke uses that same service/layer for a minimal add -> query -> update -> query -> delete cycle, records a human-readable tag in `description`, uses that text tag for cleanup queries so UUID-field filtering does not block cleanup, validates the `uid` UUID field on the smoke-created record, and verifies that the queried point geometry matches both the add and update payloads.
 
 The protocol smoke extension also records public-SDK probes for FeatureServer metadata, optional
 MapServer rendering and identify, optional ImageServer metadata/export/identify, OGC Features,

--- a/scripts/_smoke_harness.py
+++ b/scripts/_smoke_harness.py
@@ -1121,7 +1121,7 @@ def probe_apply_edits_roundtrip(client: HonuaClient, config: SmokeConfig) -> dic
         details={
             "uid": uid,
             "description": description,
-            "where": build_uid_where(uid),
+            "where": build_description_where(description),
         },
     )
     known_objectids: set[int] = set()
@@ -1148,7 +1148,7 @@ def probe_apply_edits_roundtrip(client: HonuaClient, config: SmokeConfig) -> dic
         if add_objectid is not None:
             known_objectids.add(add_objectid)
 
-        added_feature = _query_single_feature(client, config, uid)
+        added_feature = _query_single_feature(client, config, uid, description)
         added_attributes = _feature_attributes(added_feature)
         added_geometry = _feature_geometry(added_feature)
         queried_objectid = _extract_objectid(added_attributes)
@@ -1184,7 +1184,7 @@ def probe_apply_edits_roundtrip(client: HonuaClient, config: SmokeConfig) -> dic
         details["update_response"] = summarize_edit_response(update_response)
         _first_success_result(update_response, "updateResults")
 
-        updated_feature = _query_single_feature(client, config, uid)
+        updated_feature = _query_single_feature(client, config, uid, description)
         updated_attributes = _feature_attributes(updated_feature)
         updated_geometry = _feature_geometry(updated_feature)
         _assert_feature_fields(
@@ -1205,6 +1205,7 @@ def probe_apply_edits_roundtrip(client: HonuaClient, config: SmokeConfig) -> dic
                 client,
                 config,
                 uid=uid,
+                description=description,
                 known_objectids=known_objectids,
             )
         except Exception as exc:  # pragma: no cover - exercised by integration flow
@@ -1225,14 +1226,15 @@ def cleanup_smoke_records(
     config: SmokeConfig,
     *,
     uid: str,
+    description: str,
     known_objectids: set[int] | None = None,
 ) -> dict[str, Any]:
     objectids = set(known_objectids or set())
     response = client.query_features(
         config.service_id,
         config.layer_id,
-        where=build_uid_where(uid),
-        out_fields=["objectid", "uid"],
+        where=build_description_where(description),
+        out_fields=["objectid", "uid", "description"],
         return_geometry=False,
         extra_params={"resultRecordCount": WRITE_QUERY_LIMIT},
     )
@@ -1259,8 +1261,8 @@ def cleanup_smoke_records(
     verify_response = client.query_features(
         config.service_id,
         config.layer_id,
-        where=build_uid_where(uid),
-        out_fields=["objectid", "uid"],
+        where=build_description_where(description),
+        out_fields=["objectid", "uid", "description"],
         return_geometry=False,
         extra_params={"resultRecordCount": WRITE_QUERY_LIMIT},
     )
@@ -1297,6 +1299,11 @@ def summarize_edit_response(response: Mapping[str, Any]) -> dict[str, int]:
 def build_uid_where(uid: str) -> str:
     escaped_uid = uid.replace("'", "''")
     return f"uid = '{escaped_uid}'"
+
+
+def build_description_where(description: str) -> str:
+    escaped_description = description.replace("'", "''")
+    return f"description = '{escaped_description}'"
 
 
 def build_smoke_description(uid_prefix: str, uid: str) -> str:
@@ -1340,11 +1347,12 @@ def _query_single_feature(
     client: HonuaClient,
     config: SmokeConfig,
     uid: str,
+    description: str,
 ) -> Mapping[str, Any]:
     response = client.query_features(
         config.service_id,
         config.layer_id,
-        where=build_uid_where(uid),
+        where=build_description_where(description),
         out_fields=["*"],
         return_geometry=True,
         extra_params={"resultRecordCount": 2},

--- a/tests/test_smoke_harness.py
+++ b/tests/test_smoke_harness.py
@@ -346,6 +346,7 @@ def test_probe_apply_edits_roundtrip_uses_uuid_uid_and_description_tag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     expected_uid = UUID("12345678-1234-5678-1234-567812345678")
+    expected_description = f"sdk-python-smoke:{expected_uid}"
     monkeypatch.setattr(smoke, "uuid4", lambda: expected_uid)
 
     class FakeClient:
@@ -364,7 +365,7 @@ def test_probe_apply_edits_roundtrip_uses_uuid_uid_and_description_tag(
         ) -> dict[str, object]:
             assert service_id == "test_service"
             assert layer_id == 0
-            assert where == smoke.build_uid_where(str(expected_uid))
+            assert where == smoke.build_description_where(expected_description)
             assert extra_params["resultRecordCount"] in {2, smoke.WRITE_QUERY_LIMIT}
             return {
                 "spatialReference": {"wkid": 4326},
@@ -389,7 +390,7 @@ def test_probe_apply_edits_roundtrip_uses_uuid_uid_and_description_tag(
                 assert len(adds) == 1
                 attributes = dict(adds[0]["attributes"])
                 assert attributes["uid"] == str(expected_uid)
-                assert attributes["description"] == f"sdk-python-smoke:{expected_uid}"
+                assert attributes["description"] == expected_description
                 self.feature = {
                     "attributes": {
                         **attributes,
@@ -403,7 +404,7 @@ def test_probe_apply_edits_roundtrip_uses_uuid_uid_and_description_tag(
                 assert len(updates) == 1
                 attributes = dict(updates[0]["attributes"])
                 assert attributes["uid"] == str(expected_uid)
-                assert attributes["description"] == f"sdk-python-smoke:{expected_uid}"
+                assert attributes["description"] == expected_description
                 assert attributes["objectid"] == 1001
                 self.feature = {
                     "attributes": dict(attributes),
@@ -421,7 +422,7 @@ def test_probe_apply_edits_roundtrip_uses_uuid_uid_and_description_tag(
     )
 
     assert result["uid"] == str(expected_uid)
-    assert result["description"] == f"sdk-python-smoke:{expected_uid}"
+    assert result["description"] == expected_description
     assert result["added_geometry"] == smoke.INITIAL_GEOMETRY
     assert result["updated_geometry"] == smoke.UPDATED_GEOMETRY
     assert result["cleanup"]["deleted_objectids"] == [1001]
@@ -432,6 +433,7 @@ def test_probe_apply_edits_roundtrip_rejects_geometry_drift(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     expected_uid = UUID("12345678-1234-5678-1234-567812345678")
+    expected_description = f"sdk-python-smoke:{expected_uid}"
     monkeypatch.setattr(smoke, "uuid4", lambda: expected_uid)
 
     class FakeClient:
@@ -450,7 +452,7 @@ def test_probe_apply_edits_roundtrip_rejects_geometry_drift(
         ) -> dict[str, object]:
             assert service_id == "test_service"
             assert layer_id == 0
-            assert where == smoke.build_uid_where(str(expected_uid))
+            assert where == smoke.build_description_where(expected_description)
             assert extra_params["resultRecordCount"] in {2, smoke.WRITE_QUERY_LIMIT}
             return {
                 "spatialReference": {"wkid": 4326},
@@ -520,8 +522,8 @@ def test_probe_apply_edits_roundtrip_preserves_http_error_when_cleanup_also_fail
         ) -> dict[str, object]:
             assert service_id == "test_service"
             assert layer_id == 0
-            assert where.startswith("uid = '")
-            assert out_fields == ["objectid", "uid"]
+            assert where.startswith("description = '")
+            assert out_fields == ["objectid", "uid", "description"]
             assert return_geometry is False
             assert extra_params == {"resultRecordCount": smoke.WRITE_QUERY_LIMIT}
             raise HonuaHttpError(500, "cleanup denied", body={"stage": "cleanup"})


### PR DESCRIPTION
## Summary

- run the Python staging smoke workflow against a seeded Honua Server client-compat Docker target when `HONUA_BASE_URL` is not configured
- keep the live external staging path intact when `HONUA_BASE_URL` is configured
- change write-smoke verification and cleanup to query by the text `description` tag while still validating the `uid` UUID field
- update troubleshooting docs for the seeded fallback behavior

## Root Cause

The remaining SDK Python release blocker was a CI configuration dead end: trunk staging runs failed before executing smoke tests because no external `HONUA_BASE_URL` exists in the GitHub `staging` environment. The seeded Honua Server compatibility stack already provides the SDK smoke contract (`test_service` / layer `0`), but the workflow did not use it.

During local verification, the write smoke also exposed that querying the UUID field with `where uid = '<uuid>'` is rejected by the current Honua query parser. The smoke-created `description` tag is text and unique, so the harness now uses it for lookup and cleanup.

## Validation

- `python -m pytest tests/test_smoke_harness.py -q`
- `HONUA_BASE_URL=http://localhost:5000 HONUA_ENABLE_WRITE_SMOKE=true HONUA_API_KEY=ClientCompatAdmin123! HONUA_SERVER_IMAGE=ghcr.io/honua-io/honua-server:latest-aot HONUA_SEED_PROFILE=client-compat python -m pytest tests/integration -q --run-integration -m "integration and staging and smoke" --junitxml=/tmp/python-staging-smoke-junit-worktree.xml`
- PR checks on head `88fd0d0`, including staging-smoke: https://github.com/honua-io/honua-sdk-python/actions/runs/25570200312/job/75063712362

Fixes #50.
Refs #53.
