### PR TITLE
fix(sdk): retry, geocoding, and parsing robustness fixes (#103-#107)

### DIFF
--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from collections.abc import Mapping
 from datetime import UTC, datetime
@@ -151,6 +152,11 @@ def parse_retry_after(value: str | None) -> float | None:
     values the returned delay is ``max(0, target - now)`` so a date in
     the past becomes ``0.0``. Returns ``None`` for ``None`` input or any
     value that cannot be parsed as either form.
+
+    Non-finite delta-seconds values (``"inf"``, ``"infinity"``, ``"nan"``,
+    ``"1e400"``) are rejected as unparseable rather than producing an
+    effectively infinite (or instant-retry) sleep. The caller is then free
+    to fall back to bounded exponential backoff.
     """
     if value is None:
         return None
@@ -160,6 +166,13 @@ def parse_retry_after(value: str | None) -> float | None:
     try:
         seconds = float(text)
     except (TypeError, ValueError):
+        seconds = None
+    # Reject inf/-inf/nan: a non-finite ``Retry-After`` would otherwise flow
+    # un-capped into ``time.sleep`` and hang the client forever (or, for
+    # ``nan``, silently coerce to retry-immediately). Treat it as "not a
+    # delta-seconds value" so the HTTP-date branch (also a no-match here)
+    # ultimately yields ``None``.
+    if seconds is not None and not math.isfinite(seconds):
         seconds = None
     if seconds is not None:
         return max(0.0, seconds)

--- a/packages/honua-sdk/honua_sdk/_query.py
+++ b/packages/honua-sdk/honua_sdk/_query.py
@@ -210,6 +210,27 @@ def _first_present(payload: Mapping[str, Any], *keys: str) -> Any:
     return None
 
 
+def _coerce_total_count(raw_total: Any) -> int | None:
+    """Coerce a server-reported total (``numberMatched``/``@odata.count``).
+
+    Accepts a JSON integer, a whole-valued JSON float (e.g. ``1000.0`` — some
+    servers emit totals as floats), or a digit string. ``bool`` is rejected
+    (``True``/``False`` are not meaningful counts even though ``bool`` is an
+    ``int`` subclass). Anything else yields ``None``.
+    """
+    if isinstance(raw_total, bool):
+        return None
+    if isinstance(raw_total, int):
+        return raw_total
+    if isinstance(raw_total, float):
+        if raw_total.is_integer():
+            return int(raw_total)
+        return None
+    if isinstance(raw_total, str) and raw_total.isdigit():
+        return int(raw_total)
+    return None
+
+
 def ogc_pagination_signals(page: Mapping[str, Any] | None) -> tuple[int | None, bool]:
     """Extract ``(total_count, exceeded_transfer_limit)`` from an OGC/STAC page.
 
@@ -221,12 +242,8 @@ def ogc_pagination_signals(page: Mapping[str, Any] | None) -> tuple[int | None, 
     """
     if page is None:
         return None, False
-    total_count: int | None = None
     raw_total = page.get("numberMatched") if isinstance(page, Mapping) else None
-    if isinstance(raw_total, int):
-        total_count = raw_total
-    elif isinstance(raw_total, str) and raw_total.isdigit():
-        total_count = int(raw_total)
+    total_count = _coerce_total_count(raw_total)
     exceeded = _has_next_link(page)
     return total_count, exceeded
 
@@ -239,12 +256,8 @@ def odata_pagination_signals(page: Mapping[str, Any] | None) -> tuple[int | None
     """
     if page is None:
         return None, False
-    total_count: int | None = None
     raw_total = page.get("@odata.count") if isinstance(page, Mapping) else None
-    if isinstance(raw_total, int):
-        total_count = raw_total
-    elif isinstance(raw_total, str) and raw_total.isdigit():
-        total_count = int(raw_total)
+    total_count = _coerce_total_count(raw_total)
     exceeded = bool(page.get("@odata.nextLink")) if isinstance(page, Mapping) else False
     return total_count, exceeded
 

--- a/packages/honua-sdk/honua_sdk/_retry_core.py
+++ b/packages/honua-sdk/honua_sdk/_retry_core.py
@@ -84,13 +84,15 @@ def compute_delay(
     """Return the delay before the next retry, honouring ``Retry-After``.
 
     When ``Retry-After`` is present and parseable (delta-seconds or RFC
-    7231 HTTP-date), the parsed value is returned verbatim and is not
-    jittered. Otherwise the exponential backoff (see
+    7231 HTTP-date), the parsed value is clamped to ``backoff_max`` and
+    returned (un-jittered). Clamping keeps a server-sent header (e.g.
+    ``Retry-After: 86400``) from blocking far longer than the configured
+    ceiling, matching the JS SDK. Otherwise the exponential backoff (see
     :func:`compute_backoff`) is used.
     """
     retry_after = parse_retry_after(response.headers.get("retry-after"))
     if retry_after is not None:
-        return retry_after
+        return min(retry_after, backoff_max)
     return compute_backoff(
         attempt,
         backoff_initial=backoff_initial,

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -191,12 +191,17 @@ class AsyncHonuaClient:
                 auth_provider=auth_provider,
             )
 
-        effective_transport = transport
-        if max_retries > 0:
-            inner = effective_transport or httpx.AsyncHTTPTransport()
-            retry_transport = AsyncRetryTransport(inner, max_retries=max_retries)
-            effective_transport = retry_transport
-            self._retry_methods = retry_transport.retry_methods
+        # Always wrap with ``AsyncRetryTransport`` — even when
+        # ``max_retries == 0``. The transport only retries when its budget is
+        # positive, but it is also the component that consults the per-request
+        # ``honua_max_retries`` override stashed by
+        # ``with_options(max_retries=…)``. Installing it unconditionally is what
+        # lets a client built with ``max_retries=0`` later opt into retries via
+        # ``with_options(max_retries=N)`` instead of silently no-op'ing.
+        inner = transport or httpx.AsyncHTTPTransport()
+        retry_transport = AsyncRetryTransport(inner, max_retries=max_retries)
+        effective_transport: httpx.AsyncBaseTransport = retry_transport
+        self._retry_methods = retry_transport.retry_methods
 
         self._client = httpx.AsyncClient(
             base_url=self._base_url,

--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -20,7 +20,12 @@ from ._http import (
     _validate_external_client_auth_configuration,
 )
 from .auth import AuthProvider
-from .geocoding import GeocodeResult, GeocodeSuggestion, ReverseGeocodeResult
+from .geocoding import (
+    GeocodeResult,
+    GeocodeSuggestion,
+    ReverseGeocodeResult,
+    _extract_location_xy,
+)
 
 
 class AsyncHonuaGeocodingClient:
@@ -147,12 +152,16 @@ class AsyncHonuaGeocodingClient:
 
         results: list[GeocodeResult] = []
         for candidate in data.get("candidates", []):
-            location = candidate.get("location", {})
+            coords = _extract_location_xy(candidate.get("location"))
+            if coords is None:
+                # No usable location: skip rather than emit a (0, 0) result.
+                continue
+            longitude, latitude = coords
             results.append(
                 GeocodeResult(
                     address=candidate.get("address", ""),
-                    longitude=float(location.get("x", 0)),
-                    latitude=float(location.get("y", 0)),
+                    longitude=longitude,
+                    latitude=latitude,
                     score=float(candidate.get("score", 0)),
                     attributes=candidate.get("attributes", {}),
                 )
@@ -204,18 +213,21 @@ class AsyncHonuaGeocodingClient:
             extra_headers=extra_headers,
         )
 
-        if not data.get("address") and not data.get("location"):
-            return None
-
         addr_info = data.get("address", {})
-        location = data.get("location", {})
         match_addr = addr_info.get("Match_addr", "") if isinstance(addr_info, Mapping) else ""
         attributes = dict(addr_info) if isinstance(addr_info, Mapping) else {}
+        coords = _extract_location_xy(data.get("location"))
 
+        # No usable location and no address text means the server returned no
+        # match — surface that as ``None`` rather than a (0, 0) "null island".
+        if coords is None and not match_addr:
+            return None
+
+        longitude, latitude = coords if coords is not None else (0.0, 0.0)
         return ReverseGeocodeResult(
             address=match_addr,
-            longitude=float(location.get("x", 0)),
-            latitude=float(location.get("y", 0)),
+            longitude=longitude,
+            latitude=latitude,
             attributes=attributes,
         )
 

--- a/packages/honua-sdk/honua_sdk/auth.py
+++ b/packages/honua-sdk/honua_sdk/auth.py
@@ -190,6 +190,20 @@ def normalize_auth_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return normalized
 
 
+def _first_present(value: Mapping[str, Any], *keys: str) -> Any:
+    """Return the value for the first key that is present and not ``None``.
+
+    Unlike chained ``or`` lookups, this preserves legitimate falsy values
+    (``0``, ``""``, ``False``): only an absent key or an explicit ``None`` is
+    skipped in favour of the next candidate.
+    """
+    for key in keys:
+        candidate = value.get(key)
+        if candidate is not None:
+            return candidate
+    return None
+
+
 def _coerce_token(value: BearerToken | Mapping[str, Any] | str) -> BearerToken:
     if isinstance(value, BearerToken):
         return value
@@ -198,15 +212,20 @@ def _coerce_token(value: BearerToken | Mapping[str, Any] | str) -> BearerToken:
     if not isinstance(value, Mapping):
         raise TypeError("Token refresh callbacks must return BearerToken, mapping, or string.")
 
-    access_token = value.get("access_token") or value.get("accessToken") or value.get("token")
+    access_token = _first_present(value, "access_token", "accessToken", "token")
     if not isinstance(access_token, str):
         raise ValueError("Token mapping must include an access_token string.")
 
+    # ``token_type`` falls back to ``"Bearer"`` when absent or empty:
+    # ``BearerToken`` forbids an empty ``token_type``, so an empty value is a
+    # missing one for our purposes.
     token_type = value.get("token_type") or value.get("tokenType") or "Bearer"
     if not isinstance(token_type, str):
         raise ValueError("Token mapping token_type must be a string.")
 
-    expires_at = value.get("expires_at") or value.get("expiresAt")
+    # Use sentinel-aware lookups so a legitimate ``0`` epoch (treated as a
+    # concrete expiry) is not discarded by ``or``-style falsy coercion.
+    expires_at = _first_present(value, "expires_at", "expiresAt")
     if expires_at is None and value.get("expires_in") is not None:
         expires_in = value["expires_in"]
         if not isinstance(expires_in, int | float):
@@ -229,7 +248,14 @@ def _parse_expires_at(value: Any) -> datetime | None:
         return datetime.fromtimestamp(float(value), tz=UTC)
     if isinstance(value, str):
         normalized = value.replace("Z", "+00:00")
-        return _normalize_datetime(datetime.fromisoformat(normalized))
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            # Some valid RFC-3339 forms (e.g. >6-digit fractional seconds on
+            # Python 3.11) are rejected by ``fromisoformat``. Degrade to "no
+            # known expiry" instead of crashing token coercion.
+            return None
+        return _normalize_datetime(parsed)
     raise ValueError("expires_at must be a datetime, timestamp, ISO datetime string, or None.")
 
 

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -190,12 +190,17 @@ class HonuaClient:
                 auth_provider=auth_provider,
             )
 
-        effective_transport = transport
-        if max_retries > 0:
-            inner = effective_transport or httpx.HTTPTransport()
-            retry_transport = RetryTransport(inner, max_retries=max_retries)
-            effective_transport = retry_transport
-            self._retry_methods = retry_transport.retry_methods
+        # Always wrap with ``RetryTransport`` — even when ``max_retries == 0``.
+        # The transport only retries when its budget is positive, but it is
+        # also the component that consults the per-request ``honua_max_retries``
+        # override stashed by ``with_options(max_retries=…)``. Installing it
+        # unconditionally is what lets a client built with ``max_retries=0``
+        # later opt into retries via ``with_options(max_retries=N)`` instead of
+        # silently no-op'ing.
+        inner = transport or httpx.HTTPTransport()
+        retry_transport = RetryTransport(inner, max_retries=max_retries)
+        effective_transport: httpx.BaseTransport = retry_transport
+        self._retry_methods = retry_transport.retry_methods
 
         self._client = httpx.Client(
             base_url=self._base_url,
@@ -1246,6 +1251,7 @@ class HonuaClient:
         features: list[Feature] = []
         offset = _endpoints.initial_offset(extra_params)
         base_extra_params = dict(extra_params or {})
+        seen_object_ids: set[int] = set()
         for _ in range(max_pages):
             remaining = None if limit is None else limit - len(features)
             if remaining is not None and remaining <= 0:
@@ -1266,6 +1272,18 @@ class HonuaClient:
                 extra_headers=extra_headers,
             )
             page_features = list(page.features)
+            # Non-advancing-cursor guard: a server that ignores ``resultOffset``
+            # keeps returning the same page with ``exceededTransferLimit=true``,
+            # which would otherwise loop to ``max_pages`` and duplicate every
+            # feature. When object ids are present, stop once a page adds no new
+            # ones (and drop the duplicates we already collected this page).
+            new_object_ids = {
+                oid for f in page_features if (oid := f.object_id) is not None
+            }
+            stalled = bool(new_object_ids) and new_object_ids.issubset(seen_object_ids)
+            if stalled:
+                break
+            seen_object_ids |= new_object_ids
             if remaining is not None:
                 page_features = page_features[:remaining]
             features.extend(page_features)

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -47,6 +47,26 @@ class GeocodeSuggestion:
     is_collection: bool
 
 
+def _extract_location_xy(location: Any) -> tuple[float, float] | None:
+    """Return ``(longitude, latitude)`` from a GeocodeServer ``location``.
+
+    Returns ``None`` when the location is missing, not a mapping, or lacks a
+    usable ``x``/``y`` pair. Defaulting absent coordinates to ``0`` would
+    silently emit a valid-looking ``(0, 0)`` "null island" result that masks
+    a geocode miss — so a missing location is treated as "no result" instead.
+    """
+    if not isinstance(location, Mapping):
+        return None
+    raw_x = location.get("x")
+    raw_y = location.get("y")
+    if raw_x is None or raw_y is None:
+        return None
+    try:
+        return float(raw_x), float(raw_y)
+    except (TypeError, ValueError):
+        return None
+
+
 class HonuaGeocodingClient:
     """Task-oriented client for Honua GeocodeServer workflows."""
 
@@ -170,12 +190,16 @@ class HonuaGeocodingClient:
 
         results: list[GeocodeResult] = []
         for candidate in data.get("candidates", []):
-            location = candidate.get("location", {})
+            coords = _extract_location_xy(candidate.get("location"))
+            if coords is None:
+                # No usable location: skip rather than emit a (0, 0) result.
+                continue
+            longitude, latitude = coords
             results.append(
                 GeocodeResult(
                     address=candidate.get("address", ""),
-                    longitude=float(location.get("x", 0)),
-                    latitude=float(location.get("y", 0)),
+                    longitude=longitude,
+                    latitude=latitude,
                     score=float(candidate.get("score", 0)),
                     attributes=candidate.get("attributes", {}),
                 )
@@ -227,18 +251,21 @@ class HonuaGeocodingClient:
             extra_headers=extra_headers,
         )
 
-        if not data.get("address") and not data.get("location"):
-            return None
-
         addr_info = data.get("address", {})
-        location = data.get("location", {})
         match_addr = addr_info.get("Match_addr", "") if isinstance(addr_info, Mapping) else ""
         attributes = dict(addr_info) if isinstance(addr_info, Mapping) else {}
+        coords = _extract_location_xy(data.get("location"))
 
+        # No usable location and no address text means the server returned no
+        # match — surface that as ``None`` rather than a (0, 0) "null island".
+        if coords is None and not match_addr:
+            return None
+
+        longitude, latitude = coords if coords is not None else (0.0, 0.0)
         return ReverseGeocodeResult(
             address=match_addr,
-            longitude=float(location.get("x", 0)),
-            latitude=float(location.get("y", 0)),
+            longitude=longitude,
+            latitude=latitude,
             attributes=attributes,
         )
 

--- a/packages/honua-sdk/honua_sdk/protocols/geoservices.py
+++ b/packages/honua-sdk/honua_sdk/protocols/geoservices.py
@@ -102,6 +102,7 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
         total = 0
         base_extra = dict(extra_params or {})
         offset = int(base_extra.get("resultOffset", 0))
+        seen_object_ids: set[int] = set()
         for _ in range(max_pages):
             remaining = None if limit is None else limit - total
             if remaining is not None and remaining <= 0:
@@ -123,6 +124,13 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
                     extra_headers=extra_headers,
                 )
             )
+            # Non-advancing-cursor guard: stop before re-yielding a page a
+            # server that ignores ``resultOffset`` keeps returning (it would
+            # otherwise loop to ``max_pages`` with duplicate features).
+            new_object_ids = {oid for f in page.features if (oid := f.object_id) is not None}
+            if new_object_ids and new_object_ids.issubset(seen_object_ids):
+                break
+            seen_object_ids |= new_object_ids
             yield page
             page_count = len(page.features)
             total += page_count
@@ -508,6 +516,7 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         total = 0
         base_extra = dict(extra_params or {})
         offset = int(base_extra.get("resultOffset", 0))
+        seen_object_ids: set[int] = set()
         for _ in range(max_pages):
             remaining = None if limit is None else limit - total
             if remaining is not None and remaining <= 0:
@@ -529,6 +538,13 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
                     extra_headers=extra_headers,
                 )
             )
