### PR TITLE
Harden token and pagination parsing

### DIFF
--- a/packages/honua-sdk/honua_sdk/_query.py
+++ b/packages/honua-sdk/honua_sdk/_query.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import replace
+from numbers import Real
 from typing import Any
 
 from .models import Feature, FeatureQuery, QueryFeature, QueryProtocol, normalize_protocol
@@ -221,12 +222,8 @@ def ogc_pagination_signals(page: Mapping[str, Any] | None) -> tuple[int | None, 
     """
     if page is None:
         return None, False
-    total_count: int | None = None
     raw_total = page.get("numberMatched") if isinstance(page, Mapping) else None
-    if isinstance(raw_total, int):
-        total_count = raw_total
-    elif isinstance(raw_total, str) and raw_total.isdigit():
-        total_count = int(raw_total)
+    total_count = _coerce_total_count(raw_total)
     exceeded = _has_next_link(page)
     return total_count, exceeded
 
@@ -239,14 +236,30 @@ def odata_pagination_signals(page: Mapping[str, Any] | None) -> tuple[int | None
     """
     if page is None:
         return None, False
-    total_count: int | None = None
     raw_total = page.get("@odata.count") if isinstance(page, Mapping) else None
-    if isinstance(raw_total, int):
-        total_count = raw_total
-    elif isinstance(raw_total, str) and raw_total.isdigit():
-        total_count = int(raw_total)
+    total_count = _coerce_total_count(raw_total)
     exceeded = bool(page.get("@odata.nextLink")) if isinstance(page, Mapping) else False
     return total_count, exceeded
+
+
+def _coerce_total_count(raw_total: Any) -> int | None:
+    if isinstance(raw_total, bool):
+        return None
+    if isinstance(raw_total, int):
+        return raw_total
+    if isinstance(raw_total, Real) and float(raw_total).is_integer():
+        return int(raw_total)
+    if isinstance(raw_total, str):
+        text = raw_total.strip()
+        if text.isdigit():
+            return int(text)
+        try:
+            numeric = float(text)
+        except ValueError:
+            return None
+        if numeric.is_integer():
+            return int(numeric)
+    return None
 
 
 def odata_features_from_page(page: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -1238,6 +1238,7 @@ class AsyncHonuaClient:
         features: list[Feature] = []
         offset = _endpoints.initial_offset(extra_params)
         base_extra_params = dict(extra_params or {})
+        previous_page_signature: tuple[tuple[int | None, str], ...] | None = None
         for _ in range(max_pages):
             remaining = None if limit is None else limit - len(features)
             if remaining is not None and remaining <= 0:
@@ -1258,6 +1259,10 @@ class AsyncHonuaClient:
                 extra_headers=extra_headers,
             )
             page_features = list(page.features)
+            page_signature = tuple((feature.object_id, repr(feature.attributes)) for feature in page_features)
+            if previous_page_signature is not None and page_signature == previous_page_signature:
+                break
+            previous_page_signature = page_signature
             if remaining is not None:
                 page_features = page_features[:remaining]
             features.extend(page_features)

--- a/packages/honua-sdk/honua_sdk/auth.py
+++ b/packages/honua-sdk/honua_sdk/auth.py
@@ -9,6 +9,7 @@ from threading import RLock
 from typing import Any, Protocol, runtime_checkable
 
 SENSITIVE_AUTH_HEADER_NAMES = frozenset({"authorization", "x-api-key"})
+_MISSING = object()
 
 
 @runtime_checkable
@@ -198,15 +199,15 @@ def _coerce_token(value: BearerToken | Mapping[str, Any] | str) -> BearerToken:
     if not isinstance(value, Mapping):
         raise TypeError("Token refresh callbacks must return BearerToken, mapping, or string.")
 
-    access_token = value.get("access_token") or value.get("accessToken") or value.get("token")
+    access_token = _first_present(value, "access_token", "accessToken", "token")
     if not isinstance(access_token, str):
         raise ValueError("Token mapping must include an access_token string.")
 
-    token_type = value.get("token_type") or value.get("tokenType") or "Bearer"
+    token_type = _first_present(value, "token_type", "tokenType", default="Bearer")
     if not isinstance(token_type, str):
         raise ValueError("Token mapping token_type must be a string.")
 
-    expires_at = value.get("expires_at") or value.get("expiresAt")
+    expires_at = _first_present(value, "expires_at", "expiresAt")
     if expires_at is None and value.get("expires_in") is not None:
         expires_in = value["expires_in"]
         if not isinstance(expires_in, int | float):
@@ -220,6 +221,14 @@ def _coerce_token(value: BearerToken | Mapping[str, Any] | str) -> BearerToken:
     )
 
 
