### PR TITLE
docs(examples): async FastAPI service example + GeoPandas round-trip spatial test

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ The checked-in examples target the seeded `test_service` layer used by local Hon
 | Data quality report | Analyst reviewing source defects before load | `honua-sdk[geopandas]` | `python examples/data_quality_report.py` | `data-quality-report.json`, `data-quality-report.html` |
 | Spatial query cookbook | Developer or analyst comparing protocol query patterns | core SDK, optional `honua-sdk[geopandas]` for conversions | `python examples/spatial_query_cookbook.py` | printed response-shape summary |
 | FastAPI spatial service | App developer exposing async Honua-backed API routes | `fastapi`, `uvicorn` | `uvicorn examples.fastapi_spatial_service:create_app --factory --reload` | local `/features` and `/summary` routes |
+| Async feature service | App developer fronting Honua with a pooled async client | `fastapi`, `uvicorn` | `uvicorn examples.async_feature_service.service:create_app --factory --reload` | local `/services` and `/features` routes |
 | Protocol clients | SDK developer checking protocol wrappers | core SDK, optional `honua-sdk[grpc]` and `honua-sdk[geopandas]` | `python examples/protocol_clients.py` | printed protocol response examples |
 
 ## Validation

--- a/examples/async_feature_service/README.md
+++ b/examples/async_feature_service/README.md
@@ -1,0 +1,81 @@
+# Async Feature Service Demo
+
+A minimal FastAPI service backed by `AsyncHonuaClient`. It shows the async
+pattern an app developer would use to put a thin HTTP API in front of a Honua
+deployment:
+
+- `GET /services` — lists the GeoServices catalog as typed `ServiceSummary`
+  rows via `AsyncHonuaClient.list_service_summaries()`.
+- `GET /features` — runs a feature query through the canonical
+  `client.source(...).query(...)` facade, returning normalized typed features.
+- `GET /healthz` — liveness check.
+
+The app shares **one** long-lived `AsyncHonuaClient` across requests through the
+FastAPI lifespan. The client owns an `httpx` connection pool, so opening a client
+per request would discard that pooling. This is the difference from the simpler
+`examples/fastapi_spatial_service.py` scaffold, which opens a short-lived client
+per request for illustrative purposes.
+
+See [../README.md](../README.md) for the shared demo-suite cloud environment
+contract, and [../../docs/troubleshooting.md](../../docs/troubleshooting.md) for
+staging base URL, auth, and seeded-service guidance.
+
+## Prerequisites
+
+- Python 3.11+
+- A running Honua server (defaults to `http://localhost:8080`)
+
+## Install
+
+From the repo root:
+
+```bash
+pip install -e "packages/honua-sdk" fastapi uvicorn
+```
+
+## Run
+
+```bash
+uvicorn examples.async_feature_service.service:create_app --factory --reload
+```
+
+The service reads the shared demo environment contract:
+
+- base URL: `HONUA_BASE_URL` (default `http://localhost:8080`)
+- service id: `HONUA_SERVICE_ID` (default `test_service`)
+- layer id: `HONUA_LAYER_ID` (default `0`)
+- optional API key: `HONUA_API_KEY`
+
+## Try the routes
+
+```bash
+# List catalog services
+curl 'http://localhost:8000/services'
+
+# Query features (optionally filtered by attribute and/or bbox)
+curl 'http://localhost:8000/features?where=1%3D1&limit=10'
+curl 'http://localhost:8000/features?bbox=-158,21,-157,22'
+```
+
+`bbox` is `minx,miny,maxx,maxy` in EPSG:4326. An invalid bbox returns HTTP 422.
+
+## What this demonstrates
+
+- `AsyncHonuaClient` used as an async context manager over a service lifespan
+- `client.list_service_summaries()` returning typed `ServiceSummary` rows
+- `client.source(...).query(Query(...))` returning a typed `Result`
+- framework-free helpers (`fetch_features`, `list_services`,
+  `serialize_features`, `serialize_services`) that are unit-testable against a
+  fake client without standing up an ASGI server
+
+## Validation
+
+The helpers and the ASGI routes are covered by:
+
+```bash
+pytest tests/test_async_feature_service_example.py
+```
+
+The route test uses `httpx.ASGITransport` with a stubbed client injected into
+`app.state`, so it runs without a live Honua server. It is skipped automatically
+when `fastapi` is not installed.

--- a/examples/async_feature_service/__init__.py
+++ b/examples/async_feature_service/__init__.py
@@ -1,0 +1,1 @@
+"""Async FastAPI feature-service example package."""