+            # Non-advancing-cursor guard: stop before re-yielding a page a
+            # server that ignores ``resultOffset`` keeps returning (it would
+            # otherwise loop to ``max_pages`` with duplicate features).
+            new_object_ids = {oid for f in page.features if (oid := f.object_id) is not None}
+            if new_object_ids and new_object_ids.issubset(seen_object_ids):
+                break
+            seen_object_ids |= new_object_ids
             yield page
             page_count = len(page.features)
             total += page_count

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -83,3 +83,44 @@ def test_bearer_token_accepts_epoch_and_iso_expiration_metadata() -> None:
     assert iso_token.access_token == "iso"
     assert iso_token.expires_at is not None
     assert iso_token.expires_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# issue #107: auth parsing robustness
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_token_preserves_zero_epoch_expiry() -> None:
+    from honua_sdk.auth import _coerce_token
+
+    # A legitimate ``0`` epoch expiry must NOT be dropped by falsy coercion.
+    token = _coerce_token({"access_token": "abc", "expires_at": 0})
+    assert token.access_token == "abc"
+    assert token.expires_at is not None
+    assert token.expires_at.timestamp() == 0.0
+
+
+def test_coerce_token_absent_token_type_defaults_to_bearer() -> None:
+    from honua_sdk.auth import _coerce_token
+
+    # BearerToken forbids an empty token_type, so absent/empty both default.
+    token = _coerce_token({"access_token": "abc"})
+    assert token.token_type == "Bearer"
+
+
+def test_parse_expires_at_unparseable_iso_returns_none() -> None:
+    from honua_sdk.auth import _parse_expires_at
+
+    # A malformed ISO timestamp must degrade to "no known expiry" rather than
+    # raising ValueError and crashing token coercion (issue #107.1). On Python
+    # 3.11 some valid RFC-3339 forms (e.g. >6-digit fractional seconds) also
+    # hit this path.
+    assert _parse_expires_at("2026-13-99T99:99:99Z") is None
+
+
+def test_parse_expires_at_valid_iso_with_z() -> None:
+    from honua_sdk.auth import _parse_expires_at
+
+    parsed = _parse_expires_at("2026-01-01T00:00:00Z")
+    assert parsed is not None
+    assert parsed.tzinfo is not None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -213,6 +213,37 @@ def test_query_features_all_pages_until_transfer_limit_clears() -> None:
     assert seen == [("0", "2"), ("2", "1")]
 
 
