### PR TITLE
docs: add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Honua Python SDK
 
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-sdk-python/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-sdk-python)
+
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue)](https://honua-io.github.io/honua-sdk-python/)
 
 Monorepo for the Honua Python client libraries. Two independently installable


### PR DESCRIPTION
Adds the public OpenSSF Scorecard badge to the README (score now published via the org security workflow). Part of the Phase 1 security program (honua-compliance #6).