### PR TITLE
docs: before/after migration blocks; finish #67 safe polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,95 @@ Breaking changes in this line are gated by the public-API compatibility snapshot
   no longer routes silently to CQL `filter` on OGC/STAC endpoints — pass
   `cql_filter=` or set `where_as_cql=True` to opt in.
 - **0.1.x → 0.2.x (planned)** — Sync/async client modules continue to converge
-  around the shared `_endpoints.py` / `_retry_core.py` machinery. No public-API
-  removals are scheduled; new helpers will be additive.
+  around the shared `_endpoints.py` / `_retry_core.py` machinery. The
+  `bearer_token=` constructor kwarg (deprecated in 0.1.x, see below) is
+  scheduled for removal. No other public-API removals are scheduled; new
+  helpers will be additive.
+
+### Before / after — breaking-change migrations
+
+Each migration below pairs the old call shape with the supported replacement.
+The legacy forms still work where noted, but new code should prefer the
+right-hand column.
+
+**1. Raw GeoServices `.attributes` → canonical GeoJSON `.properties`**
+
+The protocol-specific `query_features` path returns raw GeoServices features
+whose field bag lives under `.attributes`. The canonical `Source` facade
+returns `Result[QueryFeature]`, where each feature exposes GeoJSON-shaped
+`.properties` (and `.geometry`) uniformly across every protocol.
+
+```python
+# Before -- raw GeoServices feature, fields under ``attributes``
+raw = client.query_features("svc", 0, where="status = 'active'")
+for feature in raw["features"]:
+    name = feature["attributes"]["name"]
+    geom = feature.get("geometry")
+
+# After -- canonical QueryFeature, fields under ``properties``
+from honua_sdk import Query, SourceDescriptor, SourceLocator
+
+descriptor = SourceDescriptor(
+    id="svc",
+    protocol="geoservices-feature-service",
+    locator=SourceLocator(service_id="svc", layer_id=0),
+)
+result = client.source(descriptor).query(Query(where="status = 'active'"))
+for feature in result.features:
+    name = feature.properties["name"]
+    geom = feature.geometry  # GeoJSON-shaped, may be ``None``
+```
+
+**2. `client.query_features(...)` → `client.source(...).query(...)`**
+
+`query_features` is a FeatureServer-only call returning a raw `dict`. The
+`Source` facade is protocol-agnostic and returns a typed `Result[QueryFeature]`
+the same way for FeatureServer, OGC Features, STAC, and OData. The
+protocol-specific call still works as a legacy escape hatch.
+
+```python
+# Before -- protocol-specific, FeatureServer-only, raw dict
+raw = client.query_features(
+    "svc", 0, where="1=1", out_fields=["id", "name"], return_geometry=True
+)
+
+# After -- canonical facade, typed Result across every protocol
+from honua_sdk import Query, SourceDescriptor, SourceLocator
+
+descriptor = SourceDescriptor(
+    id="svc",
+    protocol="geoservices-feature-service",
+    locator=SourceLocator(service_id="svc", layer_id=0),
+)
+result = client.source(descriptor).query(
+    Query(where="1=1", out_fields=["id", "name"], return_geometry=True)
+)
+# Or iterate lazily across pages instead of materializing one response:
+for feature in client.source(descriptor).iter_query(Query(where="1=1")):
+    ...
+```
+
+**3. `bearer_token=` → `auth_provider=StaticAuthProvider(...)`**
+
+The `bearer_token=` constructor kwarg is deprecated in 0.1.x (emits a
+`DeprecationWarning`) and removed in 0.2.x, collapsing auth onto the single
+`auth_provider=` parameter (mirroring stripe-python / openai-python). Wrap the
+token in `StaticAuthProvider`, which is exported from `honua_sdk.auth`.
+
+```python
+# Before -- deprecated, emits DeprecationWarning (removed in 0.2.x)
+from honua_sdk import HonuaClient
+
+client = HonuaClient("https://your-honua-server.com", bearer_token=token)
+
+# After -- single auth parameter, no warning
+from honua_sdk import HonuaClient
+from honua_sdk.auth import StaticAuthProvider
+
+client = HonuaClient(
+    "https://your-honua-server.com",
+    auth_provider=StaticAuthProvider({"Authorization": f"Bearer {token}"}),
+)
+```
 
 Per-release notes live in [packages/honua-sdk/CHANGELOG.md](packages/honua-sdk/CHANGELOG.md) and [packages/honua-admin/CHANGELOG.md](packages/honua-admin/CHANGELOG.md), maintained by release-please.