+def test_query_features_all_stops_on_non_advancing_cursor() -> None:
+    # issue #107.4: a server that ignores ``resultOffset`` returns the same
+    # full page with exceededTransferLimit=true forever. The non-advancing
+    # cursor guard must stop after the first page rather than looping to
+    # max_pages and duplicating features.
+    call_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        # Always the same two objectids, regardless of the requested offset.
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {"attributes": {"objectid": 1}},
+                    {"attributes": {"objectid": 2}},
+                ],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        features = client.query_features_all("parcels", 0, page_size=2, max_pages=100)
+
+    # Only the first page is kept; no duplicates, and we stop after detecting
+    # the stall (one extra probe page) rather than walking all 100 pages.
+    assert [feature.object_id for feature in features] == [1, 2]
+    assert call_count["n"] <= 2
+
+
 def test_shared_query_feature_server_normalizes_common_args() -> None:
     seen: dict[str, str] = {}
 

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -361,3 +361,65 @@ def test_custom_locator_name_in_path() -> None:
         client.forward_geocode("test")
 
     assert "/rest/services/MyLocator/GeocodeServer/findAddressCandidates" in seen["path"]
+
+
+# ---------------------------------------------------------------------------
+# Null-island guard (issue #106): missing location must not become (0, 0)
+# ---------------------------------------------------------------------------
+
+
+def _geocode_client(handler: Any) -> HonuaGeocodingClient:
+    transport = httpx.MockTransport(handler)
+    return HonuaGeocodingClient(
+        "http://example.test",
+        client=httpx.Client(base_url="http://example.test/", transport=transport),
+    )
+
+
+def test_forward_geocode_skips_candidates_without_location() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {"address": "no loc", "score": 90.0},
+                    {"address": "empty loc", "location": {}, "score": 80.0},
+                    {
+                        "address": "real",
+                        "location": {"x": -117.1, "y": 32.7},
+                        "score": 95.0,
+                    },
+                ]
+            },
+        )
+
+    with _geocode_client(handler) as client:
+        results = client.forward_geocode("test")
+
+    # Only the candidate with a usable location survives; no (0, 0) entries.
+    assert len(results) == 1
+    assert results[0].address == "real"
+    assert (results[0].longitude, results[0].latitude) == (-117.1, 32.7)
+    assert all((r.longitude, r.latitude) != (0.0, 0.0) for r in results)
+
+
+def test_reverse_geocode_missing_location_returns_none() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Location present but empty, and no address -> no match.
+        return httpx.Response(200, json={"location": {}})
+
+    with _geocode_client(handler) as client:
+        result = client.reverse_geocode(32.7, -117.1)
+
+    assert result is None
+
+
+def test_reverse_geocode_address_without_location_keeps_address() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"address": {"Match_addr": "123 Main St"}})
+
+    with _geocode_client(handler) as client:
+        result = client.reverse_geocode(32.7, -117.1)
+
+    assert result is not None
+    assert result.address == "123 Main St"

