### PR TITLE
Bound Retry-After delays

### DIFF
--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -6,6 +6,7 @@ import warnings
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
+import math
 from typing import Any
 from urllib.parse import quote
 
@@ -162,6 +163,8 @@ def parse_retry_after(value: str | None) -> float | None:
     except (TypeError, ValueError):
         seconds = None
     if seconds is not None:
+        if not math.isfinite(seconds):
+            return None
         return max(0.0, seconds)
     try:
         target = parsedate_to_datetime(text)

--- a/packages/honua-sdk/honua_sdk/_retry_core.py
+++ b/packages/honua-sdk/honua_sdk/_retry_core.py
@@ -84,13 +84,13 @@ def compute_delay(
     """Return the delay before the next retry, honouring ``Retry-After``.
 
     When ``Retry-After`` is present and parseable (delta-seconds or RFC
-    7231 HTTP-date), the parsed value is returned verbatim and is not
-    jittered. Otherwise the exponential backoff (see
-    :func:`compute_backoff`) is used.
+    7231 HTTP-date), the parsed value is honored but capped at
+    ``backoff_max`` and is not jittered. Otherwise the exponential
+    backoff (see :func:`compute_backoff`) is used.
     """
     retry_after = parse_retry_after(response.headers.get("retry-after"))
     if retry_after is not None:
-        return retry_after
+        return min(retry_after, backoff_max)
     return compute_backoff(
         attempt,
         backoff_initial=backoff_initial,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -155,6 +155,7 @@ def test_honours_retry_after_header() -> None:
             httpx.Response(429, text="throttled", headers={"Retry-After": "7"}),
             httpx.Response(200, json={"ok": True}),
         ],
+        backoff_max=10.0,
     )
     request = httpx.Request("GET", "http://example.test/")
 
@@ -163,6 +164,40 @@ def test_honours_retry_after_header() -> None:
 
     assert response.status_code == 200
     mock_sleep.assert_called_once_with(7.0)
+
+
+def test_retry_after_header_is_capped_by_backoff_max() -> None:
+    transport = _make_transport(
+        [
+            httpx.Response(429, text="throttled", headers={"Retry-After": "86400"}),
+            httpx.Response(200, json={"ok": True}),
+        ],
+        backoff_max=5.0,
+    )
+    request = httpx.Request("GET", "http://example.test/")
+
+    with patch("honua_sdk._retry.time.sleep") as mock_sleep:
+        response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    mock_sleep.assert_called_once_with(5.0)
+
+
+@pytest.mark.parametrize("header_value", ["inf", "infinity", "1e400", "nan"])
+def test_retry_after_non_finite_values_fall_back_to_backoff(header_value: str) -> None:
+    transport = _make_transport(
+        [
+            httpx.Response(503, text="retry", headers={"Retry-After": header_value}),
+            httpx.Response(200, json={"ok": True}),
+        ],
+    )
+    request = httpx.Request("GET", "http://example.test/")
+
+    with patch("honua_sdk._retry.time.sleep") as mock_sleep:
+        response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    mock_sleep.assert_called_once_with(0.5)
 
 
 def test_retry_after_invalid_falls_back_to_backoff() -> None:


### PR DESCRIPTION
Fixes honua-io/honua-sdk-python#103.
Fixes honua-io/honua-sdk-python#104.

## Summary
- Reject non-finite numeric Retry-After values (`inf`, `infinity`, `1e400`, `nan`) so they fall back to normal backoff instead of sleeping forever or retrying immediately.
- Cap parsed Retry-After delays at the transport `backoff_max`, matching the configured retry ceiling.
- Add regression coverage for non-finite headers and oversized finite headers.

## Validation
- `PYTHONPATH=packages/honua-sdk;packages/honua-admin python -m pytest tests/test_retry.py -q`
- Result: `29 passed`