+def _first_present(mapping: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    for key in keys:
+        value = mapping.get(key, _MISSING)
+        if value is not _MISSING:
+            return value
+    return default
+
+
 def _parse_expires_at(value: Any) -> datetime | None:
     if value is None:
         return None
@@ -229,7 +238,10 @@ def _parse_expires_at(value: Any) -> datetime | None:
         return datetime.fromtimestamp(float(value), tz=UTC)
     if isinstance(value, str):
         normalized = value.replace("Z", "+00:00")
-        return _normalize_datetime(datetime.fromisoformat(normalized))
+        try:
+            return _normalize_datetime(datetime.fromisoformat(normalized))
+        except ValueError:
+            return None
     raise ValueError("expires_at must be a datetime, timestamp, ISO datetime string, or None.")
 
 

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -1246,6 +1246,7 @@ class HonuaClient:
         features: list[Feature] = []
         offset = _endpoints.initial_offset(extra_params)
         base_extra_params = dict(extra_params or {})
+        previous_page_signature: tuple[tuple[int | None, str], ...] | None = None
         for _ in range(max_pages):
             remaining = None if limit is None else limit - len(features)
             if remaining is not None and remaining <= 0:
@@ -1266,6 +1267,10 @@ class HonuaClient:
                 extra_headers=extra_headers,
             )
             page_features = list(page.features)
+            page_signature = tuple((feature.object_id, repr(feature.attributes)) for feature in page_features)
+            if previous_page_signature is not None and page_signature == previous_page_signature:
+                break
+            previous_page_signature = page_signature
             if remaining is not None:
                 page_features = page_features[:remaining]
             features.extend(page_features)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -166,6 +166,31 @@ async def test_query_features_all_returns_typed_paginated_features() -> None:
     assert seen == [("0", "2"), ("2", "1")]
 
 
+async def test_query_features_all_stops_on_repeated_page() -> None:
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        query = dict(request.url.params.multi_items())
+        seen.append(query["resultOffset"])
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {"attributes": {"objectid": 1, "name": "A"}},
+                    {"attributes": {"objectid": 2, "name": "B"}},
+                ],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        features = await client.query_features_all("parcels", 0, page_size=2, max_pages=5)
+
+    assert [feature.object_id for feature in features] == [1, 2]
+    assert seen == ["0", "2"]
+
+
 async def test_shared_query_feature_server_normalizes_common_args() -> None:
     seen: dict[str, str] = {}
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -83,3 +83,24 @@ def test_bearer_token_accepts_epoch_and_iso_expiration_metadata() -> None:
     assert iso_token.access_token == "iso"
     assert iso_token.expires_at is not None
     assert iso_token.expires_at.tzinfo is not None
+
+
+def test_bearer_token_preserves_falsy_expiration_metadata() -> None:
+    token = RefreshableBearerTokenProvider(lambda: {"access_token": "epoch", "expiresAt": 0}).get_token()
+
+    assert token.expires_at == datetime.fromtimestamp(0, tz=timezone.utc)
+
+
+def test_bearer_token_degrades_unexpected_iso_expiration_to_none() -> None:
+    token = RefreshableBearerTokenProvider(
+        lambda: {"access_token": "odd-iso", "expiresAt": "2033-05-18T03:33:20+00:00[UTC]"}
+    ).get_token()
+
+    assert token.expires_at is None
+
+
+def test_bearer_token_does_not_replace_explicit_empty_token_type() -> None:
+    provider = RefreshableBearerTokenProvider(lambda: {"access_token": "token", "token_type": ""})
+
+    with pytest.raises(ValueError, match="token_type must be non-empty"):
+        provider.get_token()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -213,6 +213,31 @@ def test_query_features_all_pages_until_transfer_limit_clears() -> None:
     assert seen == [("0", "2"), ("2", "1")]
 
 
+def test_query_features_all_stops_on_repeated_page() -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = dict(request.url.params.multi_items())
+        seen.append(query["resultOffset"])
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {"attributes": {"objectid": 1, "name": "A"}},
+                    {"attributes": {"objectid": 2, "name": "B"}},
+                ],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        features = client.query_features_all("parcels", 0, page_size=2, max_pages=5)
+
+    assert [feature.object_id for feature in features] == [1, 2]
+    assert seen == ["0", "2"]
+
+
 def test_shared_query_feature_server_normalizes_common_args() -> None:
     seen: dict[str, str] = {}
 

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from honua_sdk._query import ogc_pagination_signals, odata_pagination_signals
+
+
+def test_pagination_signals_accept_integral_float_totals() -> None:
+    assert ogc_pagination_signals({"numberMatched": 1000.0}) == (1000, False)
+    assert ogc_pagination_signals({"numberMatched": "1000.0"}) == (1000, False)
+    assert odata_pagination_signals({"@odata.count": 42.0}) == (42, False)
+
+
+def test_pagination_signals_reject_bool_and_fractional_totals() -> None:
+    assert ogc_pagination_signals({"numberMatched": True}) == (None, False)
+    assert ogc_pagination_signals({"numberMatched": 10.5}) == (None, False)
+    assert odata_pagination_signals({"@odata.count": "10.5"}) == (None, False)


### PR DESCRIPTION
Fixes honua-io/honua-sdk-python#107.

## Summary
- Preserve present-but-falsy token metadata, including `expiresAt: 0`, instead of treating it as absent.
- Degrade unexpected ISO expiration strings to a non-expiring token rather than crashing token coercion.
- Parse integral float totals from OGC/OData pagination metadata while rejecting booleans and fractional totals.
- Stop sync and async `query_features_all` when a FeatureServer returns the same page again after advancing `resultOffset`, avoiding duplicate accumulation up to `max_pages`.

## Validation
- `PYTHONPATH=packages/honua-sdk;packages/honua-admin python -m pytest tests/test_auth.py tests/test_query_helpers.py tests/test_client.py tests/test_async_client.py -q`
- Result: `72 passed, 4 warnings`