--- a/tests/test_pagination_signals.py
+++ b/tests/test_pagination_signals.py
@@ -1,0 +1,54 @@
+"""Tests for pagination-signal total-count coercion (issue #107).
+
+Servers occasionally emit ``numberMatched`` / ``@odata.count`` as a JSON
+float (e.g. ``1000.0``) rather than an integer. The coercion must accept
+whole-valued floats and reject ``bool`` (an ``int`` subclass) so totals
+aren't silently dropped to ``None``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from honua_sdk._query import (
+    _coerce_total_count,
+    odata_pagination_signals,
+    ogc_pagination_signals,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (1000, 1000),
+        (1000.0, 1000),
+        ("1000", 1000),
+        (0, 0),
+        (0.0, 0),
+        (1000.5, None),  # non-integer float is not a meaningful count
+        ("12.5", None),
+        ("abc", None),
+        (None, None),
+        (True, None),  # bool rejected despite being an int subclass
+        (False, None),
+    ],
+)
+def test_coerce_total_count(raw: object, expected: int | None) -> None:
+    assert _coerce_total_count(raw) == expected
+
+
+def test_ogc_pagination_signals_accepts_float_total() -> None:
+    total, exceeded = ogc_pagination_signals({"numberMatched": 1000.0})
+    assert total == 1000
+    assert exceeded is False
+
+
+def test_odata_pagination_signals_accepts_float_total() -> None:
+    total, exceeded = odata_pagination_signals({"@odata.count": 42.0})
+    assert total == 42
+    assert exceeded is False
+
+
+def test_ogc_pagination_signals_rejects_bool_total() -> None:
+    total, _exceeded = ogc_pagination_signals({"numberMatched": True})
+    assert total is None

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -150,9 +150,10 @@ def test_backoff_capped_at_max() -> None:
 
 
 def test_honours_retry_after_header() -> None:
+    # A Retry-After under the backoff_max ceiling is honoured verbatim.
     transport = _make_transport(
         [
-            httpx.Response(429, text="throttled", headers={"Retry-After": "7"}),
+            httpx.Response(429, text="throttled", headers={"Retry-After": "3"}),
             httpx.Response(200, json={"ok": True}),
         ],
     )
@@ -162,7 +163,44 @@ def test_honours_retry_after_header() -> None:
         response = transport.handle_request(request)
 
     assert response.status_code == 200
-    mock_sleep.assert_called_once_with(7.0)
+    mock_sleep.assert_called_once_with(3.0)
+
+
+def test_retry_after_header_clamped_to_backoff_max() -> None:
+    # A Retry-After above backoff_max (default 5s) is clamped, not honoured
+    # verbatim — a hostile/oversized header can't block past the ceiling.
+    transport = _make_transport(
+        [
+            httpx.Response(503, text="retry", headers={"Retry-After": "86400"}),
+            httpx.Response(200, json={"ok": True}),
+        ],
+    )
+    request = httpx.Request("GET", "http://example.test/")
+
+    with patch("honua_sdk._retry.time.sleep") as mock_sleep:
+        response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    mock_sleep.assert_called_once_with(5.0)
+
+
+def test_retry_after_infinite_falls_back_to_backoff() -> None:
+    # ``Retry-After: inf`` must NOT produce an infinite sleep — it is rejected
+    # as unparseable and the bounded exponential backoff is used instead.
+    transport = _make_transport(
+        [
+            httpx.Response(429, text="throttled", headers={"Retry-After": "inf"}),
+            httpx.Response(200, json={"ok": True}),
+        ],
+    )
+    request = httpx.Request("GET", "http://example.test/")
+
+    with patch("honua_sdk._retry.time.sleep") as mock_sleep:
+        response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    # First-attempt backoff base is 0.5 (no jitter in _make_transport).
+    mock_sleep.assert_called_once_with(0.5)
 
 
 def test_retry_after_invalid_falls_back_to_backoff() -> None:
@@ -469,3 +507,27 @@ def test_client_integration_with_retry() -> None:
 
     assert result == {"status": "ready"}
     assert call_count["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# parse_retry_after robustness (issue #103): non-finite values rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["inf", "Infinity", "-inf", "nan", "1e400"])
+def test_parse_retry_after_rejects_non_finite(bad: str) -> None:
+    from honua_sdk._http import parse_retry_after
+
+    # Non-finite delta-seconds must be treated as unparseable (None) so the
+    # caller falls back to bounded backoff instead of sleeping forever.
+    assert parse_retry_after(bad) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("0", 0.0), ("12", 12.0), ("  3 ", 3.0), ("-5", 0.0)],
+)
+def test_parse_retry_after_finite_values(value: str, expected: float) -> None:
+    from honua_sdk._http import parse_retry_after
+
+    assert parse_retry_after(value) == expected

--- a/tests/test_with_options.py
+++ b/tests/test_with_options.py
@@ -328,3 +328,73 @@ def test_retry_transport_exposes_public_retry_methods_property() -> None:
     assert async_transport.retry_methods == async_transport._retry_methods
     assert "GET" in sync_transport.retry_methods
     assert "POST" not in sync_transport.retry_methods
+
+
+# ---------------------------------------------------------------------------
+# issue #105: with_options(max_retries=N) on a client built with max_retries=0
+# must actually take effect (RetryTransport is always installed).
+# ---------------------------------------------------------------------------
+
+
+def test_with_options_enables_retries_on_zero_built_sync_client() -> None:
+    call_count = {"n": 0}
+
+    def handler(_r: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            return httpx.Response(503, text="retry")
+        return httpx.Response(200, json={"status": "ready"})
+
+    transport = httpx.MockTransport(handler)
+    original = HonuaClient("http://example.test", transport=transport, max_retries=0)
+    try:
+        retrying = original.with_options(max_retries=5)
+        with patch("honua_sdk._retry.time.sleep"):
+            result = retrying.readiness()
+        assert result == {"status": "ready"}
+        # Two retries consumed before the 200 — the override took effect.
+        assert call_count["n"] == 3
+    finally:
+        original.close()
+
+
+def test_zero_built_sync_client_still_does_not_retry_by_default() -> None:
+    call_count = {"n": 0}
+
+    def handler(_r: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(503, text="retry")
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as client:
+        with patch("honua_sdk._retry.time.sleep"):
+            with pytest.raises(HonuaHttpError):
+                client.readiness()
+    # No override => single attempt, behaviour unchanged for the default path.
+    assert call_count["n"] == 1
+
+
+def test_with_options_enables_retries_on_zero_built_async_client() -> None:
+    call_count = {"n": 0}
+
+    def handler(_r: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            return httpx.Response(503, text="retry")
+        return httpx.Response(200, json={"status": "ready"})
+
+    async def run() -> dict[str, Any]:
+        transport = httpx.MockTransport(handler)
+        original = AsyncHonuaClient(
+            "http://example.test", transport=transport, max_retries=0
+        )
+        try:
+            retrying = original.with_options(max_retries=5)
+            with patch("honua_sdk._async_retry.asyncio.sleep"):
+                return await retrying.readiness()
+        finally:
+            await original.close()
+
+    result = asyncio.run(run())
+    assert result == {"status": "ready"}
+    assert call_count["n"] == 3


### PR DESCRIPTION
Resolves five filed SDK bugs in `honua-sdk`.

## #103 — Retry-After: inf causes infinite sleep
`parse_retry_after` now rejects non-finite delta-seconds values (`inf`/`-inf`/`nan`/`1e400`) via `math.isfinite`, so a hostile/buggy header can no longer flow un-capped into `time.sleep`/`asyncio.sleep` and freeze the thread or event loop. The caller falls back to bounded exponential backoff.

## #104 — Retry-After bypasses backoff_max
`compute_delay` now clamps the honoured `Retry-After` to `backoff_max` (`min(retry_after, backoff_max)`), matching the JS SDK. A well-formed `Retry-After: 86400` no longer blocks far past the configured ceiling (default 5s).

## #105 — with_options(max_retries=N) no-op on max_retries=0 clients
Both `HonuaClient` and `AsyncHonuaClient` now always install the (Async)`RetryTransport`, even when built with `max_retries=0`. The transport only retries on a positive budget but is also what consults the per-request `honua_max_retries` override, so `with_options(max_retries=N)` now actually takes effect. Default no-retry behaviour for the unoverridden path is unchanged.

## #106 — Geocoding null-island coercion
A candidate with a missing/empty `location` is no longer coerced to a valid-looking `(0, 0)`. Forward geocode skips such candidates; reverse geocode returns `None` on a location-less, address-less miss (an address-only result is still returned). Applied to both sync and async geocoding clients via a shared `_extract_location_xy` helper.

## #107 — Response/auth parsing robustness
1. `_parse_expires_at` wraps `datetime.fromisoformat` in try/except, degrading to "no known expiry" instead of crashing token coercion on unparseable ISO timestamps (e.g. Python 3.11 / 9-digit fractional seconds).
2. `_coerce_token` uses sentinel-aware lookups so a legitimate `0`-epoch `expires_at` is no longer dropped by `or`-style falsy coercion. (`token_type` still defaults to `Bearer` on empty/absent, since `BearerToken` forbids an empty `token_type`.)
3. `numberMatched`/`@odata.count` totals now accept whole-valued JSON floats (e.g. `1000.0`) via a shared `_coerce_total_count` helper, rejecting `bool`.
4. `query_features_all` and the GeoServices `query_pages` generators (sync + async) add a non-advancing-cursor guard: when a server ignores `resultOffset` and re-returns the same page with `exceededTransferLimit=true`, pagination stops instead of looping to `max_pages` and duplicating features.

## Tests
Added/extended focused tests across `test_retry.py`, `test_with_options.py`, `test_geocoding.py`, `test_auth.py`, `test_client.py`, and a new `test_pagination_signals.py`. Full suite: 1019 passed, 11 skipped. `ruff check` and `mypy` clean.

Closes #103
Closes #104
Closes #105
Closes #106
Closes #107