--- a/examples/async_feature_service/service.py
+++ b/examples/async_feature_service/service.py
@@ -1,0 +1,183 @@
+"""Async FastAPI service backed by :class:`AsyncHonuaClient`.
+
+This demo exposes two read-only routes that an app developer would realistically
+put in front of a Honua deployment:
+
+* ``GET /services`` lists the GeoServices catalog as typed
+  :class:`~honua_sdk.ServiceSummary` rows via
+  :meth:`AsyncHonuaClient.list_service_summaries`.
+* ``GET /features`` runs a feature query through the canonical
+  ``client.source(...).query(...)`` facade so returned features are normalized
+  typed objects rather than raw GeoServices dicts.
+
+The app shares a single long-lived ``AsyncHonuaClient`` across requests via the
+FastAPI lifespan, which is the pattern you want in a real service: the client
+owns an ``httpx`` connection pool, so opening one per request would throw that
+pooling away.
+
+Run it locally with::
+
+    uvicorn examples.async_feature_service.service:create_app --factory --reload
+
+The helper functions (:func:`fetch_features`, :func:`list_services`,
+:func:`serialize_features`, :func:`serialize_services`) are deliberately
+framework-free so they can be unit-tested against a fake client without
+standing up an ASGI server. See ``tests/test_async_feature_service_example.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+import os
+from typing import Any, cast
+
+from honua_sdk import (
+    AsyncHonuaClient,
+    Query,
+    Result,
+    ServiceSummary,
+    SourceDescriptor,
+    SourceLocator,
+)
+
+DEFAULT_BASE_URL = "http://localhost:8080"
+DEFAULT_SERVICE_ID = "test_service"
+DEFAULT_LAYER_ID = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceSettings:
+    """Runtime configuration for the async feature service."""
+
+    base_url: str = DEFAULT_BASE_URL
+    service_id: str = DEFAULT_SERVICE_ID
+    layer_id: int = DEFAULT_LAYER_ID
+    api_key: str | None = None
+
+
+def settings_from_env() -> ServiceSettings:
+    """Build :class:`ServiceSettings` from the shared demo-suite env contract."""
+    return ServiceSettings(
+        base_url=os.getenv("HONUA_BASE_URL", DEFAULT_BASE_URL),
+        service_id=os.getenv("HONUA_SERVICE_ID", DEFAULT_SERVICE_ID),
+        layer_id=int(os.getenv("HONUA_LAYER_ID", str(DEFAULT_LAYER_ID))),
+        api_key=os.getenv("HONUA_API_KEY"),
+    )
+
+
+def _source_for(client: Any, settings: ServiceSettings) -> Any:
+    return client.source(
+        SourceDescriptor(
+            id=settings.service_id,
+            protocol="geoservices-feature-service",
+            locator=SourceLocator(service_id=settings.service_id, layer_id=settings.layer_id),
+        )
+    )
+
+
+async def fetch_features(
+    client: Any,
+    settings: ServiceSettings,
+    *,
+    bbox: tuple[float, float, float, float] | None = None,
+    where: str = "1=1",
+    limit: int = 100,
+) -> Result[Any]:
+    """Query the configured layer through the typed source facade."""
+    source = _source_for(client, settings)
+    result = await source.query(
+        Query(
+            where=where,
+            out_fields=["*"],
+            return_geometry=True,
+            bbox=list(bbox) if bbox is not None else None,
+        ),
+        limit=limit,
+    )
+    return cast("Result[Any]", result)
+
+
+async def list_services(client: Any) -> list[ServiceSummary]:
+    """Return the GeoServices catalog as typed summaries."""
+    return cast("list[ServiceSummary]", await client.list_service_summaries())
+
+
+def serialize_features(result: Result[Any]) -> dict[str, Any]:
+    """Render a :class:`Result` as a JSON-safe payload."""
+    return {
+        "feature_count": len(result.features),
+        "features": [
+            {"properties": dict(feature.properties), "geometry": feature.geometry}
+            for feature in result.features
+        ],
+    }
+
+
+def serialize_services(services: list[ServiceSummary]) -> dict[str, Any]:
+    """Render typed service summaries as a JSON-safe payload."""
+    return {
+        "service_count": len(services),
+        "services": [
+            {"name": service.name, "type": service.type, "url": service.url}
+            for service in services
+        ],
+    }
+
+
+def _parse_bbox(value: str) -> tuple[float, float, float, float]:
+    parts = [float(part.strip()) for part in value.split(",")]
+    if len(parts) != 4:
+        raise ValueError("bbox must have four comma-separated numbers: minx,miny,maxx,maxy")
+    minx, miny, maxx, maxy = parts
+    if minx >= maxx or miny >= maxy:
+        raise ValueError("bbox minimums must be less than maximums")
+    return minx, miny, maxx, maxy
+
+
+def create_app(settings: ServiceSettings | None = None) -> Any:
+    """Build the FastAPI app, sharing one ``AsyncHonuaClient`` via lifespan."""
+    from fastapi import FastAPI, HTTPException
+    from fastapi import Query as FastAPIQuery
+
+    app_settings = settings or settings_from_env()
+
+    @asynccontextmanager
+    async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
+        async with AsyncHonuaClient(app_settings.base_url, api_key=app_settings.api_key) as client:
+            app.state.honua_client = client
+            yield
+
+    app = FastAPI(title="Honua Async Feature Service Demo", lifespan=lifespan)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/services")
+    async def services() -> dict[str, Any]:
+        client = app.state.honua_client
+        return serialize_services(await list_services(client))
+
+    @app.get("/features")
+    async def features(
+        bbox: str | None = FastAPIQuery(default=None, description="minx,miny,maxx,maxy in EPSG:4326"),
+        where: str = "1=1",
+        limit: int = FastAPIQuery(default=100, ge=1, le=1000),
+    ) -> dict[str, Any]:
+        try:
+            parsed_bbox = _parse_bbox(bbox) if bbox is not None else None
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        client = app.state.honua_client
+        result = await fetch_features(
+            client,
+            app_settings,
+            bbox=parsed_bbox,
+            where=where,
+            limit=limit,
+        )
+        return serialize_features(result)
+
+    return app

--- a/tests/test_async_feature_service_example.py
+++ b/tests/test_async_feature_service_example.py
@@ -1,0 +1,163 @@
+"""Tests for the async FastAPI feature-service example.
+
+The framework-free helpers are exercised directly against a fake client. The
+ASGI routes are driven through ``httpx.ASGITransport`` with a stubbed
+``AsyncHonuaClient`` injected into ``app.state``, so no live Honua server is
+needed. The route tests skip cleanly when ``fastapi`` is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from examples.async_feature_service import service
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+pytestmark = pytest.mark.anyio
+
+
+# ---------------------------------------------------------------------------
+# Fakes shared across the helper and route tests.
+# ---------------------------------------------------------------------------
+
+
+class FakeFeature:
+    def __init__(self, status: str, geometry: dict[str, Any] | None = None) -> None:
+        self.properties = {"status": status}
+        self.geometry = geometry
+
+
+class FakeResult:
+    def __init__(self, features: list[FakeFeature]) -> None:
+        self.features = features
+
+
+class FakeServiceSummary:
+    def __init__(self, name: str, type_: str | None, url: str | None) -> None:
+        self.name = name
+        self.type = type_
+        self.url = url
+
+
+class FakeAsyncSource:
+    def __init__(self, seen: dict[str, Any]) -> None:
+        self._seen = seen
+
+    async def query(self, query: Any, **kwargs: Any) -> FakeResult:
+        self._seen["where"] = query.where
+        self._seen["bbox"] = query.bbox
+        self._seen["limit"] = kwargs.get("limit")
+        return FakeResult(
+            [FakeFeature("active", {"x": -157.0, "y": 21.0}), FakeFeature("closed")]
+        )
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.seen: dict[str, Any] = {}
+
+    def source(self, descriptor: Any) -> FakeAsyncSource:
+        self.seen["service_id"] = descriptor.locator.service_id
+        self.seen["layer_id"] = descriptor.locator.layer_id
+        return FakeAsyncSource(self.seen)
+
+    async def list_service_summaries(self) -> list[FakeServiceSummary]:
+        return [
+            FakeServiceSummary("test_service", "FeatureServer", "https://h/test_service"),
+            FakeServiceSummary("imagery", "ImageServer", None),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests (framework-free).
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_features_drives_typed_source_query() -> None:
+    client = FakeClient()
+    settings = service.ServiceSettings(service_id="incidents", layer_id=3)
+
+    result = await service.fetch_features(
+        client,
+        settings,
+        bbox=(-158.0, 21.0, -157.0, 22.0),
+        where="status <> 'closed'",
+        limit=25,
+    )
+
+    assert client.seen["service_id"] == "incidents"
+    assert client.seen["layer_id"] == 3
+    assert client.seen["where"] == "status <> 'closed'"
+    assert client.seen["bbox"] == [-158.0, 21.0, -157.0, 22.0]
+    assert client.seen["limit"] == 25
+    assert service.serialize_features(result) == {
+        "feature_count": 2,
+        "features": [
+            {"properties": {"status": "active"}, "geometry": {"x": -157.0, "y": 21.0}},
+            {"properties": {"status": "closed"}, "geometry": None},
+        ],
+    }
+
+
+async def test_list_services_serializes_typed_summaries() -> None:
+    client = FakeClient()
+
+    summaries = await service.list_services(client)
+    payload = service.serialize_services(summaries)
+
+    assert payload == {
+        "service_count": 2,
+        "services": [
+            {"name": "test_service", "type": "FeatureServer", "url": "https://h/test_service"},
+            {"name": "imagery", "type": "ImageServer", "url": None},
+        ],
+    }
+
+
+def test_bbox_parser_validates_shape() -> None:
+    assert service._parse_bbox("-158,21,-157,22") == (-158.0, 21.0, -157.0, 22.0)
+    with pytest.raises(ValueError, match="four comma-separated"):
+        service._parse_bbox("-158,21,-157")
+    with pytest.raises(ValueError, match="minimums must be less than"):
+        service._parse_bbox("0,0,0,0")
+
+
+# ---------------------------------------------------------------------------
+# ASGI route tests via httpx.ASGITransport (no live server, no real client).
+# ---------------------------------------------------------------------------
+
+
+async def test_routes_serve_features_and_services_via_asgi() -> None:
+    pytest.importorskip("fastapi")
+    import httpx
+
+    app = service.create_app(service.ServiceSettings(service_id="test_service", layer_id=0))
+    # Inject the fake client that the lifespan would otherwise create, and skip
+    # lifespan startup so no real AsyncHonuaClient / network client is built.
+    app.state.honua_client = FakeClient()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as http:
+        health = await http.get("/healthz")
+        services = await http.get("/services")
+        features = await http.get("/features", params={"where": "1=1", "limit": 5})
+        bad_bbox = await http.get("/features", params={"bbox": "0,0,0,0"})
+
+    assert health.status_code == 200
+    assert services.status_code == 200
+    assert services.json()["service_count"] == 2
+    assert services.json()["services"][0]["name"] == "test_service"
+
+    assert features.status_code == 200
+    body = features.json()
+    assert body["feature_count"] == 2
+    assert body["features"][0]["properties"]["status"] == "active"
+
+    assert bad_bbox.status_code == 422

--- a/tests/test_geopandas_roundtrip_spatial.py
+++ b/tests/test_geopandas_roundtrip_spatial.py
@@ -1,0 +1,128 @@
+"""GeoPandas round-trip + spatial-workflow integration test.
+
+Exercises a realistic analyst loop end to end:
+
+1. Start from an Esri JSON feature-query response (as ``query_features`` returns).
+2. Convert to a GeoDataFrame with ``features_to_geodataframe``.
+3. Run a real spatial workflow: buffer the points and spatial-join them against
+   zone polygons.
+4. Convert the derived layer back to Esri JSON features with
+   ``geodataframe_to_features`` (the ``apply_edits`` payload shape).
+5. Re-ingest the payload and assert geometric + attribute integrity survived the
+   full round trip.
+
+Skips cleanly when the optional ``geopandas``/``shapely`` extras are absent so
+collection never fails on the core lane.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+gpd = pytest.importorskip("geopandas")
+pytest.importorskip("shapely")
+
+from shapely.geometry import shape as _shapely_shape
+
+from honua_sdk.geopandas import (
+    features_to_geodataframe,
+    geodataframe_to_features,
+)
+
+# A small projected (EPSG:3857-style, metres) point layer so buffer distances are
+# meaningful and areas are exact. Two stations sit inside zone A, one inside zone B.
+STATIONS_RESPONSE: dict = {
+    "spatialReference": {"wkid": 102100, "latestWkid": 3857},
+    "features": [
+        {"attributes": {"objectid": 1, "name": "alpha"}, "geometry": {"x": 10.0, "y": 10.0}},
+        {"attributes": {"objectid": 2, "name": "bravo"}, "geometry": {"x": 30.0, "y": 30.0}},
+        {"attributes": {"objectid": 3, "name": "charlie"}, "geometry": {"x": 130.0, "y": 130.0}},
+    ],
+}
+
+ZONES_RESPONSE: dict = {
+    "spatialReference": {"wkid": 102100, "latestWkid": 3857},
+    "features": [
+        {
+            "attributes": {"zone_id": "A"},
+            "geometry": {"rings": [[[0.0, 0.0], [100.0, 0.0], [100.0, 100.0], [0.0, 100.0], [0.0, 0.0]]]},
+        },
+        {
+            "attributes": {"zone_id": "B"},
+            "geometry": {
+                "rings": [[[100.0, 100.0], [200.0, 100.0], [200.0, 200.0], [100.0, 200.0], [100.0, 100.0]]]
+            },
+        },
+    ],
+}
+
+BUFFER_RADIUS = 5.0
+
+
+def test_buffer_and_spatial_join_roundtrip_preserves_integrity() -> None:
+    stations = features_to_geodataframe(STATIONS_RESPONSE)
+    zones = features_to_geodataframe(ZONES_RESPONSE)
+
+    assert len(stations) == 3
+    # CRS survived the Esri JSON -> GeoDataFrame conversion.
+    assert stations.crs is not None
+    assert stations.crs.to_epsg() == 3857
+
+    # --- Spatial op 1: buffer the point stations into circular footprints. ---
+    buffered = stations.copy()
+    buffered["geometry"] = stations.geometry.buffer(BUFFER_RADIUS)
+    assert (buffered.geometry.geom_type == "Polygon").all()
+    # Buffered area is ~ pi * r^2; default 8-segment quadrant buffer slightly
+    # under-estimates the true circle, so use a tolerant relative check.
+    assert buffered.geometry.area.iloc[0] == pytest.approx(math.pi * BUFFER_RADIUS**2, rel=0.05)
+
+    # --- Spatial op 2: spatial-join buffered footprints onto zone polygons. ---
+    joined = gpd.sjoin(buffered, zones, how="left", predicate="intersects")
+    by_name = {row["name"]: row["zone_id"] for _, row in joined.iterrows()}
+    assert by_name == {"alpha": "A", "bravo": "A", "charlie": "B"}
+
+    # --- Round trip: derived layer -> Esri JSON -> GeoDataFrame again. ---
+    # Drop the join bookkeeping column so the payload mirrors a real write set.
+    out = joined.drop(columns=[c for c in joined.columns if c.startswith("index_")])
+    features = geodataframe_to_features(out)
+
+    assert len(features) == 3
+    # Attributes round-tripped as JSON-safe values, including the joined zone.
+    first = next(f for f in features if f["attributes"]["name"] == "alpha")
+    assert first["attributes"]["zone_id"] == "A"
+    assert first["attributes"]["objectid"] == 1
+    assert "rings" in first["geometry"]
+
+    # Re-ingest and confirm geometry integrity (area preserved within float tol).
+    reloaded = features_to_geodataframe({"features": features})
+    assert len(reloaded) == 3
+
+    original_areas = sorted(out.geometry.area.tolist())
+    reloaded_areas = sorted(reloaded.geometry.area.tolist())
+    for original, restored in zip(original_areas, reloaded_areas, strict=True):
+        assert restored == pytest.approx(original)
+
+    # Geometry shape identity also survives: the alpha footprint contains its seed point.
+    alpha_geom = _shapely_shape(
+        {
+            "type": "Polygon",
+            "coordinates": [[(pt[0], pt[1]) for pt in first["geometry"]["rings"][0]]],
+        }
+    )
+    assert alpha_geom.contains(_shapely_shape({"type": "Point", "coordinates": (10.0, 10.0)}))
+
+
+def test_roundtrip_preserves_attribute_columns_without_geometry_loss() -> None:
+    stations = features_to_geodataframe(STATIONS_RESPONSE)
+
+    features = geodataframe_to_features(stations)
+    reloaded = features_to_geodataframe({"features": features})
+
+    assert sorted(reloaded.columns) == sorted(stations.columns)
+    assert reloaded["name"].tolist() == stations["name"].tolist()
+    assert reloaded["objectid"].tolist() == stations["objectid"].tolist()
+    # Point coordinates are exactly preserved through the round trip.
+    assert reloaded.geometry.x.tolist() == stations.geometry.x.tolist()
+    assert reloaded.geometry.y.tolist() == stations.geometry.y.tolist()


### PR DESCRIPTION
## Summary
Adds an async FastAPI feature-service example and a GeoPandas round-trip spatial test to the Python SDK.

## Changes
- `examples/async_feature_service/` — async FastAPI service example (service.py, README, package init)
- `examples/README.md` — index entry for the new example
- `tests/test_async_feature_service_example.py` — example coverage
- `tests/test_geopandas_roundtrip_spatial.py` — GeoPandas round-trip spatial test

## Base
Targets `feat/1198-python-scene-client` (the scene-client base branch this work sits on top of, not yet merged to trunk). Contains exactly one commit relative to that base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)