### PR TITLE
API/DX polish: client.copy() alias + bearer_token= deprecation (#67)

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -775,6 +775,10 @@
               "kind": "method",
               "signature": "(self) -> 'None'"
             },
+            "copy": {
+              "kind": "method",
+              "signature": "(self, *, timeout: 'float | None' = None, max_retries: 'int | None' = None, base_url: 'str | None' = None) -> \"'AsyncHonuaAdminClient'\""
+            },
             "create_connection": {
               "async": true,
               "kind": "method",
@@ -1119,6 +1123,10 @@
             "close": {
               "kind": "method",
               "signature": "(self) -> 'None'"
+            },
+            "copy": {
+              "kind": "method",
+              "signature": "(self, *, timeout: 'float | None' = None, max_retries: 'int | None' = None, base_url: 'str | None' = None) -> \"'HonuaAdminClient'\""
             },
             "create_connection": {
               "kind": "method",
@@ -3555,6 +3563,10 @@
               "kind": "method",
               "signature": "(self) -> 'None'"
             },
+            "copy": {
+              "kind": "method",
+              "signature": "(self, *, timeout: 'float | None' = None, max_retries: 'int | None' = None, base_url: 'str | None' = None) -> \"'AsyncHonuaClient'\""
+            },
             "elevation": {
               "kind": "method",
               "signature": "(self) -> \"'AsyncElevationClient'\""
@@ -4205,6 +4217,10 @@
             "close": {
               "kind": "method",
               "signature": "(self) -> 'None'"
+            },
+            "copy": {
+              "kind": "method",
+              "signature": "(self, *, timeout: 'float | None' = None, max_retries: 'int | None' = None, base_url: 'str | None' = None) -> \"'HonuaClient'\""
             },
             "elevation": {
               "kind": "method",

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -64,7 +64,9 @@ class AsyncHonuaAdminClient:
 
     Authentication is configured at construction with at most one of
     ``api_key``, ``bearer_token``, or ``auth_provider`` (mutually
-    exclusive). When ``client`` is supplied as a pre-built
+    exclusive). ``bearer_token=`` is **deprecated** (removal in 0.2.x);
+    prefer ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer
+    {token}"})``. When ``client`` is supplied as a pre-built
     :class:`httpx.AsyncClient`, no auth kwargs may be passed — configure
     them on the client instead.
 

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
@@ -20,6 +21,7 @@ from honua_sdk.http import (
     to_transport_error,
     validate_auth_configuration,
     validate_external_client_auth_configuration,
+    warn_deprecated_bearer_token,
 )
 
 from . import _endpoints
@@ -147,6 +149,7 @@ class AsyncHonuaAdminClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        warn_deprecated_bearer_token(bearer_token)
         validate_external_client_auth_configuration(
             client=client,
             api_key=api_key,
@@ -301,16 +304,20 @@ class AsyncHonuaAdminClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            clone = self.__class__(
-                base_url if base_url is not None else self._init_base_url,
-                timeout=effective_timeout,
-                api_key=self._init_api_key,
-                bearer_token=self._init_bearer_token,
-                auth_provider=self._init_auth_provider,
-                follow_redirects=self._init_follow_redirects,
-                transport=self._init_transport,
-                max_retries=self._init_max_retries,
-            )
+            # Suppress the re-fired bearer_token deprecation on the internal
+            # clone path; the caller acknowledged it at original construction.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                clone = self.__class__(
+                    base_url if base_url is not None else self._init_base_url,
+                    timeout=effective_timeout,
+                    api_key=self._init_api_key,
+                    bearer_token=self._init_bearer_token,
+                    auth_provider=self._init_auth_provider,
+                    follow_redirects=self._init_follow_redirects,
+                    transport=self._init_transport,
+                    max_retries=self._init_max_retries,
+                )
             clone._options_timeout = (
                 timeout if timeout is not None else self._options_timeout
             )
@@ -331,6 +338,23 @@ class AsyncHonuaAdminClient:
             max_retries if max_retries is not None else self._options_max_retries
         )
         return clone
+
+    def copy(
+        self,
+        *,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        base_url: str | None = None,
+    ) -> "AsyncHonuaAdminClient":
+        """Alias for :meth:`with_options`.
+
+        Provided for parity with the stripe-python convention. The
+        semantics are identical to :meth:`with_options`; see that method
+        for the full contract.
+        """
+        return self.with_options(
+            timeout=timeout, max_retries=max_retries, base_url=base_url
+        )
 
     def _idempotency_headers(
         self,

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -64,7 +64,9 @@ class HonuaAdminClient:
 
     Authentication is configured at construction with at most one of
     ``api_key``, ``bearer_token``, or ``auth_provider`` (mutually
-    exclusive). When ``client`` is supplied as a pre-built
+    exclusive). ``bearer_token=`` is **deprecated** (removal in 0.2.x);
+    prefer ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer
+    {token}"})``. When ``client`` is supplied as a pre-built
     :class:`httpx.Client`, no auth kwargs may be passed — configure them
     on the client instead.
 

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
@@ -20,6 +21,7 @@ from honua_sdk.http import (
     to_transport_error,
     validate_auth_configuration,
     validate_external_client_auth_configuration,
+    warn_deprecated_bearer_token,
 )
 
 from . import _endpoints
@@ -144,6 +146,7 @@ class HonuaAdminClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        warn_deprecated_bearer_token(bearer_token)
         validate_external_client_auth_configuration(
             client=client,
             api_key=api_key,
@@ -297,16 +300,20 @@ class HonuaAdminClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            clone = self.__class__(
-                base_url if base_url is not None else self._init_base_url,
-                timeout=effective_timeout,
-                api_key=self._init_api_key,
-                bearer_token=self._init_bearer_token,
-                auth_provider=self._init_auth_provider,
-                follow_redirects=self._init_follow_redirects,
-                transport=self._init_transport,
-                max_retries=self._init_max_retries,
-            )
+            # Suppress the re-fired bearer_token deprecation on the internal
+            # clone path; the caller acknowledged it at original construction.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                clone = self.__class__(
+                    base_url if base_url is not None else self._init_base_url,
+                    timeout=effective_timeout,
+                    api_key=self._init_api_key,
+                    bearer_token=self._init_bearer_token,
+                    auth_provider=self._init_auth_provider,
+                    follow_redirects=self._init_follow_redirects,
+                    transport=self._init_transport,
+                    max_retries=self._init_max_retries,
+                )
             clone._options_timeout = (
                 timeout if timeout is not None else self._options_timeout
             )
@@ -327,6 +334,23 @@ class HonuaAdminClient:
             max_retries if max_retries is not None else self._options_max_retries
         )
         return clone
