### PR TITLE
fix(security): resolve high-severity CodeQL findings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,11 @@ on:
   pull_request:
     branches: [trunk]
 
+# Least-privilege default for GITHUB_TOKEN; the deploy job escalates to
+# contents/pages write at job level when publishing to gh-pages.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -25,6 +25,11 @@ on:
 env:
   PYTHON_VERSION: "3.11"
 
+# Least-privilege default for GITHUB_TOKEN; the publish jobs escalate to
+# id-token: write at job level for PyPI Trusted Publishing.
+permissions:
+  contents: read
+
 jobs:
   pre-publish-typecheck:
     # Run mypy on the same Python matrix as ci.yml *before* uploading any

--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -15,6 +15,11 @@ env:
   HONUA_SMOKE_RESULTS_PATH: "staging-smoke-results.json"
   HONUA_SMOKE_UID_PREFIX: "sdk-python-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
 
+# Least-privilege default for GITHUB_TOKEN; the staging-smoke job declares the
+# read scopes it needs (contents/packages) at job level.
+permissions:
+  contents: read
+
 jobs:
   staging-smoke:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
## Summary

Adds explicit least-privilege top-level `permissions: contents: read` to the three workflows that previously declared **no top-level `permissions:`** block, leaving `GITHUB_TOKEN` at the repo/org default (potentially read-write). Jobs that genuinely need elevated scopes already declare them at job level, so behaviour is unchanged:

- `docs.yml` — `deploy` job keeps `contents: write` + `pages: write` for the `gh-pages` publish.
- `publish-python-sdk.yml` — `publish-*` jobs keep `id-token: write` for PyPI Trusted Publishing.
- `staging-integration.yml` — `staging-smoke` job keeps its `contents: read` + `packages: read`.

This matches the existing convention already used by `ci.yml`, `conformance.yml`, and `honua-arcpy-eval.yml` (all `contents: read` at top level).

## Triage breakdown (117 open alerts, all from OSSF **Scorecard v5**, none from CodeQL Python source analysis)

| Category | Rule | Count | Sev | Action |
|---|---|---:|---|---|
| (a) Actionable, fixed | `TokenPermissionsID` (no top-level perms) | 3 | high | **Fixed** (docs, publish, staging) |
| (a) Actionable, fixed | `actions/missing-workflow-permissions` | 2 | medium | **Fixed** (docs, publish — same root cause) |
| (a) Required write perms — left as-is | `TokenPermissionsID` | 3 | high | Not changed: `release-please.yml` needs `contents`/`pull-requests: write`; `security.yml` needs `security-events: write`; `docs.yml` deploy job needs `contents`/`pages: write`. Reducing them breaks the workflows. |
| (b) CI hardening / low-impact | `PinnedDependenciesID` (pin actions to SHA) | 104 | medium | Not changed — large churn, separate concern; recommend Dependabot-managed SHA pinning in a follow-up. |
| (c) Repo-posture meta (no file/line) | `CodeReviewID`, `SASTID`, `FuzzingID`, `CITestsID`, `CIIBestPracticesID` | 5 | high/med/low | Not code-fixable in a PR; dismiss/accept in UI. |

**Zero CodeQL findings exist in shipped Python source** (`packages/honua-sdk`, `packages/honua-admin`, `packages/honua-arcpy`) — the entire alert set is GitHub Actions / repo-posture hardening. Dependabot: **0 open alerts**.

## Validation

- All three workflows validated with `yaml.safe_load` (parse OK).
- No Python source touched, so ruff/mypy/pytest gates are unaffected.
- Job-level permission escalations verified intact (deploy/publish/smoke jobs unchanged).

## Remaining for human review / dismissal

- 104 `PinnedDependenciesID` (medium) — pin GitHub Actions to commit SHAs (best done via Dependabot `version-update` + SHA policy; high churn).
- 3 required-write `TokenPermissionsID` (high) — accept/dismiss as "used in tests"/"won't fix" since the write scopes are functionally required.
- 5 Scorecard meta-alerts (no file) — accept/dismiss in the Security UI.