### PR TITLE
feat(cli): add honua CLI (services/layers/style apply) for SDK parity with JS

### DIFF
--- a/packages/honua-sdk/honua_sdk/cli.py
+++ b/packages/honua-sdk/honua_sdk/cli.py
@@ -1,0 +1,255 @@
+"""``honua`` command-line interface.
+
+A thin, dependency-free (stdlib :mod:`argparse`) CLI that mirrors the core
+browse/list/style surface of the JS ``@honua/sdk-js`` CLI on top of the
+existing :class:`honua_sdk.HonuaClient`. It deliberately stays inside what the
+data-plane client already supports and invents no server features.
+
+Commands
+--------
+``honua services``
+    Browse the GeoServices catalog (service / dataset browse). Mirrors the JS
+    CLI service-explorer surface via :meth:`HonuaClient.list_service_summaries`.
+
+``honua layers SERVICE_ID``
+    List the layers and tables (sources) advertised by a FeatureServer's
+    metadata document. Mirrors the JS layer / source listing via
+    :meth:`HonuaClient.feature_server`.
+
+``honua style apply SERVICE_ID``
+    Render a MapServer ``export`` image applying a named renderer/style. This
+    is the closest capability the data-plane client exposes to the JS CLI's
+    ``style apply``; the bytes are written to ``--out`` (or stdout). It relies
+    on :meth:`HonuaClient.export_map`.
+
+The base URL is read from ``--base-url`` or the ``HONUA_BASE_URL`` environment
+variable; an optional API key from ``--api-key`` or ``HONUA_API_KEY``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from . import __version__
+from .client import HonuaClient
+from .errors import HonuaError
+
+if TYPE_CHECKING:
+    from .models import ServiceSummary
+
+_ENV_BASE_URL = "HONUA_BASE_URL"
+_ENV_API_KEY = "HONUA_API_KEY"
+
+
+def _resolve_base_url(args: argparse.Namespace) -> str:
+    base_url = args.base_url or os.environ.get(_ENV_BASE_URL)
+    if not base_url:
+        raise SystemExit(
+            f"error: a base URL is required (pass --base-url or set {_ENV_BASE_URL})",
+        )
+    return base_url
+
+
+def _resolve_api_key(args: argparse.Namespace) -> str | None:
+    return args.api_key or os.environ.get(_ENV_API_KEY)
+
+
+def _make_client(args: argparse.Namespace) -> HonuaClient:
+    return HonuaClient(_resolve_base_url(args), api_key=_resolve_api_key(args))
+
+
+def _emit_json(payload: Any, out: Any) -> None:
+    json.dump(payload, out, indent=2, default=str)
+    out.write("\n")
+
+
+def _service_rows(summaries: Sequence[ServiceSummary]) -> list[dict[str, Any]]:
+    return [{"name": s.name, "type": s.type, "url": s.url} for s in summaries]
+
+
+def _print_table(rows: Sequence[dict[str, Any]], columns: Sequence[str], out: Any) -> None:
+    if not rows:
+        out.write("(no entries)\n")
+        return
+    widths = {col: len(col) for col in columns}
+    for row in rows:
+        for col in columns:
+            widths[col] = max(widths[col], len(str(row.get(col, "") or "")))
+    header = "  ".join(col.ljust(widths[col]) for col in columns)
+    out.write(header.rstrip() + "\n")
+    out.write("  ".join("-" * widths[col] for col in columns) + "\n")
+    for row in rows:
+        out.write("  ".join(str(row.get(col, "") or "").ljust(widths[col]) for col in columns).rstrip() + "\n")
+
+
+def _layer_rows(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for kind in ("layers", "tables"):
+        for entry in metadata.get(kind) or []:
+            if not isinstance(entry, dict):
+                continue
+            rows.append(
+                {
+                    "id": entry.get("id"),
+                    "name": entry.get("name"),
+                    "type": entry.get("type") or ("Table" if kind == "tables" else None),
+                    "geometryType": entry.get("geometryType"),
+                }
+            )
+    return rows
+
+
+def _cmd_services(args: argparse.Namespace, out: Any) -> int:
+    with _make_client(args) as client:
+        summaries = client.list_service_summaries()
+    rows = _service_rows(summaries)
+    if args.format == "table":
+        _print_table(rows, ["name", "type", "url"], out)
+    else:
+        _emit_json(rows, out)
+    return 0
+
+
+def _cmd_layers(args: argparse.Namespace, out: Any) -> int:
+    with _make_client(args) as client:
+        metadata = client.feature_server(args.service_id).metadata()
+    rows = _layer_rows(metadata)
+    if args.format == "table":
+        _print_table(rows, ["id", "name", "type", "geometryType"], out)
+    else:
+        _emit_json(rows, out)
+    return 0
+
+
+def _cmd_style_apply(args: argparse.Namespace, out: Any) -> int:
+    extra_params: dict[str, Any] = {}
+    if args.style is not None:
+        # MapServer/dynamicLayers carry the named renderer; forward it verbatim
+        # so the server applies the style during rendering.
+        extra_params["style"] = args.style
+    if args.layers is not None:
+        extra_params["layers"] = args.layers
+    with _make_client(args) as client:
+        image = client.export_map(
+            args.service_id,
+            args.bbox,
+            image_format=args.image_format,
+            extra_params=extra_params or None,
+        )
+    if args.out is None or args.out == "-":
+        sys.stdout.buffer.write(image)
+    else:
+        with open(args.out, "wb") as handle:
+            handle.write(image)
+        out.write(f"wrote {len(image)} bytes to {args.out}\n")
+    return 0
+
+
+def _add_common_connection_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help=f"Honua server base URL (or set {_ENV_BASE_URL}).",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help=f"API key for authentication (or set {_ENV_API_KEY}).",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``honua`` argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="honua",
+        description="Command-line interface for the Honua geospatial platform.",
+    )
+    parser.add_argument("--version", action="version", version=f"honua {__version__}")
+    subparsers = parser.add_subparsers(dest="command", metavar="<command>")
+
+    # honua services
+    services = subparsers.add_parser(
+        "services",
+        help="List services in the GeoServices catalog (service/dataset browse).",
+    )
+    _add_common_connection_args(services)
+    services.add_argument("--format", choices=("json", "table"), default="json")
+    services.set_defaults(func=_cmd_services)
+
+    # honua layers SERVICE_ID
+    layers = subparsers.add_parser(
+        "layers",
+        help="List a FeatureServer's layers and tables (layer/source list).",
+    )
+    _add_common_connection_args(layers)
+    layers.add_argument("service_id", help="Catalog service identifier.")
+    layers.add_argument("--format", choices=("json", "table"), default="json")
+    layers.set_defaults(func=_cmd_layers)
+
+    # honua style apply SERVICE_ID
+    style = subparsers.add_parser("style", help="Style operations.")
+    style_sub = style.add_subparsers(dest="style_command", metavar="<subcommand>")
+    style_apply = style_sub.add_parser(
+        "apply",
+        help="Render a map applying a named style (MapServer export).",
+    )
+    _add_common_connection_args(style_apply)
+    style_apply.add_argument("service_id", help="Catalog service identifier.")
+    style_apply.add_argument(
+        "--bbox",
+        required=True,
+        help="Bounding box 'xmin,ymin,xmax,ymax'.",
+    )
+    style_apply.add_argument(
+        "--style",
+        default=None,
+        help="Named style / renderer to apply during rendering.",
+    )
+    style_apply.add_argument(
+        "--layers",
+        default=None,
+        help="Optional layers selector forwarded to the export request.",
+    )
+    style_apply.add_argument("--image-format", default="png", help="Output image format (default: png).")
+    style_apply.add_argument(
+        "--out",
+        default=None,
+        help="Output file path for the rendered image ('-' or omit for stdout).",
+    )
+    style_apply.set_defaults(func=_cmd_style_apply)
+    style.set_defaults(func=_dispatch_style)
+
+    return parser
+
+
+def _dispatch_style(args: argparse.Namespace, out: Any) -> int:
+    # ``honua style`` with no subcommand: show help for the style group.
+    out.write("error: 'style' requires a subcommand (apply)\n")
+    return 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``honua`` console script."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func = getattr(args, "func", None)
+    if func is None:
+        parser.print_help()
+        return 2
+    try:
+        result = func(args, sys.stdout)
+    except SystemExit:
+        raise
+    except HonuaError as exc:
+        sys.stderr.write(f"error: {exc}\n")
+        return 1
+    return int(result)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/packages/honua-sdk/pyproject.toml
+++ b/packages/honua-sdk/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
   "httpx>=0.27.0",
 ]
 
+[project.scripts]
+honua = "honua_sdk.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/honua-io"
 Repository = "https://github.com/honua-io/honua-sdk-python"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from honua_sdk import HonuaClient
+from honua_sdk import cli
+
+
+def _client_with_handler(handler: Any) -> HonuaClient:
+    return HonuaClient("http://example.test", transport=httpx.MockTransport(handler))
+
+
+@pytest.fixture
+def patch_client(monkeypatch: pytest.MonkeyPatch):
+    """Return a helper that wires a MockTransport-backed client into the CLI."""
+
+    def _install(handler: Any) -> None:
+        monkeypatch.setattr(cli, "_make_client", lambda _args: _client_with_handler(handler))
+
+    return _install
+
+
+def test_services_json_output(patch_client: Any) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/services"
+        return httpx.Response(
+            200,
+            json={
+                "services": [
+                    {"name": "roads", "type": "FeatureServer", "url": "/rest/services/roads/FeatureServer"},
+                    {"name": "imagery", "type": "MapServer"},
+                ]
+            },
+        )
+
+    patch_client(handler)
+    out = io.StringIO()
+    rc = cli._cmd_services(_ns(format="json"), out)
+    assert rc == 0
+    parsed = json.loads(out.getvalue())
+    assert parsed == [
+        {"name": "roads", "type": "FeatureServer", "url": "/rest/services/roads/FeatureServer"},
+        {"name": "imagery", "type": "MapServer", "url": None},
+    ]
+
+
+def test_services_table_output(patch_client: Any) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"services": [{"name": "roads", "type": "FeatureServer"}]})
+
+    patch_client(handler)
+    out = io.StringIO()
+    rc = cli._cmd_services(_ns(format="table"), out)
+    assert rc == 0
+    text = out.getvalue()
+    assert "name" in text
+    assert "roads" in text
+    assert "FeatureServer" in text
+
+
+def test_layers_lists_layers_and_tables(patch_client: Any) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/services/roads/FeatureServer"
+        return httpx.Response(
+            200,
+            json={
+                "layers": [{"id": 0, "name": "Highways", "type": "Feature Layer", "geometryType": "esriGeometryPolyline"}],
+                "tables": [{"id": 1, "name": "Inspections"}],
+            },
+        )
+
+    patch_client(handler)
+    out = io.StringIO()
+    rc = cli._cmd_layers(_ns(service_id="roads", format="json"), out)
+    assert rc == 0
+    parsed = json.loads(out.getvalue())
+    assert parsed == [
+        {"id": 0, "name": "Highways", "type": "Feature Layer", "geometryType": "esriGeometryPolyline"},
+        {"id": 1, "name": "Inspections", "type": "Table", "geometryType": None},
+    ]
+
+
+def test_style_apply_writes_image(tmp_path: Any, patch_client: Any) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["query"] = dict(request.url.params.multi_items())
+        return httpx.Response(200, content=b"\x89PNG-bytes")
+
+    patch_client(handler)
+    out_path = tmp_path / "render.png"
+    out = io.StringIO()
+    rc = cli._cmd_style_apply(
+        _ns(
+            service_id="basemap",
+            bbox="0,0,1,1",
+            style="night",
+            layers="show:0",
+            image_format="png",
+            out=str(out_path),
+        ),
+        out,
+    )
+    assert rc == 0
+    assert out_path.read_bytes() == b"\x89PNG-bytes"
+    assert "MapServer/export" in captured["path"]
+    assert captured["query"]["style"] == "night"
+    assert captured["query"]["layers"] == "show:0"
+
+
+def test_main_returns_2_for_no_command() -> None:
+    assert cli.main([]) == 2
+
+
+def test_main_handles_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "boom"})
+
+    monkeypatch.setattr(cli, "_make_client", lambda _args: _client_with_handler(handler))
+    rc = cli.main(["services", "--base-url", "http://example.test"])
+    assert rc == 1
+
+
+def test_resolve_base_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HONUA_BASE_URL", "http://env.test")
+    args = _ns()
+    args.base_url = None
+    assert cli._resolve_base_url(args) == "http://env.test"
+
+
+def test_resolve_base_url_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HONUA_BASE_URL", raising=False)
+    args = _ns()
+    args.base_url = None
+    with pytest.raises(SystemExit):
+        cli._resolve_base_url(args)
+
+
+def test_build_parser_exposes_commands() -> None:
+    parser = cli.build_parser()
+    ns = parser.parse_args(["services", "--base-url", "http://x"])
+    assert ns.func is cli._cmd_services
+
+
+def test_style_without_subcommand_returns_2() -> None:
+    rc = cli._dispatch_style(_ns(), io.StringIO())
+    assert rc == 2
+
+
+class _Namespace:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+def _ns(**kwargs: Any) -> Any:
+    defaults: dict[str, Any] = {"base_url": "http://example.test", "api_key": None}
+    defaults.update(kwargs)
+    return _Namespace(**defaults)


### PR DESCRIPTION
## Summary
Adds a `honua` command-line interface to the Python SDK (`packages/honua-sdk/honua_sdk/cli.py`) with `services`, `layers`, and `style apply` subcommands, plus a console-script entry point in `pyproject.toml`.

## Why
This closes a cross-SDK parity gap: the JS SDK already ships a CLI, but the Python SDK had none. Python users now get the same command-line workflow.

## Changes
- New `honua_sdk/cli.py` with services/layers/style-apply commands
- `pyproject.toml` console-script entry point
- `tests/test_cli.py` coverage

## Base
Targets `feat/1198-python-scene-client` (the scene-client base branch this work sits on top of, not yet merged to trunk). Contains exactly one commit relative to that base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)