### PR TITLE
chore(sdk): finish mypy strict ratchet + deepen migration timeline (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,52 @@ Breaking changes in this line are gated by the public-API compatibility snapshot
   typed `Result[QueryFeature]` across every protocol. The `Query.where` field
   no longer routes silently to CQL `filter` on OGC/STAC endpoints — pass
   `cql_filter=` or set `where_as_cql=True` to opt in.
+
+  *Querying — before/after:*
+
+  ```python
+  # Before (0.0.x): per-protocol method, raw-dict response
+  fc = client.query_features("parcels", where="state = 'HI'", out_fields="*")
+  for feature in fc["features"]:
+      name = feature["attributes"]["NAME"]
+
+  # After (0.1.x): unified Source facade, typed Result[QueryFeature]
+  result = client.source(SourceDescriptor("parcels")).query(
+      Query(where="state = 'HI'", out_fields=["*"])
+  )
+  for feature in result.features:
+      name = feature.properties["NAME"]
+  ```
+
+  *Feature attributes — `.attributes` → `.properties`:*
+
+  ```python
+  # Before (0.0.x): GeoJSON-style raw dict, ArcGIS `attributes` key
+  value = feature["attributes"]["POP2020"]
+
+  # After (0.1.x): normalized QueryFeature, `.properties` everywhere
+  value = feature.properties["POP2020"]
+  ```
+
 - **0.1.x → 0.2.x (planned)** — Sync/async client modules continue to converge
-  around the shared `_endpoints.py` / `_retry_core.py` machinery. No public-API
-  removals are scheduled; new helpers will be additive.
+  around the shared `_endpoints.py` / `_retry_core.py` machinery. The
+  `bearer_token=` constructor argument (deprecated in 0.1.x, which emits a
+  `DeprecationWarning`) is scheduled for removal; migrate to
+  `auth_provider=`:
+
+  ```python
+  # Before (0.1.x, deprecated): bearer_token= kwarg
+  client = HonuaClient(base_url, bearer_token=token)
+
+  # After (0.2.x): explicit auth provider (works today, 0.1.x onward)
+  from honua_sdk.auth import StaticAuthProvider
+
+  client = HonuaClient(
+      base_url,
+      auth_provider=StaticAuthProvider({"Authorization": f"Bearer {token}"}),
+  )
+  ```
+
+  No other public-API removals are scheduled; new helpers will be additive.
 
 Per-release notes live in [packages/honua-sdk/CHANGELOG.md](packages/honua-sdk/CHANGELOG.md) and [packages/honua-admin/CHANGELOG.md](packages/honua-admin/CHANGELOG.md), maintained by release-please.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,11 @@ python_version = "3.11"
 #     prior ogc/protocols/source/grpc/_retry_core opt-outs have been
 #     retired now that the httpx-JSON return shapes are cast to typed
 #     return signatures at each call site.
+#   * warn_no_return / disallow_subclassing_any / strict_equality — the
+#     final queued strict-mode ratchets, now enabled (clean across all
+#     source files). The only remaining gap to literal `strict = true` is
+#     `no_implicit_reexport`, deliberately left off so the curated
+#     `__init__` re-export surface stays implicit-friendly.
 strict = false
 warn_unused_configs = true
 warn_redundant_casts = true
@@ -107,11 +112,12 @@ no_implicit_optional = true
 check_untyped_defs = true
 disallow_untyped_defs = true
 # Individual strict-mode ratchets added on top of disallow_untyped_defs.
-# Full `strict = true` would also enable warn_no_return / disallow_subclassing_any;
-# those remain queued for a follow-up pass now that warn_return_any is clean.
 disallow_any_generics = true
 disallow_untyped_calls = true
 warn_return_any = true
+warn_no_return = true
+disallow_subclassing_any = true
+strict_equality = true
 ignore_missing_imports = true
 packages = ["honua_sdk", "honua_admin"]
 
@@ -124,3 +130,4 @@ module = "honua_sdk.grpc._generated.*"
 disallow_untyped_defs = false
 disallow_untyped_calls = false
 disallow_any_generics = false
+disallow_subclassing_any = false


### PR DESCRIPTION
Polish pass against the **A+ structural & ergonomic backlog** in #67. Scoped to safe, non-breaking, clearly-beneficial items; the large structural refactors are deferred (see below).

## Done

- **mypy strict ratchet (Quality / CI).** Enabled the three remaining *queued* strict-mode flags called out in `pyproject.toml [tool.mypy]`: `warn_no_return`, `disallow_subclassing_any`, and `strict_equality`. Clean across all 54 source files. The grpc generated-protobuf override gains `disallow_subclassing_any = false` (upstream-untyped bases). The only gap left to literal `strict = true` is `no_implicit_reexport`, deliberately left off so the curated `__init__` re-export surface stays implicit-friendly — documented inline.
- **Migration timeline depth (Docs).** Expanded the root `CHANGELOG.md` migration timeline with concrete before/after code blocks per breaking change, exactly as the issue requests:
  - unified `Source`/`Query`/`Result` facade vs. legacy `client.query_features(...)`
  - `.attributes` → `.properties` feature shape
  - `bearer_token=` → `auth_provider=StaticAuthProvider(...)` auth migration
  - Example snippets verified against the live API signatures (`SourceDescriptor`, `Query.out_fields`, `Result.features`, `QueryFeature.properties`, `StaticAuthProvider`).

## Already implemented upstream (no-op here)

Audited the full checklist; the following were already landed (chiefly #85 "wheel-contents assertion, symmetric publish smoke, docs preview artifact, typed Source factory" and later PRs), so no change was needed:

- `client.copy()` ergonomic alias for `with_options()` — present.
- `bearer_token=` `DeprecationWarning` — emitted (covered by tests).
- Auto `Idempotency-Key` on POSTs via `retry_methods` — present.
- `SourceClientProtocol` factory methods now return concrete wrapper types (no longer `Any`).
- Key models (`Result`, `QueryFeature`, `SourceDescriptor`, `Query`) are dataclasses with `__repr__`/`__eq__`.
- CI: wheel-contents assertion (`py.typed`, `_retry_core.py`, `grpc/`, `migration/`), symmetric publish smoke (full `tests/` on both jobs), and docs `site/` preview artifact upload.

## Deferred (out of scope for a small non-breaking polish PR)

These are large structural refactors that risk the public-API compatibility snapshot and are better as their own focused PRs, not folded into a polish basket:

- `client.py` / `async_client.py` resource-mixin split or unasync codegen.
- `honua-admin` sync/async dedup into a shared `_endpoints.py`.
- `models.py` (854 LOC) → `models/` subpackage; `protocols/geoservices.py` & `protocols/odata.py` per-resource splits.
- Per-symbol API-reference nav (replacing the two `mkdocstrings` dumps).

## Validation

- `pytest tests/`: **1077 passed, 1 skipped** (under shared build lock)
- `mypy` (with the new strict flags): clean, 54 source files
- `ruff check`: clean
- compatibility gate: passed (no public-API drift)

Part of #67.