### PR TITLE
Add async OGC process job handling to ArcPy migration runner (Refs #59)

### DIFF
--- a/packages/honua-sdk/honua_sdk/migration/__init__.py
+++ b/packages/honua-sdk/honua_sdk/migration/__init__.py
@@ -3,7 +3,14 @@
 from __future__ import annotations
 
 from .arcpy import (
+    JOB_STATUS_ACCEPTED,
+    JOB_STATUS_DISMISSED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_RUNNING,
+    JOB_STATUS_SUCCESSFUL,
     ArcPyCall,
+    ArcPyJobError,
+    ArcPyJobTimeoutError,
     ArcPyMigrationPlan,
     ArcPyProcessExecution,
     ArcPyProcessRunner,
@@ -17,7 +24,14 @@ from .arcpy import (
 )
 
 __all__ = [
+    "JOB_STATUS_ACCEPTED",
+    "JOB_STATUS_DISMISSED",
+    "JOB_STATUS_FAILED",
+    "JOB_STATUS_RUNNING",
+    "JOB_STATUS_SUCCESSFUL",
     "ArcPyCall",
+    "ArcPyJobError",
+    "ArcPyJobTimeoutError",
     "ArcPyMigrationPlan",
     "ArcPyProcessExecution",
     "ArcPyProcessRunner",

--- a/packages/honua-sdk/honua_sdk/migration/arcpy.py
+++ b/packages/honua-sdk/honua_sdk/migration/arcpy.py
@@ -8,6 +8,7 @@ inventory work on developer machines without licensed Esri software.
 from __future__ import annotations
 
 import ast
+import time
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -154,16 +155,88 @@ class ArcPyMigrationPlan:
         }
 
 
+# OGC API - Processes job status values (Part 1, /req/job-list/job-list-success).
+JOB_STATUS_ACCEPTED = "accepted"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_SUCCESSFUL = "successful"
+JOB_STATUS_FAILED = "failed"
+JOB_STATUS_DISMISSED = "dismissed"
+
+_TERMINAL_JOB_STATUSES = frozenset(
+    {JOB_STATUS_SUCCESSFUL, JOB_STATUS_FAILED, JOB_STATUS_DISMISSED}
+)
+_SYNC_COMPLETE_STATUSES = frozenset({JOB_STATUS_SUCCESSFUL, "succeeded", "ok", "complete", "completed"})
+
+
 @dataclass(frozen=True)
 class ArcPyProcessExecution:
-    """Result returned after executing one translated OGC process."""
+    """Result returned after executing one translated OGC process.
+
+    For synchronous execution ``result`` holds the immediate process response
+    and ``job_id``/``status``/``results`` stay ``None``. For asynchronous
+    execution ``job_id`` is the polled job identifier, ``status`` is the final
+    OGC job status, ``result`` is the terminal job status document, and
+    ``results`` is the downloaded results document when the job succeeded.
+    """
 
     translation: ArcPyProcessTranslation
     result: JsonObject
+    job_id: str | None = None
+    status: str | None = None
+    results: JsonObject | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """Return whether the execution reached a successful terminal state."""
+
+        if self.status is None:
+            return _job_status(self.result) in _SYNC_COMPLETE_STATUSES or _job_status(self.result) is None
+        return _normalize_status(self.status) == JOB_STATUS_SUCCESSFUL
+
+    def to_dict(self) -> JsonObject:
+        """Return a JSON-serializable execution evidence record."""
+
+        record: JsonObject = {
+            "translation": self.translation.to_dict(),
+            "result": self.result,
+            "succeeded": self.succeeded,
+        }
+        if self.job_id is not None:
+            record["jobId"] = self.job_id
+        if self.status is not None:
+            record["status"] = self.status
+        if self.results is not None:
+            record["results"] = self.results
+        return record
 
 
 class UnsupportedArcPyCallError(ValueError):
     """Raised when a runner is asked to execute an unsupported ArcPy call."""
+
+
+class ArcPyJobError(RuntimeError):
+    """Raised when a translated process job ends in a failed/dismissed state."""
+
+    def __init__(self, job_id: str | None, status: str, document: JsonObject) -> None:
+        self.job_id = job_id
+        self.status = status
+        self.document = document
+        label = f"job {job_id!r}" if job_id else "process job"
+        super().__init__(f"ArcPy migration {label} ended with status {status!r}.")
+
+
+class ArcPyJobTimeoutError(RuntimeError):
+    """Raised when a translated process job does not reach a terminal state."""
+
+    def __init__(self, job_id: str | None, status: str | None, polls: int) -> None:
+        self.job_id = job_id
+        self.status = status
+        self.polls = polls
+        label = f"job {job_id!r}" if job_id else "process job"
+        super().__init__(
+            f"ArcPy migration {label} did not finish after {polls} poll(s) "
+            f"(last status {status!r})."
+        )
 
 
 @dataclass(frozen=True)
@@ -620,21 +693,82 @@ class ArcPyProcessRunner:
     :class:`honua_sdk.protocols.OgcProcessesClient`.
     """
 
-    def __init__(self, client_or_processes: Any) -> None:
+    def __init__(
+        self,
+        client_or_processes: Any,
+        *,
+        poll_interval: float = 1.0,
+        max_polls: int = 120,
+        sleep: Any = None,
+    ) -> None:
         self._processes = client_or_processes.ogc_processes() if hasattr(client_or_processes, "ogc_processes") else client_or_processes
+        self._poll_interval = poll_interval
+        self._max_polls = max_polls
+        self._sleep = sleep if sleep is not None else _default_sleep
 
     def execute(self, translation: ArcPyProcessTranslation) -> ArcPyProcessExecution:
-        """Execute one translated ArcPy call as an OGC process."""
+        """Execute one translated ArcPy call as a synchronous OGC process."""
 
-        if not translation.process_id:
-            raise UnsupportedArcPyCallError(f"ArcPy call {translation.call.qualified_name!r} does not have a process mapping.")
-        result = self._processes.execute(translation.process_id, translation.payload)
+        process_id, payload = self._execution_args(translation)
+        result = self._processes.execute(process_id, payload)
         return ArcPyProcessExecution(translation=translation, result=result)
 
     def execute_plan(self, plan: ArcPyMigrationPlan) -> tuple[ArcPyProcessExecution, ...]:
-        """Execute all supported translations in plan order."""
+        """Execute all supported translations synchronously, in plan order."""
 
         return tuple(self.execute(translation) for translation in plan.translations)
+
+    def execute_async(self, translation: ArcPyProcessTranslation) -> ArcPyProcessExecution:
+        """Submit a translated call, poll its job, and download results.
+
+        The first response is treated as an OGC API - Processes status document.
+        When it carries a job id, the runner polls ``job(job_id)`` until the job
+        reaches a terminal status, then fetches ``job_results(job_id)`` on
+        success. A synchronous (non-job) response is returned as-is so callers
+        can use a single entry point regardless of server execution mode.
+        """
+
+        process_id, payload = self._execution_args(translation)
+        submission = self._processes.execute(process_id, payload)
+        job_id = _job_id(submission)
+        if job_id is None:
+            # Server ran the process synchronously; no job to poll.
+            return ArcPyProcessExecution(translation=translation, result=submission)
+
+        document = submission
+        status = _normalize_status(_job_status(submission))
+        polls = 0
+        while status not in _TERMINAL_JOB_STATUSES:
+            if polls >= self._max_polls:
+                raise ArcPyJobTimeoutError(job_id, status, polls)
+            self._sleep(self._poll_interval)
+            polls += 1
+            document = self._processes.job(job_id)
+            status = _normalize_status(_job_status(document))
+
+        if status != JOB_STATUS_SUCCESSFUL:
+            raise ArcPyJobError(job_id, status, document)
+
+        results = self._processes.job_results(job_id)
+        return ArcPyProcessExecution(
+            translation=translation,
+            result=document,
+            job_id=job_id,
+            status=status,
+            results=results,
+        )
+
+    def execute_plan_async(self, plan: ArcPyMigrationPlan) -> tuple[ArcPyProcessExecution, ...]:
+        """Execute all supported translations as polled jobs, in plan order."""
+
+        return tuple(self.execute_async(translation) for translation in plan.translations)
+
+    def _execution_args(self, translation: ArcPyProcessTranslation) -> tuple[str, JsonObject]:
+        if not translation.process_id:
+            raise UnsupportedArcPyCallError(
+                f"ArcPy call {translation.call.qualified_name!r} does not have a process mapping."
+            )
+        return translation.process_id, translation.payload
 
 
 def _translate_call(call: ArcPyCall, *, process_id_map: Mapping[str, str]) -> ArcPyProcessTranslation:
@@ -804,6 +938,53 @@ def _node_source(node: ast.AST) -> str:
         return ast.unparse(node)
     except Exception:  # pragma: no cover - ast.unparse should be available on supported Python
         return node.__class__.__name__
+
+
+def _default_sleep(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+def _job_id(document: Any) -> str | None:
+    if not isinstance(document, Mapping):
+        return None
+    for key in ("jobID", "jobId", "job_id", "id"):
+        value = document.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, int):
+            return str(value)
+    return None
+
+
+def _job_status(document: Any) -> str | None:
+    if not isinstance(document, Mapping):
+        return None
+    value = document.get("status")
+    return value if isinstance(value, str) and value else None
+
+
+def _normalize_status(status: str | None) -> str | None:
+    if status is None:
+        return None
+    normalized = status.strip().lower()
+    return _STATUS_ALIASES.get(normalized, normalized)
+
+
+_STATUS_ALIASES: Mapping[str, str] = {
+    "succeeded": JOB_STATUS_SUCCESSFUL,
+    "success": JOB_STATUS_SUCCESSFUL,
+    "complete": JOB_STATUS_SUCCESSFUL,
+    "completed": JOB_STATUS_SUCCESSFUL,
+    "failure": JOB_STATUS_FAILED,
+    "error": JOB_STATUS_FAILED,
+    "dismiss": JOB_STATUS_DISMISSED,
+    "cancelled": JOB_STATUS_DISMISSED,
+    "canceled": JOB_STATUS_DISMISSED,
+    "pending": JOB_STATUS_ACCEPTED,
+    "queued": JOB_STATUS_ACCEPTED,
+    "in_progress": JOB_STATUS_RUNNING,
+    "inprogress": JOB_STATUS_RUNNING,
+}
 
 
 def _camel_to_snake(value: str) -> str:

--- a/tests/test_arcpy_migration.py
+++ b/tests/test_arcpy_migration.py
@@ -5,12 +5,18 @@ from typing import Any
 
 import httpx
 
+import pytest
+
 from honua_sdk import HonuaClient
 from honua_sdk.migration import (
+    ArcPyJobError,
+    ArcPyJobTimeoutError,
     ArcPyProcessRunner,
+    UnsupportedArcPyCallError,
     scan_arcpy_source,
     translate_arcpy_source,
 )
+from honua_sdk.migration.arcpy import ArcPyProcessExecution, ArcPyProcessTranslation
 
 
 ARCPY_SOURCE = """
@@ -117,3 +123,171 @@ def test_scan_arcpy_source_reports_syntax_error_without_importing_arcpy() -> Non
     assert report.calls == ()
     assert report.syntax_error is not None
     assert "line 2" in report.syntax_error
+
+
+def _make_translation(process_id: str = "buffer") -> ArcPyProcessTranslation:
+    plan = translate_arcpy_source(
+        'import arcpy\narcpy.analysis.Buffer("parcels", "parcels_buffer", "10 Meters")'
+    )
+    translation = plan.translations[0]
+    return ArcPyProcessTranslation(
+        call=translation.call,
+        process_id=process_id,
+        payload=translation.payload,
+        notes=translation.notes,
+    )
+
+
+class _JobHandler:
+    """Stateful OGC API - Processes async-job mock transport."""
+
+    def __init__(self, *, status_sequence: list[str], results: dict[str, Any] | None = None, job_id: str = "job-1") -> None:
+        self.status_sequence = status_sequence
+        self.results = results if results is not None else {"outputs": {"result": "https://store/parcels_buffer.json"}}
+        self.job_id = job_id
+        self.requests: list[tuple[str, str]] = []
+        self._poll_index = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.raw_path.decode("ascii").split("?")[0]
+        self.requests.append((request.method, path))
+        if request.method == "POST" and path.endswith("/execution"):
+            return httpx.Response(201, json={"jobID": self.job_id, "status": self.status_sequence[0]})
+        if request.method == "GET" and path.endswith(f"/jobs/{self.job_id}"):
+            self._poll_index += 1
+            index = min(self._poll_index, len(self.status_sequence) - 1)
+            return httpx.Response(200, json={"jobID": self.job_id, "status": self.status_sequence[index]})
+        if request.method == "GET" and path.endswith(f"/jobs/{self.job_id}/results"):
+            return httpx.Response(200, json=self.results)
+        return httpx.Response(404, json={"error": "unexpected"})
+
+
+def test_runner_execute_async_polls_job_until_success_and_downloads_results() -> None:
+    handler = _JobHandler(status_sequence=["accepted", "running", "successful"])
+    slept: list[float] = []
+    translation = _make_translation("buffer")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        runner = ArcPyProcessRunner(client, poll_interval=0.5, sleep=slept.append)
+        execution = runner.execute_async(translation)
+
+    assert execution.job_id == "job-1"
+    assert execution.status == "successful"
+    assert execution.succeeded is True
+    assert execution.results == {"outputs": {"result": "https://store/parcels_buffer.json"}}
+    # submit + 2 polls (running, successful) + results download
+    assert handler.requests == [
+        ("POST", "/ogc/processes/processes/buffer/execution"),
+        ("GET", "/ogc/processes/jobs/job-1"),
+        ("GET", "/ogc/processes/jobs/job-1"),
+        ("GET", "/ogc/processes/jobs/job-1/results"),
+    ]
+    assert slept == [0.5, 0.5]
+
+    evidence = execution.to_dict()
+    assert evidence["jobId"] == "job-1"
+    assert evidence["status"] == "successful"
+    assert evidence["succeeded"] is True
+    assert evidence["results"] == handler.results
+
+
+def test_runner_execute_async_returns_synchronous_response_without_polling() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        # No job id in the body => server executed synchronously.
+        return httpx.Response(200, json={"outputs": {"result": "inline"}})
+
+    translation = _make_translation("buffer")
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        execution = ArcPyProcessRunner(client).execute_async(translation)
+
+    assert execution.job_id is None
+    assert execution.status is None
+    assert execution.results is None
+    assert execution.result == {"outputs": {"result": "inline"}}
+    assert execution.succeeded is True
+
+
+def test_runner_execute_async_raises_on_failed_job() -> None:
+    handler = _JobHandler(status_sequence=["accepted", "failed"])
+    translation = _make_translation("buffer")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        runner = ArcPyProcessRunner(client, sleep=lambda _seconds: None)
+        with pytest.raises(ArcPyJobError) as excinfo:
+            runner.execute_async(translation)
+
+    assert excinfo.value.job_id == "job-1"
+    assert excinfo.value.status == "failed"
+    # No results fetch after a failed job.
+    assert ("GET", "/ogc/processes/jobs/job-1/results") not in handler.requests
+
+
+def test_runner_execute_async_times_out_when_job_never_finishes() -> None:
+    handler = _JobHandler(status_sequence=["accepted", "running"])
+    translation = _make_translation("buffer")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        runner = ArcPyProcessRunner(client, max_polls=3, sleep=lambda _seconds: None)
+        with pytest.raises(ArcPyJobTimeoutError) as excinfo:
+            runner.execute_async(translation)
+
+    assert excinfo.value.polls == 3
+    assert excinfo.value.status == "running"
+
+
+def test_runner_normalizes_vendor_job_status_aliases() -> None:
+    handler = _JobHandler(status_sequence=["queued", "in_progress", "succeeded"])
+    translation = _make_translation("buffer")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        runner = ArcPyProcessRunner(client, sleep=lambda _seconds: None)
+        execution = runner.execute_async(translation)
+
+    assert execution.status == "successful"
+    assert execution.succeeded is True
+
+
+def test_runner_execute_plan_async_runs_all_translations_in_order() -> None:
+    plan = translate_arcpy_source(
+        'import arcpy\n'
+        'arcpy.analysis.Buffer("parcels", "parcels_buffer", "10 Meters")\n'
+        'arcpy.analysis.Clip("parcels_buffer", "district", "parcels_clip")\n'
+    )
+    submitted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.raw_path.decode("ascii").split("?")[0]
+        if request.method == "POST" and path.endswith("/execution"):
+            process_id = path.split("/")[-2]
+            submitted.append(process_id)
+            return httpx.Response(201, json={"jobID": f"job-{process_id}", "status": "accepted"})
+        if path.endswith("/results"):
+            return httpx.Response(200, json={"outputs": {}})
+        job_id = path.split("/")[-1]
+        return httpx.Response(200, json={"jobID": job_id, "status": "successful"})
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        runner = ArcPyProcessRunner(client, sleep=lambda _seconds: None)
+        executions = runner.execute_plan_async(plan)
+
+    assert submitted == ["buffer", "clip"]
+    assert all(execution.succeeded for execution in executions)
+    assert [execution.job_id for execution in executions] == ["job-buffer", "job-clip"]
+
+
+def test_runner_execute_async_rejects_unmapped_translation() -> None:
+    translation = _make_translation(process_id="")
+    runner = ArcPyProcessRunner(object())
+    with pytest.raises(UnsupportedArcPyCallError):
+        runner.execute_async(translation)
+
+
+def test_process_execution_to_dict_for_synchronous_result() -> None:
+    translation = _make_translation("buffer")
+    execution = ArcPyProcessExecution(translation=translation, result={"status": "successful"})
+
+    record = execution.to_dict()
+    assert "jobId" not in record
+    assert "status" not in record
+    assert record["succeeded"] is True
+    assert record["result"] == {"status": "successful"}


### PR DESCRIPTION
## What this does

Implements the **Honua process runner / job-and-result handling** slice of the
ArcPy/Python GP migration work (#59). The scanner, translator, and tool-mapping
table already exist in `honua_sdk.migration.arcpy`; the runner could only fire a
single synchronous `execute` and return whatever the server replied. This PR
teaches `ArcPyProcessRunner` the full OGC API - Processes asynchronous job
lifecycle.

### Changes (`packages/honua-sdk/honua_sdk/migration/arcpy.py`)

- `ArcPyProcessRunner.execute_async()` / `execute_plan_async()`: submit a
  translated call, read the returned status document, poll `job(job_id)` until a
  terminal OGC status, then download `job_results(job_id)` on success. A
  synchronous (non-job) response is returned as-is, so callers use one entry
  point regardless of the server's execution mode.
- `ArcPyProcessExecution` now carries job evidence (`job_id`, `status`,
  `results`), a `succeeded` helper, and a JSON-serializable `to_dict()` suitable
  for migration evidence artifacts.
- Vendor job-status aliases (e.g. `succeeded`, `queued`, `in_progress`) are
  normalized to canonical OGC values (`successful`, `accepted`, `running`).
- New `ArcPyJobError` (failed/dismissed job) and `ArcPyJobTimeoutError`
  (job never reaches a terminal state) raised with the relevant job context.
- Polling is deterministic and injectable via `poll_interval`, `max_polls`, and
  a `sleep` hook, so tests run without real delays.
- New public names exported from `honua_sdk.migration`.

These symbols live under the `honua_sdk.migration` submodule, which is not part
of the compatibility-gate public-API snapshot (`PUBLIC_MODULES`), so no snapshot
churn.

## Scope

First slice of #59 (item 3 in the issue's follow-on split guidance: "Honua
process runner and job/result handling"). The static scanner + inventory,
tool-call mapping/manifest generation, parity evidence, and the optional
licensed ArcPy lane remain as separate follow-on slices. This slice stands on
its own and advances the migration path without over-promising.

## Testing

- `tests/test_arcpy_migration.py`: added MockTransport-driven tests for
  job polling to success + results download, synchronous fast-path, failed-job
  error, poll timeout, vendor status-alias normalization, `execute_plan_async`
  ordering, unmapped-translation rejection, and `to_dict` evidence shape.
- Local (via the shared build lock): `ruff check .` clean, `mypy` clean,
  full `pytest` suite green, combined coverage gate met (`migration/arcpy.py`
  at 99%), and `scripts/compatibility_gate.py` passes.

Refs #59