### PR DESCRIPTION
Part of #67.

Completes the remaining **safe, verifiable** A+ polish items from #67 and verifies the rest. The two large client/admin dedup refactors are deliberately deferred (owner scope) and one item is an owner-only repo setting.

## Done in this PR

- **Migration timeline depth** (`CHANGELOG.md`): added a Before/After code block per breaking change, each verified against the current public API signatures:
  - raw GeoServices `.attributes` -> canonical `QueryFeature.properties`
  - `client.query_features(...)` -> `client.source(SourceDescriptor(...)).query(Query(...))`
  - `bearer_token=` -> `auth_provider=StaticAuthProvider({"Authorization": f"Bearer {token}"})`

## Verified already landed (no change needed)

- **Per-symbol API-reference nav** — the two `mkdocstrings` dumps (`reference/honua_sdk.md`, `honua_admin.md`) are already replaced by a per-resource nav (`reference/honua-sdk/{clients,source-facade,models,errors}.md`, `reference/honua-admin/{clients,models,errors}.md`) with prose + per-symbol `:::` directives (landed in #115). `mkdocs build --strict` clean.
- **`models.py` -> `models/` subpackage** — already split (`_discovery/_edits/_features/_helpers/_protocols/_query/_sources`) with `__init__` re-exports (landed in #115). Compat gate clean.
- **CI artifact upload of built `site/`** — `docs.yml` already has an `actions/upload-artifact@v7` step (`Upload rendered site artifact`) on the PR build job.
- **mypy `strict = true`** — confirmed in `pyproject.toml [tool.mypy]` (#102).
- **Wheel-contents assertion** — `ci.yml` asserts `py.typed`, `_retry_core.py`, `grpc/`, `migration/` are inside both wheels (#85).
- **Symmetric publish smoke** — both sdk and admin jobs run the full `tests/` suite (`publish-python-sdk.yml`).
- **`client.copy()`, `bearer_token=` deprecation, auto Idempotency-Key, typed `SourceClientProtocol` factory** — present (#85). Retry/parsing robustness present (#109).

## Verified, needs an owner action (not a code change)

- **GitHub Pages target** — the `mike` deploy **landed**: `origin/gh-pages` has the full mike structure (`.nojekyll`, `latest/index.html`, `latest/reference/`, `versions.json`). But `https://honua-io.github.io/honua-sdk-python/` returns **404** because **Pages serving is not enabled** on the repo (`has_pages=false`, Pages API 404). This is a one-time repo Settings -> Pages -> Source: `gh-pages` toggle (or `gh api -X POST repos/honua-io/honua-sdk-python/pages -f source.branch=gh-pages`). The README badge target is correct and will resolve the moment Pages is enabled, so the badge is left unchanged.

## Skipped (owner-gated)

- **`protocols/geoservices.py` / `odata.py` per-resource split** — technically a clean pure-reorg (8 independent classes over `_base`, no module-level helpers, cross-refs only in docstrings), but the owner had this same opportunity in #115 (which split `models/`) and deliberately left these. Skipped to avoid touching the protocol import surface for internal tidiness; left as owner-gated.

## Deferred (explicitly out of scope per #67)

- `client.py` / `async_client.py` unasync-style dedup.
- `honua-admin` sync/async `_client.py` dedup.

## Gates (all green, local)

- `mkdocs build --strict` — clean
- `ruff check .` — All checks passed
- `mypy` (strict) — Success: no issues found in 61 source files
- `python scripts/compatibility_gate.py` — Compatibility gate passed
- `pytest tests/` — 1113 passed, 3 skipped