+
+    def copy(
+        self,
+        *,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        base_url: str | None = None,
+    ) -> "HonuaAdminClient":
+        """Alias for :meth:`with_options`.
+
+        Provided for parity with the stripe-python convention. The
+        semantics are identical to :meth:`with_options`; see that method
+        for the full contract.
+        """
+        return self.with_options(
+            timeout=timeout, max_retries=max_retries, base_url=base_url
+        )
 
     def _idempotency_headers(
         self,

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
@@ -48,6 +49,35 @@ def _validate_auth_configuration(
 ) -> None:
     if bearer_token is not None and auth_provider is not None:
         raise ValueError("Provide either `bearer_token` or `auth_provider`, not both.")
+
+
+def _warn_deprecated_bearer_token(
+    bearer_token: str | None,
+    *,
+    stacklevel: int = 3,
+) -> None:
+    """Emit a :class:`DeprecationWarning` when ``bearer_token=`` is used.
+
+    The ``bearer_token=`` constructor kwarg is deprecated in favor of the
+    single ``auth_provider=`` parameter (mirroring the one-auth-parameter
+    convention used by stripe-python / openai-python). Migrate callers to
+    ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer {token}"})``.
+    Scheduled for removal in 0.2.x.
+
+    ``stacklevel`` defaults to 3 so the warning points at the caller's
+    constructor invocation (warn → ``_warn_deprecated_bearer_token`` →
+    ``__init__`` → caller).
+    """
+    if bearer_token is None:
+        return
+    warnings.warn(
+        "The `bearer_token=` constructor argument is deprecated and will be "
+        "removed in 0.2.x. Pass authentication via `auth_provider=` instead, "
+        'e.g. `auth_provider=StaticAuthProvider({"Authorization": f"Bearer '
+        '{token}"})` (StaticAuthProvider is exported from honua_sdk.auth).',
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
 
 
 def _validate_external_client_auth_configuration(

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -97,7 +97,9 @@ class AsyncHonuaClient:
 
     Authentication is configured at construction with at most one of
     ``api_key``, ``bearer_token``, or ``auth_provider`` (mutually
-    exclusive). When ``client`` is supplied as a pre-built
+    exclusive). ``bearer_token=`` is **deprecated** (removal in 0.2.x);
+    prefer ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer
+    {token}"})``. When ``client`` is supplied as a pre-built
     :class:`httpx.AsyncClient`, no auth kwargs may be passed — configure
     them on the client instead.
 

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +20,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    _warn_deprecated_bearer_token,
 )
 from ._query import (
     features_from_geojson_page,
@@ -136,6 +138,7 @@ class AsyncHonuaClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _warn_deprecated_bearer_token(bearer_token)
         _validate_external_client_auth_configuration(
             client=client,
             api_key=api_key,
@@ -286,16 +289,20 @@ class AsyncHonuaClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            clone = self.__class__(
-                base_url if base_url is not None else self._init_base_url,
-                timeout=effective_timeout,
-                api_key=self._init_api_key,
-                bearer_token=self._init_bearer_token,
-                auth_provider=self._init_auth_provider,
-                follow_redirects=self._init_follow_redirects,
-                transport=self._init_transport,
-                max_retries=self._init_max_retries,
-            )
+            # Suppress the re-fired bearer_token deprecation on the internal
+            # clone path; the caller acknowledged it at original construction.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                clone = self.__class__(
+                    base_url if base_url is not None else self._init_base_url,
+                    timeout=effective_timeout,
+                    api_key=self._init_api_key,
+                    bearer_token=self._init_bearer_token,
+                    auth_provider=self._init_auth_provider,
+                    follow_redirects=self._init_follow_redirects,
+                    transport=self._init_transport,
+                    max_retries=self._init_max_retries,
+                )
             clone._options_timeout = (
                 timeout if timeout is not None else self._options_timeout
             )
@@ -316,6 +323,24 @@ class AsyncHonuaClient:
             max_retries if max_retries is not None else self._options_max_retries
         )
         return clone
+
+    def copy(
+        self,
+        *,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        base_url: str | None = None,
+    ) -> "AsyncHonuaClient":
+        """Alias for :meth:`with_options`.
+
+        Provided for parity with the stripe-python convention, where both
+        ``client.copy(...)`` and ``client.with_options(...)`` return a
+        reconfigured clone. The semantics are identical to
+        :meth:`with_options`; see that method for the full contract.
+        """
+        return self.with_options(
+            timeout=timeout, max_retries=max_retries, base_url=base_url
+        )
 
     async def readiness(
         self,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    _warn_deprecated_bearer_token,
 )
 from ._query import (
     features_from_geojson_page,
@@ -135,6 +137,7 @@ class HonuaClient:
         if client is not None and transport is not None:
             raise ValueError("Provide either `client` or `transport`, not both.")
         _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
+        _warn_deprecated_bearer_token(bearer_token)
         _validate_external_client_auth_configuration(
             client=client,
             api_key=api_key,
@@ -288,16 +291,22 @@ class HonuaClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            clone = self.__class__(
-                base_url if base_url is not None else self._init_base_url,
-                timeout=effective_timeout,
-                api_key=self._init_api_key,
-                bearer_token=self._init_bearer_token,
-                auth_provider=self._init_auth_provider,
-                follow_redirects=self._init_follow_redirects,
-                transport=self._init_transport,
-                max_retries=self._init_max_retries,
-            )
+            # The clone re-forwards ``bearer_token`` so the deprecation
+            # warning would re-fire here even though the caller already
+            # acknowledged it at original construction. Suppress it on the
+            # internal clone path; the user only deals with it once.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                clone = self.__class__(
+                    base_url if base_url is not None else self._init_base_url,
+                    timeout=effective_timeout,
+                    api_key=self._init_api_key,
+                    bearer_token=self._init_bearer_token,
+                    auth_provider=self._init_auth_provider,
+                    follow_redirects=self._init_follow_redirects,
+                    transport=self._init_transport,
+                    max_retries=self._init_max_retries,
+                )
             clone._options_timeout = (
                 timeout if timeout is not None else self._options_timeout
             )
@@ -323,6 +332,25 @@ class HonuaClient:
             max_retries if max_retries is not None else self._options_max_retries
         )
         return clone
+
+    def copy(
+        self,
+        *,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        base_url: str | None = None,
+    ) -> "HonuaClient":
+        """Alias for :meth:`with_options`.
+
+        Provided for parity with the stripe-python convention, where both
+        ``client.copy(...)`` and ``client.with_options(...)`` return a
+        reconfigured clone. The semantics (transport sharing vs. an
+        independent clone) are identical to :meth:`with_options`; see that
+        method for the full contract.
+        """
+        return self.with_options(
+            timeout=timeout, max_retries=max_retries, base_url=base_url
+        )
 
     def readiness(
         self,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -96,7 +96,9 @@ class HonuaClient:
 
     Authentication is configured at construction with at most one of
     ``api_key``, ``bearer_token``, or ``auth_provider`` (mutually
-    exclusive). When ``client`` is supplied as a pre-built
+    exclusive). ``bearer_token=`` is **deprecated** (removal in 0.2.x);
+    prefer ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer
+    {token}"})``. When ``client`` is supplied as a pre-built
     :class:`httpx.Client`, no auth kwargs may be passed — configure them
     on the client instead.
 

--- a/packages/honua-sdk/honua_sdk/http.py
+++ b/packages/honua-sdk/honua_sdk/http.py
@@ -26,6 +26,7 @@ HTTP helpers (no leading underscore):
 * :func:`extract_trusted_authority`
 * :func:`validate_auth_configuration`
 * :func:`validate_external_client_auth_configuration`
+* :func:`warn_deprecated_bearer_token`
 * :func:`to_http_error`             — :class:`httpx.Response` → :class:`HonuaHttpError`
 * :func:`to_transport_error`        — :class:`httpx.HTTPError` → :class:`HonuaTransportError`
 * :func:`parse_retry_after`         — accepts seconds-int or HTTP-date
@@ -63,6 +64,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    _warn_deprecated_bearer_token,
 )
 from ._retry import RetryTransport
 from .auth import AuthProvider
