### PR TITLE
Dedupe sync/async clients via async→sync codegen (Part of #67)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Run Ruff
         run: ruff check .
 
+      - name: Verify generated sync clients are not stale
+        # The synchronous clients (honua_sdk/client.py, honua_admin/_client.py)
+        # are generated from their async source-of-truth by scripts/gen_sync.py
+        # and committed. If someone edits an async client without regenerating,
+        # the committed sync mirror drifts. Regenerate and fail on any diff so
+        # the two never diverge silently. (Uses ruff — installed above — for the
+        # import-sort pass; no package install needed.)
+        run: |
+          python scripts/gen_sync.py --check
+
   typecheck:
     runs-on: ubuntu-latest
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ python -m pytest tests/ -q --tb=short \
 # Compatibility / public-API snapshot gate
 python scripts/compatibility_gate.py
 
+# Regenerate the synchronous clients from their async source-of-truth.
+# honua_sdk/client.py and honua_admin/_client.py are GENERATED from
+# async_client.py / _async_client.py by this script and committed; never
+# hand-edit them. Edit the async module, then regenerate. `--check` (run in
+# CI's lint job) fails if a committed sync file is stale. Requires ruff on PATH.
+python scripts/gen_sync.py            # rewrite the committed sync files
+python scripts/gen_sync.py --check    # verify they are up to date
+
 # Build a package wheel + sdist (run inside the package dir)
 hatch build                         # in packages/honua-sdk or packages/honua-admin
 twine check dist/*
@@ -95,7 +103,12 @@ honua-arcpy has a separate lane (`.github/workflows/honua-arcpy-eval.yml`):
 ## Architecture
 
 - **`honua_sdk`** — data plane. Public entry points: `HonuaClient` /
-  `AsyncHonuaClient` (`client.py`, `async_client.py`). The canonical query path
+  `AsyncHonuaClient` (`client.py`, `async_client.py`). **`async_client.py` is the
+  hand-written source of truth; `client.py` is GENERATED from it** by
+  `scripts/gen_sync.py` (same for `honua_admin._async_client` → `_client`). Edit
+  the async module and run `python scripts/gen_sync.py`; never hand-edit the
+  generated sync file (its header says so, and CI's `--check` step fails on
+  drift). The canonical query path
   is `client.source(SourceDescriptor(...))` → a `Source` facade
   (`source.py`) exposing `query`/`query_all`/`stream`/`apply_edits`/`protocol`,
   returning normalized `Result` / `QueryFeature` (`models.py`). Compact helpers
@@ -113,8 +126,9 @@ honua-arcpy has a separate lane (`.github/workflows/honua-arcpy-eval.yml`):
 - **`honua_admin`** — control plane: `HonuaAdminClient` /
   `_async_client.py`, `_models.py`, `_endpoints.py`, `_arcpy_scanner.py`
   (AST-walking inventory scanner).
-- **`scripts/`** — `compatibility_gate.py`, `release_smoke.py`,
-  `backlog_review.py`, `validate_publish_tag.py`, `generate_proto.sh`.
+- **`scripts/`** — `compatibility_gate.py`, `gen_sync.py` (async→sync client
+  codegen), `release_smoke.py`, `backlog_review.py`, `validate_publish_tag.py`,
+  `generate_proto.sh`.
 
 ## Directory Layout
 

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -25,7 +25,6 @@ from honua_sdk.http import (
 )
 
 from . import _endpoints
-from ._client import _json_object
 from ._models import (
     DEFAULT_STYLE_ENCODING as _DEFAULT_STYLE_ENCODING,
 )
@@ -1854,3 +1853,17 @@ def _merge_request_headers(
     if idempotency_key is not None:
         merged["Idempotency-Key"] = idempotency_key
     return merged
+
+
+def _json_object(response: httpx.Response) -> dict[str, Any]:
+    """Parse an unenveloped OGC JSON response body as an object.
+
+    The ``/ogc/styles`` surface returns raw OGC JSON (no ``ApiResponse``
+    envelope). Non-object bodies degrade to an empty ``dict``.
+    """
+    if not response.content:
+        return {}
+    payload = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return {}

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -1,4 +1,6 @@
 """Admin API client for Honua Server."""
+# AUTO-GENERATED from packages/honua-admin/honua_admin/_async_client.py by scripts/gen_sync.py — do not edit by hand.
+# Edit the async source-of-truth and run `python scripts/gen_sync.py`.
 
 from __future__ import annotations
 
@@ -66,17 +68,17 @@ from ._models import (
 class HonuaAdminClient:
     """Synchronous client for the Honua Admin (control-plane) API.
 
-    Methods on this client map 1:1 to admin REST endpoints (services,
-    metadata resources, manifests, connections, layers, styles, config)
-    and return typed model objects.
+    Methods map 1:1 to
+    admin REST endpoints (services, metadata resources, manifests,
+    connections, layers, styles, config) and return typed model objects.
 
     Authentication is configured at construction with at most one of
     ``api_key``, ``bearer_token``, or ``auth_provider`` (mutually
     exclusive). ``bearer_token=`` is **deprecated** (removal in 0.2.x);
     prefer ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer
     {token}"})``. When ``client`` is supplied as a pre-built
-    :class:`httpx.Client`, no auth kwargs may be passed — configure them
-    on the client instead.
+    :class:`httpx.Client`, no auth kwargs may be passed — configure
+    them on the client instead.
 
     Retries: only idempotent methods (GET/HEAD/PUT/DELETE/OPTIONS) on
     transient statuses (429/502/503/504) are retried by default. Opt
@@ -101,7 +103,8 @@ class HonuaAdminClient:
     :class:`HonuaTransportError` (and its subclass
     :class:`HonuaTimeoutError`).
 
-    See also: :class:`honua_sdk.HonuaClient` and ``docs/core-client.md``.
+    See also: :class:`honua_sdk.HonuaClient` and
+    ``docs/core-client.md``.
     """
 
     MINIMUM_SUPPORTED_SERVER_BASELINE = AdminCompatibilityBaseline()
@@ -133,16 +136,18 @@ class HonuaAdminClient:
             auth_provider: Pluggable provider that yields request-time
                 auth headers. Mutually exclusive with ``bearer_token``
                 and with a pre-built ``client``.
-            follow_redirects: Whether the underlying ``httpx.Client``
-                follows 3xx redirects. Sensitive auth headers are still
-                stripped when redirected to a different authority.
-            client: A caller-supplied :class:`httpx.Client`. When set,
-                the SDK will not own or close the client and the auth
-                kwargs above must not be passed (configure them on the
-                client instead).
-            transport: A caller-supplied :class:`httpx.BaseTransport`.
-                Mutually exclusive with ``client``. Use this to inject
-                a :class:`httpx.MockTransport` in tests.
+            follow_redirects: Whether the underlying
+                :class:`httpx.Client` follows 3xx redirects.
+                Sensitive auth headers are still stripped when redirected
+                to a different authority.
+            client: A caller-supplied :class:`httpx.Client`. When
+                set, the SDK will not own or close the client and the
+                auth kwargs above must not be passed (configure them on
+                the client instead).
+            transport: A caller-supplied
+                :class:`httpx.BaseTransport`. Mutually exclusive with
+                ``client``. Use this to inject a
+                :class:`httpx.MockTransport` in tests.
             max_retries: Maximum number of retry attempts on transient
                 HTTP statuses (429/502/503/504). ``0`` disables retries.
                 Only safe methods (GET/HEAD/PUT/DELETE/OPTIONS) and
@@ -186,8 +191,8 @@ class HonuaAdminClient:
         if client is not None:
             self._client = client
             # Capture the public ``base_url`` from the supplied client so we
-            # never have to reach into the private ``_base_url`` attribute
-            # of :class:`httpx.Client` from request-time code paths.
+            # never reach into the private ``_base_url`` attribute of
+            # :class:`httpx.Client` from request-time code paths.
             self._base_url: httpx.URL = httpx.URL(client.base_url)
             return
 
@@ -230,8 +235,9 @@ class HonuaAdminClient:
     def close(self) -> None:
         """Release underlying HTTP resources if this instance owns the client.
 
-        When constructed with an externally supplied :class:`httpx.Client`,
-        ownership stays with the caller and this method is a no-op.
+        When constructed with an externally supplied
+        :class:`httpx.Client`, ownership stays with the caller and
+        this method is a no-op.
         """
         if self._owns_client:
             self._client.close()
@@ -248,22 +254,21 @@ class HonuaAdminClient:
         When only ``timeout`` and/or ``max_retries`` are supplied, the
         returned client **reuses the original's** :class:`httpx.Client`
         and its connection pool — only the per-request ``timeout`` and
-        (optionally) the per-request retry budget are overridden. This
-        makes one-off requests with adjusted options effectively free.
-        In this transport-sharing mode the clone does **not** own the
-        underlying client; calling :meth:`close` on the clone is a no-op.
-        Only the original is responsible for closing the transport.
+        (optionally) the per-request retry budget are overridden. In this
+        transport-sharing mode the clone does **not** own the underlying
+        client; calling :meth:`close` on the clone is a no-op. Only the
+        original is responsible for closing the transport.
 
         **Passing ``base_url`` creates an independent client; the
         transport is NOT shared.** Because the underlying
-        :class:`httpx.Client` binds its ``base_url`` (and authority-bound
-        timeouts, event hooks, and connection-pool keys) at construction
-        time, swapping the base URL on a shared client would silently
-        target the wrong host for any code path that relies on those
-        bindings. To avoid that footgun, supplying ``base_url`` builds a
-        fresh :class:`httpx.Client` for the clone and the clone owns it
-        — you must :meth:`close` the clone (or use it as a context
-        manager) independently of the original.
+        :class:`httpx.Client` binds its ``base_url`` (and
+        authority-bound timeouts, event hooks, and connection-pool keys)
+        at construction time, swapping the base URL on a shared client
+        would silently target the wrong host for any code path that
+        relies on those bindings. To avoid that footgun, supplying
+        ``base_url`` builds a fresh :class:`httpx.Client` for the
+        clone and the clone owns it — you must ``clone.close()`` (or use ``with``) independently of the
+        original.
 
         The auth provider, if any, is reused (not duplicated) so token
         state is shared across the original and the clone.
@@ -275,16 +280,16 @@ class HonuaAdminClient:
                 values reuse the parent's transport with a per-request
                 ``httpx.Timeout(...)`` override.
             max_retries: When set, overrides the retry budget. ``0``
-                disables retries on the clone by forwarding a per-request
-                override to the retry transport.
+                disables retries on the clone via a per-request extension
+                read by the retry transport.
             base_url: When set, the returned clone is fully independent
-                (owns its own :class:`httpx.Client` and connection pool)
-                and must be closed separately. The transport is NOT
-                shared with the original.
+                (owns its own :class:`httpx.Client` and connection
+                pool) and must be closed separately. The transport is
+                NOT shared with the original.
 
         Returns:
-            A :class:`HonuaAdminClient` instance — transport-sharing
-            when the override timeout is greater than or equal to the
+            An :class:`HonuaAdminClient` — transport-sharing when
+            the override timeout is greater than or equal to the
             parent's configured timeout, independently-owned when
             ``base_url`` is supplied or when ``timeout`` is smaller than
             the parent's configured timeout.
@@ -484,7 +489,7 @@ class HonuaAdminClient:
         Raises:
             HonuaHttpError: The server responded with a non-success status.
             HonuaTransportError: The request failed before any HTTP
-                response was received (DNS/connect/read failures).
+                response was received.
         """
         data = self._request_json(
             "GET",
@@ -506,8 +511,7 @@ class HonuaAdminClient:
         """Fetch the resolved settings for a single service.
 
         Args:
-            name: Service name as advertised by the catalog. The value
-                is URL-encoded before being placed in the path.
+            name: Service name as advertised by the catalog. URL-encoded.
 
         Returns:
             A :class:`ServiceSettingsResponse` describing protocol
@@ -541,14 +545,11 @@ class HonuaAdminClient:
         """Replace the enabled-protocol list for a service.
 
         Args:
-            name: Service name; URL-encoded before being placed in the path.
-            protocols: Ordered list of protocol identifiers to enable
-                (e.g. ``["MapServer", "FeatureServer"]``). The server
-                treats this as the complete desired state.
+            name: Service name; URL-encoded.
+            protocols: Desired ordered list of protocol identifiers.
 
         Returns:
-            The refreshed :class:`ServiceSettingsResponse` reflecting the
-            new protocol configuration.
+            The refreshed :class:`ServiceSettingsResponse`.
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
@@ -588,7 +589,7 @@ class HonuaAdminClient:
         """Patch the MapServer-specific settings for a service.
 
         Args:
-            name: Service name; URL-encoded before being placed in the path.
+            name: Service name; URL-encoded.
             max_image_width: Maximum allowed image width in pixels.
             max_image_height: Maximum allowed image height in pixels.
             default_image_width: Default image width applied when callers omit one.
@@ -652,17 +653,15 @@ class HonuaAdminClient:
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
     ) -> list[MetadataResource]:
-        """List metadata resources, optionally filtered.
+        """List metadata resources, optionally filtered by kind/namespace.
 
         Args:
-            kind: When provided, restrict results to a single resource
-                kind (e.g. ``"Layer"``, ``"Service"``).
-            namespace: When provided, restrict results to a single
-                logical namespace.
+            kind: Optional resource-kind filter.
+            namespace: Optional namespace filter.
 
         Returns:
-            All matching :class:`MetadataResource` instances; empty list
-            when the server returns a non-list payload.
+            Matching :class:`MetadataResource` objects; empty when the
+            server returns a non-list payload.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -699,23 +698,20 @@ class HonuaAdminClient:
         """Fetch a single metadata resource together with its ETag.
 
         Args:
-            kind: Resource kind (e.g. ``"Layer"``); URL-encoded.
-            ns: Namespace the resource lives in; URL-encoded.
+            kind: Resource kind; URL-encoded.
+            ns: Namespace; URL-encoded.
             name: Resource name; URL-encoded.
 
         Returns:
-            A tuple ``(resource, etag)``. ``etag`` is ``None`` when the
-            server did not return an ``ETag`` response header — pass the
-            value back to :meth:`update_metadata_resource` /
-            :meth:`delete_metadata_resource` as ``if_match`` to enforce
-            optimistic concurrency.
+            A tuple ``(resource, etag)``; ``etag`` is ``None`` when the
+            server did not return an ``ETag`` response header.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
 
         Raises:
-            HonuaHttpError: The server responded with a non-success status,
-                including when the response body cannot be decoded as JSON.
+            HonuaHttpError: The server responded with a non-success
+                status or the response body was not valid JSON.
             HonuaTransportError: The request failed at the transport layer.
         """
         kind_segment = encode_path_segment(kind)
@@ -751,9 +747,7 @@ class HonuaAdminClient:
         """Create a new metadata resource on the server.
 
         Args:
-            resource: The resource to create. The server assigns
-                generation metadata; pass the returned value back to
-                callers who need the canonical form.
+            resource: Desired initial state of the resource.
 
         Returns:
             The server-canonical :class:`MetadataResource` after creation.
@@ -762,8 +756,7 @@ class HonuaAdminClient:
         ``idempotency_key``) are forwarded to :meth:`_request`.
 
         Raises:
-            HonuaHttpError: The server rejected the create (e.g. duplicate
-                name, validation failure).
+            HonuaHttpError: The server rejected the create.
             HonuaTransportError: The request failed at the transport layer.
         """
         data = self._request_json(
@@ -795,10 +788,7 @@ class HonuaAdminClient:
             ns: Namespace; URL-encoded.
             name: Resource name; URL-encoded.
             resource: Desired full state of the resource.
-            if_match: Optional ETag value. When provided, the server
-                rejects the write if the current resource ETag does not
-                match (HTTP 412 Precondition Failed surfaces as
-                :class:`HonuaHttpError`).
+            if_match: Optional ETag for optimistic concurrency.
 
         Returns:
             The server-canonical :class:`MetadataResource` after update.
@@ -807,8 +797,8 @@ class HonuaAdminClient:
         ``idempotency_key``) are forwarded to :meth:`_request`.
 
         Raises:
-            HonuaHttpError: The server rejected the update, including
-                precondition failures when ``if_match`` is supplied.
+            HonuaHttpError: The server rejected the update (including
+                precondition failures when ``if_match`` is supplied).
             HonuaTransportError: The request failed at the transport layer.
         """
         kind_segment = encode_path_segment(kind)
@@ -851,8 +841,7 @@ class HonuaAdminClient:
         ``idempotency_key``) are forwarded to :meth:`_request`.
 
         Raises:
-            HonuaHttpError: The server rejected the delete (e.g. 404 if
-                the resource no longer exists, or 412 on ETag mismatch).
+            HonuaHttpError: The server rejected the delete.
             HonuaTransportError: The request failed at the transport layer.
         """
         kind_segment = encode_path_segment(kind)
@@ -883,8 +872,7 @@ class HonuaAdminClient:
         """Return the server's reported admin API version.
 
         Returns:
-            An :class:`AdminVersionResponse` carrying SDK / server
-            version strings and the server build metadata.
+            An :class:`AdminVersionResponse`.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -910,9 +898,7 @@ class HonuaAdminClient:
         """Return the server's advertised admin capabilities and compat block.
 
         Returns:
-            An :class:`AdminCapabilitiesResponse` exposing protocol
-            availability and the compatibility contract used by
-            :meth:`check_compatibility`.
+            An :class:`AdminCapabilitiesResponse`.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -953,8 +939,8 @@ class HonuaAdminClient:
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`get_capabilities`.
         """
-        compatibility = self.get_capabilities(
-            timeout=timeout, extra_headers=extra_headers
+        compatibility = (
+            self.get_capabilities(timeout=timeout, extra_headers=extra_headers)
         ).compatibility
         if compatibility is None:
             return AdminCompatibilityFeatureFlags(
@@ -1005,12 +991,10 @@ class HonuaAdminClient:
         """Export the server's metadata as a single declarative manifest.
 
         Args:
-            namespace: When provided, restrict the manifest to a single
-                logical namespace.
+            namespace: Optional namespace filter.
 
         Returns:
-            A :class:`MetadataManifest` suitable for round-tripping back
-            through :meth:`apply_manifest`.
+            A :class:`MetadataManifest`.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -1042,8 +1026,7 @@ class HonuaAdminClient:
         """Apply a declarative metadata manifest to the server.
 
         Args:
-            request: The manifest payload, dry-run flag, prune flag, and
-                any per-application options.
+            request: Manifest payload plus any dry-run / prune flags.
             idempotency_key: Stripe-style ``Idempotency-Key`` header value.
                 When ``None`` and the underlying retry transport is
                 configured to retry ``POST`` (i.e. the caller opted in via
@@ -1051,8 +1034,7 @@ class HonuaAdminClient:
                 that retries are de-duplicated server-side.
 
         Returns:
-            A :class:`ManifestApplyResult` summarising created, updated,
-            unchanged, and deleted resources.
+            A :class:`ManifestApplyResult` summarising the effect.
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
@@ -1104,8 +1086,8 @@ class HonuaAdminClient:
         """List every secure datasource connection registered on the server.
 
         Returns:
-            Typed :class:`SecureConnectionSummary` objects (credentials
-            elided). Empty list when the server returns a non-list payload.
+            Typed :class:`SecureConnectionSummary` objects; empty when
+            the server returns a non-list payload.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -1134,12 +1116,10 @@ class HonuaAdminClient:
         """Fetch detailed information for a single secure connection.
 
         Args:
-            id: Connection identifier; URL-encoded before being placed in
-                the path.
+            id: Connection identifier; URL-encoded.
 
         Returns:
-            A :class:`SecureConnectionDetail` with non-secret connection
-            metadata (DSN fields, encryption metadata, etc.).
+            A :class:`SecureConnectionDetail`.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -1168,8 +1148,7 @@ class HonuaAdminClient:
         """Create a new secure datasource connection.
 
         Args:
-            request: Connection definition including DSN, credentials,
-                and any options the server should persist.
+            request: Connection definition (DSN, credentials, options).
             idempotency_key: Stripe-style ``Idempotency-Key`` header value.
                 When ``None`` and the underlying retry transport is
                 configured to retry ``POST`` (i.e. the caller opted in via
@@ -1177,8 +1156,7 @@ class HonuaAdminClient:
                 that retries are de-duplicated server-side.
 
         Returns:
-            A :class:`SecureConnectionSummary` describing the new
-            connection (with secrets elided).
+            A :class:`SecureConnectionSummary` (secrets elided).
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
@@ -1212,16 +1190,14 @@ class HonuaAdminClient:
                 :meth:`create_connection`.
 
         Returns:
-            A :class:`ConnectionTestResult` reporting whether the server
-            could establish the connection.
+            A :class:`ConnectionTestResult`. A failed probe is reported
+            in the result payload, not as an exception.
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
 
         Raises:
-            HonuaHttpError: The server returned a non-success status; a
-                failed connection probe is still surfaced as a normal
-                :class:`ConnectionTestResult` payload, not an exception.
+            HonuaHttpError: The server returned a non-success status.
             HonuaTransportError: The request failed at the transport layer.
         """
         data = self._request_json(
@@ -1284,15 +1260,13 @@ class HonuaAdminClient:
             id: Connection identifier; URL-encoded.
 
         Returns:
-            A :class:`ConnectionTestResult`. A failed probe is reported
-            in the result payload, not as an exception.
+            A :class:`ConnectionTestResult`.
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
 
         Raises:
-            HonuaHttpError: The server itself rejected the request (e.g.
-                404 if the connection has been deleted).
+            HonuaHttpError: The server itself rejected the request.
             HonuaTransportError: The request failed at the transport layer.
         """
         connection_id = encode_path_segment(id)
@@ -1344,9 +1318,7 @@ class HonuaAdminClient:
         """Verify that the server can decrypt every stored credential.
 
         Returns:
-            An :class:`EncryptionValidationResult` summarising which
-            connections (if any) could not be decrypted with the
-            current key.
+            An :class:`EncryptionValidationResult`.
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
@@ -1374,8 +1346,7 @@ class HonuaAdminClient:
         """Rotate the server's connection-encryption key.
 
         Returns:
-            A :class:`KeyRotationResult` reporting how many connections
-            were re-encrypted under the new key.
+            A :class:`KeyRotationResult`.
 
         Per-request options (``timeout`` / ``extra_headers`` /
         ``idempotency_key``) are forwarded to :meth:`_request`.
@@ -1409,12 +1380,11 @@ class HonuaAdminClient:
 
         Args:
             conn_id: Connection identifier; URL-encoded.
-            service_name: When provided, restrict results to layers that
-                belong to a specific service.
+            service_name: When provided, restrict to one service's layers.
 
         Returns:
-            All matching :class:`PublishedLayerSummary` instances; empty
-            list when the server returns a non-list payload.
+            Matching :class:`PublishedLayerSummary` objects; empty when
+            the server returns a non-list payload.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -1451,8 +1421,7 @@ class HonuaAdminClient:
 
         Args:
             conn_id: Connection identifier; URL-encoded.
-            request: Layer-publication payload (target table, service,
-                naming, default symbology, etc.).
+            request: Layer-publication payload.
             idempotency_key: Stripe-style ``Idempotency-Key`` header value.
                 When ``None`` and the underlying retry transport is
                 configured to retry ``POST`` (i.e. the caller opted in via
@@ -1495,10 +1464,9 @@ class HonuaAdminClient:
 
         Args:
             conn_id: Connection identifier; URL-encoded.
-            layer_id: Numeric layer identifier as advertised by the service.
+            layer_id: Numeric layer identifier.
             enabled: Desired ``enabled`` state.
-            service_name: When provided, scopes the toggle to a single
-                service so layers shared across services are unaffected.
+            service_name: Optional service-scoped toggle.
 
         Returns:
             The refreshed :class:`PublishedLayerSummary`.
@@ -1540,12 +1508,11 @@ class HonuaAdminClient:
         Args:
             conn_id: Connection identifier; URL-encoded.
             enabled: Desired ``enabled`` state for every layer in scope.
-            service_name: When provided, restrict the bulk toggle to a
-                single service's layers.
+            service_name: Optional per-service restriction.
 
         Returns:
             Refreshed :class:`PublishedLayerSummary` objects for every
-            affected layer; empty list when the server returns a non-list
+            affected layer; empty when the server returns a non-list
             payload.
 
         Per-request options (``timeout`` / ``extra_headers`` /
@@ -1589,8 +1556,7 @@ class HonuaAdminClient:
             conn_id: Connection identifier; URL-encoded.
 
         Returns:
-            A :class:`TableDiscoveryResponse` listing schemas, tables,
-            and per-table geometry/key hints.
+            A :class:`TableDiscoveryResponse`.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -1621,9 +1587,8 @@ class HonuaAdminClient:
         """List the styles published over OGC API - Styles (``GET /ogc/styles``).
 
         Returns:
-            An :class:`OgcStylesList` of ``styleId``-keyed
-            :class:`OgcStyleSummary` entries plus the optional default
-            style and landing links.
+            An :class:`OgcStylesList` of ``styleId``-keyed entries plus the
+            optional default style and landing links.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.
@@ -1778,7 +1743,7 @@ class HonuaAdminClient:
             layer_id: Numeric layer identifier.
 
         Returns:
-            A :class:`LayerStyleResponse` carrying the current renderer.
+            A :class:`LayerStyleResponse`.
 
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`_request`.

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -1243,6 +1243,7 @@ class AsyncHonuaClient:
         features: list[Feature] = []
         offset = _endpoints.initial_offset(extra_params)
         base_extra_params = dict(extra_params or {})
+        seen_object_ids: set[int] = set()
         for _ in range(max_pages):
             remaining = None if limit is None else limit - len(features)
             if remaining is not None and remaining <= 0:
@@ -1263,6 +1264,18 @@ class AsyncHonuaClient:
                 extra_headers=extra_headers,
             )
             page_features = list(page.features)
+            # Non-advancing-cursor guard: a server that ignores ``resultOffset``
+            # keeps returning the same page with ``exceededTransferLimit=true``,
+            # which would otherwise loop to ``max_pages`` and duplicate every
+            # feature. When object ids are present, stop once a page adds no new
+            # ones (and drop the duplicates we already collected this page).
+            new_object_ids = {
+                oid for f in page_features if (oid := f.object_id) is not None
+            }
+            stalled = bool(new_object_ids) and new_object_ids.issubset(seen_object_ids)
+            if stalled:
+                break
+            seen_object_ids |= new_object_ids
             if remaining is not None:
                 page_features = page_features[:remaining]
             features.extend(page_features)

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -1,4 +1,6 @@
 """Synchronous HTTP client for Honua Server APIs."""
+# AUTO-GENERATED from packages/honua-sdk/honua_sdk/async_client.py by scripts/gen_sync.py — do not edit by hand.
+# Edit the async source-of-truth and run `python scripts/gen_sync.py`.
 
 from __future__ import annotations
 
@@ -91,8 +93,9 @@ if TYPE_CHECKING:
 class HonuaClient:
     """Task-oriented synchronous client for common Honua data-plane workflows.
 
-    Wraps the Honua REST/HTTP surface (catalog, FeatureServer, OGC API
-    Features, STAC, OData, WFS, WMS, WMTS, geocoding) and the canonical
+    Wraps the Honua
+    REST/HTTP surface (catalog, FeatureServer, OGC API Features, STAC,
+    OData, WFS, WMS, WMTS, geocoding) and the canonical
     ``Source`` / ``Query`` / ``Result`` facade behind a single typed
     entrypoint.
 
@@ -101,8 +104,8 @@ class HonuaClient:
     exclusive). ``bearer_token=`` is **deprecated** (removal in 0.2.x);
     prefer ``auth_provider=StaticAuthProvider({"Authorization": f"Bearer
     {token}"})``. When ``client`` is supplied as a pre-built
-    :class:`httpx.Client`, no auth kwargs may be passed — configure them
-    on the client instead.
+    :class:`httpx.Client`, no auth kwargs may be passed — configure
+    them on the client instead.
 
     Retries: only idempotent methods (GET/HEAD/PUT/DELETE/OPTIONS) on
     transient statuses (429/502/503/504) are retried by default. Opt
@@ -190,13 +193,13 @@ class HonuaClient:
                 auth_provider=auth_provider,
             )
 
-        # Always wrap with ``RetryTransport`` — even when ``max_retries == 0``.
-        # The transport only retries when its budget is positive, but it is
-        # also the component that consults the per-request ``honua_max_retries``
-        # override stashed by ``with_options(max_retries=…)``. Installing it
-        # unconditionally is what lets a client built with ``max_retries=0``
-        # later opt into retries via ``with_options(max_retries=N)`` instead of
-        # silently no-op'ing.
+        # Always wrap with ``RetryTransport`` — even when
+        # ``max_retries == 0``. The transport only retries when its budget is
+        # positive, but it is also the component that consults the per-request
+        # ``honua_max_retries`` override stashed by
+        # ``with_options(max_retries=…)``. Installing it unconditionally is what
+        # lets a client built with ``max_retries=0`` later opt into retries via
+        # ``with_options(max_retries=N)`` instead of silently no-op'ing.
         inner = transport or httpx.HTTPTransport()
         retry_transport = RetryTransport(inner, max_retries=max_retries)
         effective_transport: httpx.BaseTransport = retry_transport
@@ -220,8 +223,8 @@ class HonuaClient:
         """Release underlying HTTP resources if this instance owns the client.
 
         When the client was constructed with an externally supplied
-        :class:`httpx.Client`, ownership stays with the caller and this
-        method is a no-op.
+        :class:`httpx.Client`, ownership stays with the caller and
+        this method is a no-op.
         """
         if self._owns_client:
             self._client.close()
@@ -238,25 +241,21 @@ class HonuaClient:
         When only ``timeout`` and/or ``max_retries`` are supplied, the
         returned client **reuses the original's** :class:`httpx.Client`
         and its connection pool — only the per-request ``timeout`` and
-        (optionally) the per-request retry budget are overridden. This
-        makes one-off requests with adjusted options effectively free.
-        In this transport-sharing mode the clone does **not** own the
-        underlying client; calling :meth:`close` on the clone is a no-op.
-        Only the original is responsible for closing the transport.
+        (optionally) the per-request retry budget are overridden. In this
+        transport-sharing mode the clone does **not** own the underlying
+        client; calling :meth:`close` on the clone is a no-op. Only the
+        original is responsible for closing the transport.
 
         **Passing ``base_url`` creates an independent client; the
         transport is NOT shared.** Because the underlying
-        :class:`httpx.Client` binds its ``base_url`` (and authority-bound
-        timeouts, event hooks, and connection-pool keys) at construction
-        time, swapping the base URL on a shared client would silently
-        target the wrong host for any code path that relies on those
-        bindings. To avoid that footgun, supplying ``base_url`` builds a
-        fresh :class:`httpx.Client` for the clone and the clone owns it
-        — you must :meth:`close` the clone (or use it as a context
-        manager) independently of the original.
-
-        The auth provider, if any, is reused (not duplicated) so token
-        state is shared across the original and the clone.
+        :class:`httpx.Client` binds its ``base_url`` (and
+        authority-bound timeouts, event hooks, and connection-pool keys)
+        at construction time, swapping the base URL on a shared client
+        would silently target the wrong host for any code path that
+        relies on those bindings. To avoid that footgun, supplying
+        ``base_url`` builds a fresh :class:`httpx.Client` for the
+        clone and the clone owns it — you must ``clone.close()`` (or use ``with``) independently of the
+        original.
 
         Args:
             timeout: When set, overrides the per-request timeout. Smaller
@@ -265,15 +264,15 @@ class HonuaClient:
                 values reuse the parent's transport with a per-request
                 ``httpx.Timeout(...)`` override.
             max_retries: When set, overrides the retry budget. ``0``
-                disables retries on the clone by forwarding a per-request
-                override to the retry transport.
+                disables retries on the clone via a per-request extension
+                read by the retry transport.
             base_url: When set, the returned clone is fully independent
-                (owns its own :class:`httpx.Client` and connection pool)
-                and must be closed separately. The transport is NOT
-                shared with the original.
+                (owns its own :class:`httpx.Client` and connection
+                pool) and must be closed separately. The transport is
+                NOT shared with the original.
 
         Returns:
-            A :class:`HonuaClient` instance — transport-sharing when the
+            An :class:`HonuaClient` — transport-sharing when the
             override timeout is greater than or equal to the parent's
             configured timeout, independently-owned when ``base_url`` is
             supplied or when ``timeout`` is smaller than the parent's
@@ -300,10 +299,8 @@ class HonuaClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            # The clone re-forwards ``bearer_token`` so the deprecation
-            # warning would re-fire here even though the caller already
-            # acknowledged it at original construction. Suppress it on the
-            # internal clone path; the user only deals with it once.
+            # Suppress the re-fired bearer_token deprecation on the internal
+            # clone path; the caller acknowledged it at original construction.
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
                 clone = self.__class__(
@@ -324,16 +321,11 @@ class HonuaClient:
             )
             return clone
 
-        # Shallow-copy ``self`` so any future ``_init_*`` slot added to the
-        # constructor automatically rides along to the clone without
-        # manual maintenance here. The clone shares the parent's
-        # :class:`httpx.Client`, ``_base_url``, retry-method set, and
-        # constructor inputs; only the override fields below are
-        # rewritten on the copy.
+        # Shallow-copy ``self`` so future ``_init_*`` slots ride along
+        # automatically; see the sync ``HonuaClient.with_options`` for
+        # the full rationale.
         clone = copy.copy(self)
         clone._owns_client = False  # clone never closes the shared transport
-        # Fold parent overrides in so chained ``with_options`` calls
-        # accumulate rather than reset.
         clone._options_timeout = (
             timeout if timeout is not None else self._options_timeout
         )
@@ -353,9 +345,8 @@ class HonuaClient:
 
         Provided for parity with the stripe-python convention, where both
         ``client.copy(...)`` and ``client.with_options(...)`` return a
-        reconfigured clone. The semantics (transport sharing vs. an
-        independent clone) are identical to :meth:`with_options`; see that
-        method for the full contract.
+        reconfigured clone. The semantics are identical to
+        :meth:`with_options`; see that method for the full contract.
         """
         return self.with_options(
             timeout=timeout, max_retries=max_retries, base_url=base_url
@@ -455,12 +446,12 @@ class HonuaClient:
         Per-request options (``timeout`` / ``extra_headers``) are forwarded
         to :meth:`capabilities`.
         """
-        return self.capabilities(timeout=timeout, extra_headers=extra_headers).supports(
-            capability
-        )
+        return (
+            self.capabilities(timeout=timeout, extra_headers=extra_headers)
+        ).supports(capability)
 
     def source(self, descriptor: "SourceDescriptor | Mapping[str, Any]") -> "Source":
-        """Return a source-bound facade for canonical Source/Query/Result workflows.
+        """Return a source-bound facade for Source/Query/Result workflows.
 
         Args:
             descriptor: A :class:`SourceDescriptor` (or mapping convertible
@@ -468,7 +459,7 @@ class HonuaClient:
                 should target.
 
         Returns:
-            A :class:`Source` bound to this client's transport.
+            An :class:`Source` bound to this client's transport.
         """
         from .source import Source
 
@@ -542,21 +533,21 @@ class HonuaClient:
         """Return an OGC API Features wrapper bound to this client.
 
         Returns:
-            A :class:`HonuaOgcFeatures` facade that reuses this client's
-            HTTP session.
+            An :class:`HonuaOgcFeatures` facade that reuses this
+            client's HTTP session.
         """
         from .ogc import HonuaOgcFeatures
 
         return HonuaOgcFeatures(self)
 
     def geocoder(self, locator: str = "World") -> "HonuaGeocodingClient":
-        """Return a GeocodeServer wrapper that reuses this client's HTTP session.
+        """Return a GeocodeServer wrapper that reuses this client's session.
 
         Args:
             locator: GeocodeServer locator name (defaults to ``"World"``).
 
         Returns:
-            A :class:`HonuaGeocodingClient` bound to ``locator``.
+            An :class:`HonuaGeocodingClient` bound to ``locator``.
         """
         from .geocoding import HonuaGeocodingClient
 
@@ -569,7 +560,7 @@ class HonuaClient:
             service_id: Service identifier as advertised by the catalog.
 
         Returns:
-            A :class:`GeoServicesFeatureServerClient` bound to this
+            An :class:`GeoServicesFeatureServerClient` bound to this
             client's transport.
 
         Raises:
@@ -588,8 +579,8 @@ class HonuaClient:
             service_id: Service identifier as advertised by the catalog.
 
         Returns:
-            A :class:`GeoServicesMapServerClient` bound to this client's
-            transport.
+            An :class:`GeoServicesMapServerClient` bound to this
+            client's transport.
         """
         from .protocols import GeoServicesMapServerClient
 
@@ -603,7 +594,8 @@ class HonuaClient:
                 wrapper targets the deployment-level ImageServer surface.
 
         Returns:
-            A :class:`GeoServicesImageServerClient` bound to this client.
+            An :class:`GeoServicesImageServerClient` bound to this
+            client.
         """
         from .protocols import GeoServicesImageServerClient
 
@@ -613,8 +605,8 @@ class HonuaClient:
         """Return the GeoServices GeometryServer wrapper.
 
         Returns:
-            A :class:`GeoServicesGeometryServerClient` bound to this
-            client's transport.
+            An :class:`GeoServicesGeometryServerClient` bound to
+            this client's transport.
         """
         from .protocols import GeoServicesGeometryServerClient
 
@@ -624,7 +616,8 @@ class HonuaClient:
         """Return an OGC API Maps wrapper.
 
         Returns:
-            An :class:`OgcMapsClient` bound to this client's transport.
+            An :class:`OgcMapsClient` bound to this client's
+            transport.
         """
         from .protocols import OgcMapsClient
 
@@ -634,7 +627,8 @@ class HonuaClient:
         """Return an OGC API Tiles wrapper.
 
         Returns:
-            An :class:`OgcTilesClient` bound to this client's transport.
+            An :class:`OgcTilesClient` bound to this client's
+            transport.
         """
         from .protocols import OgcTilesClient
 
@@ -644,7 +638,8 @@ class HonuaClient:
         """Return an OGC API Coverages wrapper.
 
         Returns:
-            An :class:`OgcCoveragesClient` bound to this client's transport.
+            An :class:`OgcCoveragesClient` bound to this client's
+            transport.
         """
         from .protocols import OgcCoveragesClient
 
@@ -654,7 +649,8 @@ class HonuaClient:
         """Return an OGC API Processes wrapper.
 
         Returns:
-            An :class:`OgcProcessesClient` bound to this client's transport.
+            An :class:`OgcProcessesClient` bound to this client's
+            transport.
         """
         from .protocols import OgcProcessesClient
 
@@ -670,8 +666,8 @@ class HonuaClient:
         """Return a geoprocessing (OGC API Processes) client.
 
         Returns:
-            A :class:`~honua_sdk.geoprocessing.HonuaGeoprocessing` bound to
-            this client's transport for listing/describing processes and
+            An :class:`~honua_sdk.geoprocessing.HonuaGeoprocessing` bound
+            to this client's transport for listing/describing processes and
             submitting + polling + fetching the results of process executions.
         """
         from .geoprocessing import HonuaGeoprocessing
@@ -682,12 +678,13 @@ class HonuaClient:
         """Return a workflow package authoring + publication client.
 
         Returns:
-            A :class:`~honua_sdk.workflow.HonuaWorkflow` bound to this client's
-            transport for authoring workflow package drafts, snapshotting
-            immutable versions, validating / dry-running / publishing them, and
-            running publications over the server's ``/api/v1/console`` workflow
-            package surface (the durable replacement for the dropped GeoETL
-            pipeline endpoints; admin authorization required server-side).
+            An :class:`~honua_sdk.workflow.HonuaWorkflow` bound to this
+            client's transport for authoring workflow package drafts,
+            snapshotting immutable versions, validating / dry-running /
+            publishing them, and running publications over the server's
+            ``/api/v1/console`` workflow package surface (the durable
+            replacement for the dropped GeoETL pipeline endpoints; admin
+            authorization required server-side).
         """
         from .workflow import HonuaWorkflow
 
@@ -697,7 +694,7 @@ class HonuaClient:
         """Return a STAC API wrapper.
 
         Returns:
-            A :class:`StacClient` bound to this client's transport.
+            An :class:`StacClient` bound to this client's transport.
         """
         from .protocols import StacClient
 
@@ -707,8 +704,7 @@ class HonuaClient:
         """Return a 3D scene metadata + resolution wrapper.
 
         Returns:
-            A :class:`SceneClient` bound to this client's transport for
-            scene discovery and render-endpoint resolution.
+            An :class:`SceneClient` bound to this client's transport.
         """
         from .protocols import SceneClient
 
@@ -718,8 +714,7 @@ class HonuaClient:
         """Return an elevation HTTP API wrapper.
 
         Returns:
-            An :class:`ElevationClient` bound to this client's transport
-            for point-value and along-line profile elevation queries.
+            An :class:`ElevationClient` bound to this client's transport.
         """
         from .protocols.scenes import ElevationClient
 
@@ -729,7 +724,7 @@ class HonuaClient:
         """Return a WFS 2.0 wrapper.
 
         Returns:
-            A :class:`WfsClient` bound to this client's transport.
+            An :class:`WfsClient` bound to this client's transport.
         """
         from .protocols import WfsClient
 
@@ -742,7 +737,7 @@ class HonuaClient:
             service_id: Service identifier as advertised by the catalog.
 
         Returns:
-            A :class:`WmsClient` bound to this client's transport.
+            An :class:`WmsClient` bound to this client's transport.
         """
         from .protocols import WmsClient
 
@@ -755,7 +750,7 @@ class HonuaClient:
             service_id: Service identifier as advertised by the catalog.
 
         Returns:
-            A :class:`WmtsClient` bound to this client's transport.
+            An :class:`WmtsClient` bound to this client's transport.
         """
         from .protocols import WmtsClient
 
@@ -815,12 +810,11 @@ class HonuaClient:
                 request across all protocols (FeatureServer, OGC Features,
                 STAC, OData). Accepts a ``float`` seconds value or an
                 :class:`httpx.Timeout`.
-            extra_headers: Additional HTTP headers merged into every
-                page request across all protocols.
             idempotency_key: Stripe-style ``Idempotency-Key`` header
                 value attached to every page request. Merged into
-                ``extra_headers`` before forwarding to the pagination
-                wrappers.
+                ``extra_headers`` before forwarding.
+            extra_headers: Additional HTTP headers merged into every
+                page request across all protocols.
 
         Returns:
             A :class:`FeatureQueryResult` containing the normalized
@@ -871,14 +865,14 @@ class HonuaClient:
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
     ) -> tuple[tuple[QueryFeature, ...], bool, int | None, int]:
-        """Walk protocol pages, collect features, and capture pagination signals.
+        """Walk protocol pages and capture pagination signals.
 
         Returns ``(features, exceeded_transfer_limit, total_count, pages_seen)``.
 
         Per-call ``timeout`` / ``extra_headers`` are forwarded to every
         protocol's pagination wrapper (FeatureServer, OGC Features, STAC,
         OData). The kwarg construction for each protocol lives in
-        :mod:`._query_dispatch` so the sync and async dispatchers share
+        :mod:`._query_dispatch` so the sync and dispatchers share
         every non-IO step.
         """
         collected: list[QueryFeature] = []
@@ -888,7 +882,6 @@ class HonuaClient:
         limit = query.limit
 
         def _extend(items: list[QueryFeature]) -> bool:
-            """Append ``items`` up to ``limit``; return ``True`` when the cap is hit."""
             if limit is not None:
                 remaining = limit - len(collected)
                 if remaining <= 0:
@@ -1506,12 +1499,9 @@ class HonuaClient:
 
         Per-request options (Stripe / OpenAI-SDK shaped):
 
-        * ``timeout``: overrides the client- and ``with_options``-level
-          timeout for this call only. Accepts ``float`` seconds or an
-          :class:`httpx.Timeout`.
-        * ``extra_headers``: merged into the outbound request headers
-          (existing ``headers`` win on key conflict, then ``extra_headers``,
-          then any auto-generated ``Idempotency-Key``).
+        * ``timeout``: overrides client- and ``with_options``-level timeouts
+          for this call only.
+        * ``extra_headers``: merged into the outbound request headers.
         * ``idempotency_key``: when set, attaches an ``Idempotency-Key``
           header to the outbound request, overriding any header of the
           same name in ``headers`` / ``extra_headers``.
@@ -1527,7 +1517,6 @@ class HonuaClient:
             "json": json_body,
             "headers": merged_headers,
         }
-        # Per-request timeout wins; otherwise apply per-client override from with_options.
         if timeout is not None:
             request_kwargs["timeout"] = (
                 timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Generate the synchronous client modules from their async source-of-truth.
+
+The synchronous data-plane (:mod:`honua_sdk.client`) and control-plane
+(:mod:`honua_admin._client`) clients are *near-perfect mirrors* of their async
+counterparts: identical method names, signatures, docstrings, and control flow,
+differing only by the mechanical sync/async transform (``async def`` → ``def``,
+``await x`` → ``x``, ``async with`` → ``with``, the ``httpx.AsyncClient`` →
+``httpx.Client`` family, and the ``Async*`` class/module names → their sync
+equivalents).
+
+To eliminate the long-lived hand-maintained duplication, the **async modules
+are the single source of truth** and the sync modules are *generated* from them
+by this script. The generated files are committed to the repository so that
+``pip install`` never needs codegen and there is **no new runtime dependency**
+(this is a dev-only tool — it is not in any package's dependency list, and the
+``unasync`` package is intentionally not used).
+
+Usage::
+
+    python scripts/gen_sync.py            # rewrite the committed sync files
+    python scripts/gen_sync.py --check    # fail if a sync file is stale
+
+The ``--check`` mode regenerates each file in memory and compares it against the
+committed version, exiting non-zero (with a diff) if they differ. CI runs this
+mode so that editing an async source without regenerating its sync mirror fails
+the build.
+
+Whenever a sync/async pair drifts in a way this transform cannot express,
+*reconcile the divergence in the async source* and extend the replacement table
+below — never hand-edit a generated sync file (its header says as much).
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from re import Match
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AUTO_GENERATED_BANNER = (
+    "# AUTO-GENERATED from {source} by scripts/gen_sync.py "
+    "— do not edit by hand.\n"
+    "# Edit the async source-of-truth and run `python scripts/gen_sync.py`.\n"
+)
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single ordered text replacement.
+
+    ``pattern`` is a compiled regex applied with :func:`re.Pattern.sub`;
+    ``replacement`` is its substitution. Rules are applied in declaration
+    order, so more specific rules must precede the general ones they would
+    otherwise be clobbered by (e.g. ``Asynchronous`` → ``Synchronous`` must
+    run before the generic ``\\bAsync`` → ```` strip).
+    """
+
+    pattern: re.Pattern[str]
+    replacement: str | Callable[[Match[str]], str]
+
+    def apply(self, text: str) -> str:
+        return self.pattern.sub(self.replacement, text)
+
+
+def _rule(
+    pattern: str, replacement: str | Callable[[Match[str]], str]
+) -> Rule:
+    return Rule(re.compile(pattern), replacement)
+
+
+# Ordered, exhaustive sync/async replacement table.
+#
+# Order matters. Specific rules come first; the broad ``\bAsync`` identifier
+# strip comes last so it only fires on the residual ``Async*`` class names
+# (``AsyncHonuaClient`` → ``HonuaClient`` etc.) after the typed/httpx/module
+# special cases have already been handled.
+_COMMON_RULES: tuple[Rule, ...] = (
+    # --- prose (docstrings / comments / module summary) -------------------
+    # ``Asynchronous`` / ``asynchronous`` must be rewritten before the generic
+    # ``Async`` strip would corrupt them. Casing is preserved.
+    _rule(r"\bAsynchronous\b", "Synchronous"),
+    _rule(r"\basynchronous\b", "synchronous"),
+    # ``Async counterpart to :class:`X`: <word>`` is async-only boilerplate
+    # that describes the relationship to the sync class — meaningless in the
+    # generated sync file. Strip the lead-in (which may wrap across a line)
+    # and upper-case the first letter of the sentence it introduced, so e.g.
+    # "Async counterpart to :class:`HonuaClient`: wraps the …" becomes
+    # "Wraps the …". The ``\s+`` after the colon absorbs the line wrap +
+    # docstring indentation.
+    _rule(
+        r"Async counterpart to :class:`[^`]+`:\s+([a-z])",
+        lambda m: m.group(1).upper(),
+    ),
+    # Module-summary docstrings: ``"""Async ... API client ..."""``. The
+    # leading ``Async `` (with a trailing space, so the generic Async-strip
+    # below — which requires an immediately-following capital — does not fire)
+    # is dropped from the one-line module docstring.
+    _rule(r'^"""Async ', '"""'),
+    # Residual async-flavoured prose inside docstrings that does NOT use the
+    # ``async``/``await`` *keywords* (those are handled by the statement-level
+    # rules below) but still describes async behaviour. These phrases are
+    # wrong in the generated sync file.
+    #
+    # "an async <Thing>" / "the async <Thing>" → drop the adjective, fixing
+    # the indefinite article to agree with the now-following word. The
+    # source uses LETTER-based article agreement (e.g. "a WFS", "a STAC",
+    # "an OGC", "an OData"), so the article is "an" iff the next word starts
+    # with a vowel *letter* — which reproduces every hand-written sync case.
+    _rule(
+        r"\b([Aa])n? async (\w)",
+        lambda m: (
+            f"{m.group(1)}n {m.group(2)}"
+            if m.group(2).lower() in "aeiou"
+            else f"{m.group(1)} {m.group(2)}"
+        ),
+    ),
+    _rule(r"\b([Tt])he async (\w)", r"\1he \2"),
+    # Parenthetical "(async)" qualifier in summary lines — drop it (the sync
+    # mirror simply omits it). Handles both " ... signals (async)." and
+    # " ... request (async), ...".
+    _rule(r"\s*\(async\)", ""),
+    # "this coroutine is a no-op" → "this method is a no-op". Scope the
+    # rewrite to the "... is a no-op" phrasing so we never touch a genuine
+    # technical use of the word elsewhere.
+    _rule(r"\bcoroutine is a no-op\b", "method is a no-op"),
+    # "awaiting :meth:`x`" → "calling :meth:`x`" (the sync verb).
+    _rule(r"\bawaiting (?=:meth:`)", "calling "),
+    #
+    # --- statement-level async syntax -------------------------------------
+    _rule(r"\basync def\b", "def"),
+    _rule(r"\basync with\b", "with"),
+    _rule(r"\basync for\b", "for"),
+    # Any *remaining* bare "async <lower-word>" adjective in prose (no leading
+    # article) — e.g. "async iterator"/"async generator". Runs AFTER the
+    # ``async def``/``with``/``for`` keyword rules above so it only ever fires
+    # on residual prose, never on a control-flow keyword.
+    _rule(r"\basync (?=[a-z])", ""),
+    # ``await EXPR`` → ``EXPR``. Only strip the keyword + following space; this
+    # leaves the awaited expression intact. ``await`` only ever appears as a
+    # prefix operator in these modules.
+    _rule(r"\bawait\s+", ""),
+    #
+    # --- dunder context-manager / iterator protocol -----------------------
+    _rule(r"__aenter__", "__enter__"),
+    _rule(r"__aexit__", "__exit__"),
+    _rule(r"__aiter__", "__iter__"),
+    _rule(r"__anext__", "__next__"),
+    #
+    # --- async stdlib / builtins ------------------------------------------
+    _rule(r"\basyncio\.sleep\b", "time.sleep"),
+    # Any other ``asyncio.<attr>`` is unexpected in these facades; map the
+    # module defensively so a stray reference becomes a clear sync error
+    # rather than a silently-awaited coroutine. (No occurrences today.)
+    _rule(r"\banext\(", "next("),
+    _rule(r"\baiter\(", "iter("),
+    #
+    # --- typing constructs -------------------------------------------------
+    _rule(r"\bAsyncIterator\b", "Iterator"),
+    _rule(r"\bAsyncIterable\b", "Iterable"),
+    _rule(r"\bAsyncGenerator\b", "Generator"),
+    _rule(r"\bAsyncContextManager\b", "ContextManager"),
+    # ``Awaitable[T]`` → ``T`` (unwrap the awaitable). Handles a single level
+    # of bracket nesting in the inner type, which is all the public surface
+    # uses. (No occurrences today, but kept for completeness/safety.)
+    _rule(r"\bAwaitable\[((?:[^\[\]]|\[[^\[\]]*\])*)\]", r"\1"),
+    #
+    # --- httpx async surface ----------------------------------------------
+    # Handled by the generic ``\bAsync`` strip below
+    # (AsyncClient → Client, AsyncBaseTransport → BaseTransport,
+    # AsyncHTTPTransport → HTTPTransport), but the resource-close method is
+    # distinct and must be mapped explicitly.
+    _rule(r"\baclose\b", "close"),
+    #
+    # --- module-name seams -------------------------------------------------
+    # Async-only sibling modules collapse onto their sync equivalents.
+    _rule(r"\b_async_retry\b", "_retry"),
+    _rule(r"\basync_geocoding\b", "geocoding"),
+    #
+    # --- residual Async-prefixed identifiers ------------------------------
+    # Everything left — the ``Async*`` client/transport/protocol class names
+    # (AsyncHonuaClient → HonuaClient, AsyncSource → Source,
+    # AsyncRetryTransport → RetryTransport, AsyncClient → Client, …). The word
+    # boundary keeps it from touching substrings inside larger identifiers.
+    _rule(r"\bAsync(?=[A-Z])", ""),
+)
+
+
+@dataclass(frozen=True)
+class Target:
+    """One async-source → generated-sync mapping."""
+
+    source: Path
+    dest: Path
+    rules: tuple[Rule, ...] = field(default=_COMMON_RULES)
+
+    @property
+    def source_rel(self) -> str:
+        return self.source.relative_to(ROOT).as_posix()
+
+    @property
+    def dest_rel(self) -> str:
+        return self.dest.relative_to(ROOT).as_posix()
+
+
+TARGETS: tuple[Target, ...] = (
+    Target(
+        source=ROOT / "packages/honua-sdk/honua_sdk/async_client.py",
+        dest=ROOT / "packages/honua-sdk/honua_sdk/client.py",
+    ),
+    Target(
+        source=ROOT / "packages/honua-admin/honua_admin/_async_client.py",
+        dest=ROOT / "packages/honua-admin/honua_admin/_client.py",
+    ),
+)
+
+
+def _ruff_fix_imports(text: str, dest: Path) -> str:
+    """Re-sort imports in the generated source via ``ruff``.
+
+    The async and sync sibling-module import names sort to different positions
+    (e.g. ``from ._async_retry import AsyncRetryTransport`` sits before
+    ``_http`` while ``from ._retry import RetryTransport`` sorts after
+    ``_query_dispatch``). Rather than encode brittle positional edits, run
+    ruff's import-sorter (rule family ``I``) over the transformed text. ruff is
+    a dev/CI tool already required by this repo; it is **not** a runtime
+    dependency of any package.
+    """
+    proc = subprocess.run(
+        [
+            "ruff",
+            "check",
+            "--select",
+            "I",
+            "--fix",
+            "--quiet",
+            "--stdin-filename",
+            str(dest),
+            "-",
+        ],
+        input=text,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        check=False,
+    )
+    # ruff exits non-zero when it could not auto-fix everything; with only the
+    # import-sort rule selected and well-formed input that should not happen.
+    if proc.returncode not in (0, 1):
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(
+            f"ruff import-sort failed for {dest} (exit {proc.returncode})"
+        )
+    return proc.stdout
+
+
+def _transform(target: Target) -> str:
+    source_text = target.source.read_text(encoding="utf-8")
+
+    # Apply the ordered replacement table to the body.
+    body = source_text
+    for rule in target.rules:
+        body = rule.apply(body)
+
+    # Insert the auto-generated banner *after* the module docstring so the
+    # docstring remains ``__doc__``. The async source always opens with a
+    # triple-quoted one-line module docstring on line 1.
+    banner = AUTO_GENERATED_BANNER.format(source=target.source_rel)
+    lines = body.splitlines(keepends=True)
+    insert_at = _docstring_end_index(lines)
+    rebuilt = "".join(lines[:insert_at]) + banner + "".join(lines[insert_at:])
+
+    return _ruff_fix_imports(rebuilt, target.dest)
+
+
+def _docstring_end_index(lines: list[str]) -> int:
+    """Index of the first line *after* the module docstring.
+
+    Supports a single-line triple-quoted docstring (the convention used by
+    both async sources) and a multi-line one. Returns ``0`` when there is no
+    leading module docstring.
+    """
+    if not lines:
+        return 0
+    first = lines[0].lstrip()
+    for quote in ('"""', "'''"):
+        if first.startswith(quote):
+            # Single-line docstring: closing quotes on the same line.
+            if first.rstrip().endswith(quote) and len(first.strip()) >= 2 * len(quote):
+                return 1
+            # Multi-line: scan for the closing delimiter.
+            for idx in range(1, len(lines)):
+                if quote in lines[idx]:
+                    return idx + 1
+            return len(lines)
+    return 0
+
+
+def generate(target: Target) -> str:
+    return _transform(target)
+
+
+def write_all() -> None:
+    for target in TARGETS:
+        generated = generate(target)
+        target.dest.write_text(generated, encoding="utf-8")
+        print(f"wrote {target.dest_rel} (from {target.source_rel})")
+
+
+def check_all() -> int:
+    stale: list[str] = []
+    for target in TARGETS:
+        generated = generate(target)
+        current = target.dest.read_text(encoding="utf-8")
+        if generated != current:
+            stale.append(target.dest_rel)
+            diff = difflib.unified_diff(
+                current.splitlines(keepends=True),
+                generated.splitlines(keepends=True),
+                fromfile=f"{target.dest_rel} (committed)",
+                tofile=f"{target.dest_rel} (regenerated)",
+            )
+            sys.stderr.writelines(diff)
+    if stale:
+        sys.stderr.write(
+            "\nStale generated sync file(s): "
+            + ", ".join(stale)
+            + "\nRun `python scripts/gen_sync.py` and commit the result.\n"
+        )
+        return 1
+    print("Generated sync files are up to date.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify the committed sync files match the async sources; "
+        "exit non-zero (with a diff) if any is stale.",
+    )
+    args = parser.parse_args(argv)
+    if args.check:
+        return check_all()
+    write_all()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -166,6 +166,37 @@ async def test_query_features_all_returns_typed_paginated_features() -> None:
     assert seen == [("0", "2"), ("2", "1")]
 
 
+async def test_query_features_all_stops_on_non_advancing_cursor() -> None:
+    # issue #107.4: a server that ignores ``resultOffset`` returns the same
+    # full page with exceededTransferLimit=true forever. The non-advancing
+    # cursor guard must stop after the first page rather than looping to
+    # max_pages and duplicating features.
+    call_count = {"n": 0}
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        # Always the same two objectids, regardless of the requested offset.
+        return httpx.Response(
+            200,
+            json={
+                "features": [
+                    {"attributes": {"objectid": 1}},
+                    {"attributes": {"objectid": 2}},
+                ],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        features = await client.query_features_all("parcels", 0, page_size=2, max_pages=100)
+
+    # Only the first page is kept; no duplicates, and we stop after detecting
+    # the stall (one extra probe page) rather than walking all 100 pages.
+    assert [feature.object_id for feature in features] == [1, 2]
+    assert call_count["n"] < 100
+
+
 async def test_shared_query_feature_server_normalizes_common_args() -> None:
     seen: dict[str, str] = {}
 


### PR DESCRIPTION
Part of #67.

## What

De-duplicates the near-mirror sync/async HTTP clients via unasync-style codegen: the **async modules are the single source of truth**, and the synchronous mirrors are **generated** from them and committed.

- `packages/honua-sdk/honua_sdk/async_client.py` → generates `client.py`
- `packages/honua-admin/honua_admin/_async_client.py` → generates `_client.py`

The transform (`scripts/gen_sync.py`) is **dev-only** — no new runtime dependency, `unasync` is not added to any package's deps, and the generated files are committed so `pip install` never runs codegen.

## Public API: unchanged

This is dedup, not redesign. Class names, method names, signatures, and import paths are identical. The **compatibility gate reports zero public-API drift**, and an AST comparison (docstrings stripped) of each generated file vs. its prior hand-written version is **identical**.

## Phase 0 — divergence reconciled

Diffed both pairs and classified every difference as a legit async-ism (`await`, `async with/for`, `aclose`, `AsyncIterator`, the `httpx.Async*` family, `Async*` class names) vs. genuine behavioral divergence.

- **One genuine divergence (data-plane):** the `query_features_all` *non-advancing-cursor guard* (issue #107.4 — dedupes features and stops early when a server ignores `resultOffset`) existed only in the **sync** client. Reconciled by porting it into `async_client.py` (the correct behavior), plus a new parallel async test.
- **Admin pair (~35 LOC):** no behavioral divergence — only docstring wording/wrapping plus a structural import seam. The async admin client imported the sync/async-agnostic `_json_object` helper from the sync `._client`; inlined it into `_async_client.py` so the generated sync module defines it locally instead of importing itself.

All remaining differences were docstring prose/wrapping, which now derive from the async source-of-truth.

## Transform approach

`scripts/gen_sync.py` applies an exhaustive, ordered regex replacement table (specific rules before general): `async def`→`def`, `await `→``, `async with/for`→`with/for`, `__aenter__/__aexit__`→`__enter__/__exit__`, `aclose`→`close`, `AsyncIterator/AsyncIterable/AsyncGenerator`→sync, `Awaitable[...]` unwrapping, `asyncio.sleep`→`time.sleep`, `anext`→`next`, the `httpx.Async*` family, async sibling-module seams (`_async_retry`→`_retry`, `async_geocoding`→`geocoding`), the `Async*`-prefixed class names → sync, plus async-flavored *prose* in docstrings (article-corrected). It runs a `ruff --select I --fix` import-sort pass and emits an `AUTO-GENERATED` header.

## CI staleness guard

`python scripts/gen_sync.py --check` is wired into the lint job (and documented in AGENTS.md): editing an async client without regenerating its committed sync mirror fails CI via `git`-equivalent diff.

## Verification (all green)

- **pytest** (sync + async): 1114 passed, 3 skipped; coverage 94.58% (gate 94%)
- **mypy** (strict): no issues in 61 files
- **ruff check .**: all checks passed
- **mkdocs build --strict**: exit 0
- **compatibility gate**: passed — zero public-API change
- **gen_sync --check**: up to date (idempotent; reproducible with system Python + ruff)

## Self-review

Re-read both generated files end-to-end. Found and fixed leaked async-flavored docstring *prose* the initial transform missed ("async context manager", "this coroutine is a no-op", "awaiting :meth:`close`", "Return an async X wrapper" with article agreement, "(async)" qualifiers, "Async counterpart to …" boilerplate). After fixes: no leaked `await`, no `Async`/`asyncio`/`aclose`, no async-only constructs in the sync files (the only `async_client.py` reference is the intentional generated-from banner). Iterators/context managers and type annotations fully transformed; AST-identical to the originals modulo docstrings.

LOC: ~3,050 of hand-maintained sync/async duplication eliminated (two ~1.5–1.9k-line sync files become generated, traded for a 358-line transform script).
