### PR TITLE
Skip geocode results without coordinates

### DIFF
--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -20,7 +20,7 @@ from ._http import (
     _validate_external_client_auth_configuration,
 )
 from .auth import AuthProvider
-from .geocoding import GeocodeResult, GeocodeSuggestion, ReverseGeocodeResult
+from .geocoding import GeocodeResult, GeocodeSuggestion, ReverseGeocodeResult, _location_xy
 
 
 class AsyncHonuaGeocodingClient:
@@ -147,12 +147,15 @@ class AsyncHonuaGeocodingClient:
 
         results: list[GeocodeResult] = []
         for candidate in data.get("candidates", []):
-            location = candidate.get("location", {})
+            coords = _location_xy(candidate.get("location"))
+            if coords is None:
+                continue
+            longitude, latitude = coords
             results.append(
                 GeocodeResult(
                     address=candidate.get("address", ""),
-                    longitude=float(location.get("x", 0)),
-                    latitude=float(location.get("y", 0)),
+                    longitude=longitude,
+                    latitude=latitude,
                     score=float(candidate.get("score", 0)),
                     attributes=candidate.get("attributes", {}),
                 )
@@ -204,18 +207,19 @@ class AsyncHonuaGeocodingClient:
             extra_headers=extra_headers,
         )
 
-        if not data.get("address") and not data.get("location"):
+        coords = _location_xy(data.get("location"))
+        if coords is None:
             return None
 
         addr_info = data.get("address", {})
-        location = data.get("location", {})
         match_addr = addr_info.get("Match_addr", "") if isinstance(addr_info, Mapping) else ""
         attributes = dict(addr_info) if isinstance(addr_info, Mapping) else {}
+        longitude, latitude = coords
 
         return ReverseGeocodeResult(
             address=match_addr,
-            longitude=float(location.get("x", 0)),
-            latitude=float(location.get("y", 0)),
+            longitude=longitude,
+            latitude=latitude,
             attributes=attributes,
         )
 

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -47,6 +47,14 @@ class GeocodeSuggestion:
     is_collection: bool
 
 
+def _location_xy(location: Any) -> tuple[float, float] | None:
+    if not isinstance(location, Mapping):
+        return None
+    if "x" not in location or "y" not in location:
+        return None
+    return float(location["x"]), float(location["y"])
+
+
 class HonuaGeocodingClient:
     """Task-oriented client for Honua GeocodeServer workflows."""
 
@@ -170,12 +178,15 @@ class HonuaGeocodingClient:
 
         results: list[GeocodeResult] = []
         for candidate in data.get("candidates", []):
-            location = candidate.get("location", {})
+            coords = _location_xy(candidate.get("location"))
+            if coords is None:
+                continue
+            longitude, latitude = coords
             results.append(
                 GeocodeResult(
                     address=candidate.get("address", ""),
-                    longitude=float(location.get("x", 0)),
-                    latitude=float(location.get("y", 0)),
+                    longitude=longitude,
+                    latitude=latitude,
                     score=float(candidate.get("score", 0)),
                     attributes=candidate.get("attributes", {}),
                 )
@@ -227,18 +238,19 @@ class HonuaGeocodingClient:
             extra_headers=extra_headers,
         )
 
-        if not data.get("address") and not data.get("location"):
+        coords = _location_xy(data.get("location"))
+        if coords is None:
             return None
 
         addr_info = data.get("address", {})
-        location = data.get("location", {})
         match_addr = addr_info.get("Match_addr", "") if isinstance(addr_info, Mapping) else ""
         attributes = dict(addr_info) if isinstance(addr_info, Mapping) else {}
+        longitude, latitude = coords
 
         return ReverseGeocodeResult(
             address=match_addr,
-            longitude=float(location.get("x", 0)),
-            latitude=float(location.get("y", 0)),
+            longitude=longitude,
+            latitude=latitude,
             attributes=attributes,
         )
 

--- a/tests/test_async_geocoding.py
+++ b/tests/test_async_geocoding.py
@@ -96,6 +96,28 @@ async def test_forward_geocode_empty_results() -> None:
     assert results == []
 
 
+async def test_forward_geocode_skips_candidates_without_coordinates() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {"address": "No location", "score": 99.0},
+                    {"address": "Missing y", "location": {"x": -117.1}, "score": 98.0},
+                    {"address": "Valid", "location": {"x": -117.2, "y": 32.8}, "score": 97.0},
+                ]
+            },
+        )
+
+    async with _async_client_with_transport(handler) as client:
+        results = await client.forward_geocode("123 Main St")
+
+    assert len(results) == 1
+    assert results[0].address == "Valid"
+    assert results[0].longitude == -117.2
+    assert results[0].latitude == 32.8
+
+
 async def test_forward_geocode_max_results_and_country_code_options() -> None:
     seen: dict[str, Any] = {}
 
@@ -167,6 +189,23 @@ async def test_reverse_geocode_success() -> None:
 async def test_reverse_geocode_returns_none_on_empty() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={})
+
+    async with _async_client_with_transport(handler) as client:
+        result = await client.reverse_geocode(0.0, 0.0)
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"address": {"Match_addr": "123 Main St"}},
+        {"address": {"Match_addr": "123 Main St"}, "location": {"x": -117.1}},
+    ],
+)
+async def test_reverse_geocode_returns_none_without_coordinates(payload: dict[str, Any]) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
 
     async with _async_client_with_transport(handler) as client:
         result = await client.reverse_geocode(0.0, 0.0)

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -74,6 +74,29 @@ def test_forward_geocode_empty_results() -> None:
     assert results == []
 
 
+def test_forward_geocode_skips_candidates_without_coordinates() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "candidates": [
+                    {"address": "No location", "score": 99.0},
+                    {"address": "Missing y", "location": {"x": -117.1}, "score": 98.0},
+                    {"address": "Valid", "location": {"x": -117.2, "y": 32.8}, "score": 97.0},
+                ]
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaGeocodingClient("http://example.test", client=httpx.Client(base_url="http://example.test/", transport=transport)) as client:
+        results = client.forward_geocode("123 Main St")
+
+    assert len(results) == 1
+    assert results[0].address == "Valid"
+    assert results[0].longitude == -117.2
+    assert results[0].latitude == 32.8
+
+
 def test_forward_geocode_error_payload() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -161,6 +184,24 @@ def test_reverse_geocode_success() -> None:
 def test_reverse_geocode_returns_none_on_empty() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaGeocodingClient("http://example.test", client=httpx.Client(base_url="http://example.test/", transport=transport)) as client:
+        result = client.reverse_geocode(0.0, 0.0)
+
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"address": {"Match_addr": "123 Main St"}},
+        {"address": {"Match_addr": "123 Main St"}, "location": {"x": -117.1}},
+    ],
+)
+def test_reverse_geocode_returns_none_without_coordinates(payload: dict[str, Any]) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
 
     transport = httpx.MockTransport(handler)
     with HonuaGeocodingClient("http://example.test", client=httpx.Client(base_url="http://example.test/", transport=transport)) as client:


### PR DESCRIPTION
Fixes honua-io/honua-sdk-python#106.

## Summary
- Skip forward geocode candidates that do not include both `location.x` and `location.y` instead of manufacturing `(0, 0)` coordinates.
- Return `None` from reverse geocoding when the response lacks usable coordinates.
- Apply the same behavior to sync and async geocoding clients.

## Validation
- `PYTHONPATH=packages/honua-sdk;packages/honua-admin python -m pytest tests/test_geocoding.py tests/test_async_geocoding.py -q`
- Result: `44 passed`