@@ -86,6 +88,7 @@ to_http_error = _to_http_error
 to_transport_error = _to_transport_error
 validate_auth_configuration = _validate_auth_configuration
 validate_external_client_auth_configuration = _validate_external_client_auth_configuration
+warn_deprecated_bearer_token = _warn_deprecated_bearer_token
 
 __all__ = [
     "AsyncRetryTransport",
@@ -105,6 +108,7 @@ __all__ = [
     "_to_transport_error",
     "_validate_auth_configuration",
     "_validate_external_client_auth_configuration",
+    "_warn_deprecated_bearer_token",
     "apply_sensitive_auth_headers",
     "build_sensitive_auth_headers",
     "encode_path_segment",
@@ -115,4 +119,5 @@ __all__ = [
     "to_transport_error",
     "validate_auth_configuration",
     "validate_external_client_auth_configuration",
+    "warn_deprecated_bearer_token",
 ]

--- a/tests/test_copy_and_bearer_deprecation.py
+++ b/tests/test_copy_and_bearer_deprecation.py
@@ -1,0 +1,116 @@
+"""Tests for the ``copy()`` alias and the ``bearer_token=`` deprecation.
+
+Both items are ergonomic polish from the A+ grading backlog (issue #67):
+
+* ``copy()`` is a stripe-python-style alias for ``with_options()`` on all
+  four public clients; it must return the same kind of clone with the same
+  transport-sharing semantics.
+* The ``bearer_token=`` constructor kwarg is deprecated in favour of the
+  single ``auth_provider=`` parameter and must emit a ``DeprecationWarning``
+  at construction time (but not on internal ``with_options`` clones).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import httpx
+import pytest
+
+from honua_admin import AsyncHonuaAdminClient, HonuaAdminClient
+from honua_sdk import HonuaClient, StaticAuthProvider
+from honua_sdk.async_client import AsyncHonuaClient
+
+# ---------------------------------------------------------------------------
+# copy() alias
+# ---------------------------------------------------------------------------
+
+
+def test_sync_copy_reuses_parent_transport_like_with_options() -> None:
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={"ok": True}))
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as original:
+        clone = original.copy(timeout=99.0)
+        # Shared-transport clone: identical httpx.Client / connection pool.
+        assert clone._client is original._client
+        assert clone.readiness() == {"ok": True}
+
+
+def test_sync_copy_with_base_url_builds_independent_client() -> None:
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={}))
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as original:
+        clone = original.copy(base_url="http://other.test")
+        try:
+            # Independent clone owns its own client (not the parent's).
+            assert clone._client is not original._client
+            assert clone._base_url == httpx.URL("http://other.test/")
+        finally:
+            clone.close()
+
+
+def test_sync_admin_copy_matches_with_options() -> None:
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={}))
+    with HonuaAdminClient("http://example.test", transport=transport, max_retries=0) as original:
+        clone = original.copy(timeout=99.0)
+        assert clone._client is original._client
+
+
+def test_async_clients_expose_copy() -> None:
+    # ``copy`` is a thin synchronous wrapper around ``with_options`` on the
+    # async clients too; assert it is present and callable without awaiting
+    # network I/O.
+    transport = httpx.MockTransport(lambda _r: httpx.Response(200, json={}))
+    async_client = AsyncHonuaClient("http://example.test", transport=transport, max_retries=0)
+    clone = async_client.copy(timeout=99.0)
+    assert clone._client is async_client._client
+
+    admin = AsyncHonuaAdminClient("http://example.test", transport=transport, max_retries=0)
+    admin_clone = admin.copy(timeout=99.0)
+    assert admin_clone._client is admin._client
+
+
+# ---------------------------------------------------------------------------
+# bearer_token= deprecation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: HonuaClient("http://example.test", bearer_token="t", max_retries=0),
+        lambda: AsyncHonuaClient("http://example.test", bearer_token="t", max_retries=0),
+        lambda: HonuaAdminClient("http://example.test", bearer_token="t", max_retries=0),
+        lambda: AsyncHonuaAdminClient("http://example.test", bearer_token="t", max_retries=0),
+    ],
+)
+def test_bearer_token_emits_deprecation_warning(factory) -> None:  # type: ignore[no-untyped-def]
+    with pytest.warns(DeprecationWarning, match="bearer_token"):
+        client = factory()
+    # The message must steer callers to the supported replacement.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        factory()
+    assert any("auth_provider" in str(w.message) for w in caught)
+    del client
+
+
+def test_auth_provider_does_not_warn() -> None:
+    provider = StaticAuthProvider({"Authorization": "Bearer t"})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        client = HonuaClient("http://example.test", auth_provider=provider, max_retries=0)
+        client.close()
+
+
+def test_with_options_clone_does_not_refire_bearer_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        original = HonuaClient("http://example.test", bearer_token="t", max_retries=0)
+        # One warning so far (original construction).
+        baseline = sum(1 for w in caught if issubclass(w.category, DeprecationWarning))
+        # Internal clone re-forwards bearer_token but must NOT re-warn.
+        clone = original.with_options(base_url="http://other.test")
+        after = sum(1 for w in caught if issubclass(w.category, DeprecationWarning))
+    assert baseline == 1
+    assert after == baseline
+    clone.close()
+    original.close()


### PR DESCRIPTION
## What this does

First slice of the A+ polish backlog in #67, covering two self-contained **API/DX** items:

1. **`client.copy()` ergonomic alias for `with_options()`** on all four public clients (`HonuaClient`, `AsyncHonuaClient`, `HonuaAdminClient`, `AsyncHonuaAdminClient`). Matches the stripe-python convention where both `copy(...)` and `with_options(...)` return a reconfigured clone. `copy()` is a thin wrapper that delegates to `with_options()`, so transport-sharing vs. independent-clone semantics are identical.

2. **Deprecate the `bearer_token=` constructor kwarg.** Stripe/openai-python keep auth to a single parameter; here `bearer_token=` and `auth_provider=` are mutually exclusive at runtime. Construction with `bearer_token=` now emits a `DeprecationWarning` steering callers to `auth_provider=StaticAuthProvider({"Authorization": f"Bearer {token}"})` (helper already exported from `honua_sdk.auth`). Behaviour is unchanged; removal is targeted for 0.2.x. The warning does **not** re-fire on internal `with_options()`/`copy()` clones, which re-forward the stashed token.

A shared `_warn_deprecated_bearer_token` helper lives in `_http.py` and is exposed through the public `honua_sdk.http` surface so `honua-admin` reuses the same message and removal timeline. Class docstrings now flag the deprecation and the public-API compatibility snapshot is refreshed for the new `copy()` method.

## Scope

**First slice** of #67 (the issue is an umbrella backlog of ~16 independent polish items across API/DX, Quality/CI, and Docs). This PR delivers two coherent, low-risk API/DX items end-to-end. Remaining items (sync/async dedup, `models.py`/protocols splits, `mypy strict`, per-symbol docs nav, CI smoke/wheel-contents assertions, changelog depth) are left for follow-up PRs.

Refs #67.

## How it was tested

- New `tests/test_copy_and_bearer_deprecation.py` (10 tests): `copy()` transport-sharing and independent-clone parity with `with_options()` across all four clients; `DeprecationWarning` on `bearer_token=`; `auth_provider=` staying warning-free; and `with_options()` clones not re-firing the warning.
- `ruff check .` — clean.
- `mypy packages/honua-sdk/honua_sdk packages/honua-admin/honua_admin` — clean (47 files).
- Full suite `pytest tests/` with the combined coverage gate — 877 passed, total coverage 94.11% (above the 94% floor).
- `scripts/compatibility_gate.py` — passes with the refreshed public-API snapshot.