### PR TITLE
Wire spatial filters, statistics, and unbounded pagination through the REST query path

### DIFF
--- a/compatibility/protocol-factories.json
+++ b/compatibility/protocol-factories.json
@@ -23,6 +23,11 @@
         "returns": "AsyncGeoServicesGeometryServerClient",
         "signature": "(self) -> \"'AsyncGeoServicesGeometryServerClient'\""
       },
+      "grpc": {
+        "parameters": "(self, *, target: 'str | None' = None, insecure: 'bool | None' = None, credentials: 'Any' = None, timeout: 'float | None' = 30.0, extra_metadata: 'Mapping[str, str] | None' = None)",
+        "returns": "HonuaGrpcAsyncClient",
+        "signature": "(self, *, target: 'str | None' = None, insecure: 'bool | None' = None, credentials: 'Any' = None, timeout: 'float | None' = 30.0, extra_metadata: 'Mapping[str, str] | None' = None) -> \"'HonuaGrpcAsyncClient'\""
+      },
       "image_server": {
         "parameters": "(self, service_id: 'str | None' = None)",
         "returns": "AsyncGeoServicesImageServerClient",
@@ -114,6 +119,11 @@
         "parameters": "(self)",
         "returns": "GeoServicesGeometryServerClient",
         "signature": "(self) -> \"'GeoServicesGeometryServerClient'\""
+      },
+      "grpc": {
+        "parameters": "(self, *, target: 'str | None' = None, insecure: 'bool | None' = None, credentials: 'Any' = None, timeout: 'float | None' = 30.0, extra_metadata: 'Mapping[str, str] | None' = None)",
+        "returns": "HonuaGrpcClient",
+        "signature": "(self, *, target: 'str | None' = None, insecure: 'bool | None' = None, credentials: 'Any' = None, timeout: 'float | None' = 30.0, extra_metadata: 'Mapping[str, str] | None' = None) -> \"'HonuaGrpcClient'\""
       },
       "image_server": {
         "parameters": "(self, service_id: 'str | None' = None)",

--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -3807,13 +3807,17 @@
               "kind": "method",
               "signature": "(self) -> \"'AsyncHonuaGeoprocessing'\""
             },
+            "grpc": {
+              "kind": "method",
+              "signature": "(self, *, target: 'str | None' = None, insecure: 'bool | None' = None, credentials: 'Any' = None, timeout: 'float | None' = 30.0, extra_metadata: 'Mapping[str, str] | None' = None) -> \"'HonuaGrpcAsyncClient'\""
+            },
             "image_server": {
               "kind": "method",
               "signature": "(self, service_id: 'str | None' = None) -> \"'AsyncGeoServicesImageServerClient'\""
             },
             "iter_query": {
               "kind": "method",
-              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'AsyncIterator[QueryFeature]'"
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = 100, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'AsyncIterator[QueryFeature]'"
             },
             "list_service_summaries": {
               "async": true,
@@ -3860,7 +3864,7 @@
             "query": {
               "async": true,
               "kind": "method",
-              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'FeatureQueryResult'"
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, out_statistics: 'Sequence[Mapping[str, Any]] | None' = None, group_by: 'str | Sequence[str] | None' = None, return_distinct_values: 'bool | None' = None, return_count_only: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = 100, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'FeatureQueryResult'"
             },
             "query_feature_set": {
               "async": true,
@@ -3965,7 +3969,7 @@
             },
             "iter_features": {
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'AsyncIterator[QueryFeature]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'AsyncIterator[QueryFeature]'"
             },
             "protocol": {
               "kind": "method",
@@ -3977,16 +3981,16 @@
             "query": {
               "async": true,
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Result[QueryFeature]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Result[QueryFeature]'"
             },
             "query_all": {
               "async": true,
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'tuple[QueryFeature, ...]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'tuple[QueryFeature, ...]'"
             },
             "stream": {
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'AsyncIterator[QueryFeature]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'AsyncIterator[QueryFeature]'"
             },
             "supports": {
               "kind": "method",
@@ -4245,6 +4249,11 @@
               "name": "bbox"
             },
             {
+              "annotation": "Mapping[str, Any] | None",
+              "default": "None",
+              "name": "spatial_filter"
+            },
+            {
               "annotation": "str | Sequence[str] | None",
               "default": "None",
               "name": "fields"
@@ -4253,6 +4262,26 @@
               "annotation": "bool",
               "default": "True",
               "name": "return_geometry"
+            },
+            {
+              "annotation": "Sequence[Mapping[str, Any]] | None",
+              "default": "None",
+              "name": "out_statistics"
+            },
+            {
+              "annotation": "str | Sequence[str] | None",
+              "default": "None",
+              "name": "group_by"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_distinct_values"
+            },
+            {
+              "annotation": "bool",
+              "default": "False",
+              "name": "return_count_only"
             },
             {
               "annotation": "int | None",
@@ -4278,7 +4307,7 @@
           "kind": "class",
           "module": "honua_sdk.models",
           "qualname": "FeatureQuery",
-          "signature": "(source: 'str', protocol: 'QueryProtocol | str' = 'feature-server', layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool' = True, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any]' = <factory>) -> None"
+          "signature": "(source: 'str', protocol: 'QueryProtocol | str' = 'feature-server', layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool' = True, out_statistics: 'Sequence[Mapping[str, Any]] | None' = None, group_by: 'str | Sequence[str] | None' = None, return_distinct_values: 'bool' = False, return_count_only: 'bool' = False, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any]' = <factory>) -> None"
         },
         "FeatureQueryResult": {
           "fields": [
@@ -4469,13 +4498,17 @@
               "kind": "method",
               "signature": "(self) -> \"'HonuaGeoprocessing'\""
             },
+            "grpc": {
+              "kind": "method",
+              "signature": "(self, *, target: 'str | None' = None, insecure: 'bool | None' = None, credentials: 'Any' = None, timeout: 'float | None' = 30.0, extra_metadata: 'Mapping[str, str] | None' = None) -> \"'HonuaGrpcClient'\""
+            },
             "image_server": {
               "kind": "method",
               "signature": "(self, service_id: 'str | None' = None) -> \"'GeoServicesImageServerClient'\""
             },
             "iter_query": {
               "kind": "method",
-              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Iterator[QueryFeature]'"
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = 100, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Iterator[QueryFeature]'"
             },
             "list_service_summaries": {
               "kind": "method",
@@ -4519,7 +4552,7 @@
             },
             "query": {
               "kind": "method",
-              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = None, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'FeatureQueryResult'"
+              "signature": "(self, source: 'str | FeatureQuery', *, protocol: 'QueryProtocol | None' = None, layer_id: 'int | None' = None, where: 'str | None' = None, filter: 'str | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, out_statistics: 'Sequence[Mapping[str, Any]] | None' = None, group_by: 'str | Sequence[str] | None' = None, return_distinct_values: 'bool | None' = None, return_count_only: 'bool | None' = None, page_size: 'int | None' = None, limit: 'int | None' = None, max_pages: 'int | None' = 100, extra_params: 'Mapping[str, Any] | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'FeatureQueryResult'"
             },
             "query_feature_set": {
               "kind": "method",
@@ -4992,7 +5025,7 @@
             },
             "iter_features": {
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'Iterator[QueryFeature]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'Iterator[QueryFeature]'"
             },
             "protocol": {
               "kind": "method",
@@ -5003,15 +5036,15 @@
             },
             "query": {
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Result[QueryFeature]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Result[QueryFeature]'"
             },
             "query_all": {
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'tuple[QueryFeature, ...]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None) -> 'tuple[QueryFeature, ...]'"
             },
             "stream": {
               "kind": "method",
-              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Iterator[QueryFeature]'"
+              "signature": "(self, query: 'Query | Mapping[str, Any] | None' = None, *, where: 'str | None' = None, out_fields: 'str | Sequence[str] | None' = None, return_geometry: 'bool | None' = None, bbox: 'str | Sequence[int | float] | None' = None, spatial_filter: 'Mapping[str, Any] | None' = None, limit: 'int | None' = None, page_size: 'int | None' = None, max_pages: 'int | None' = None, cql_filter: 'str | None' = None, where_as_cql: 'bool | None' = None, extra_params: 'Mapping[str, Any] | None' = None, fields: 'str | Sequence[str] | None' = None, filter: 'str | None' = None, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'Iterator[QueryFeature]'"
             },
             "supports": {
               "kind": "method",

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -60,8 +60,13 @@ Two `Query` knobs control the underlying pagination loop:
   Forwarded to FeatureServer's `resultRecordCount`, OGC/STAC's `limit`,
   and OData's `$top` (subject to server-side caps).
 - **`max_pages`** — upper bound on the number of pages the iterator
-  will fetch. When omitted, the iterator drains until the server stops
-  advertising more pages.
+  will fetch. The `client.query` / `client.iter_query` facades default
+  this cap to **100**; pass **`max_pages=None`** for an *unbounded* walk
+  that drains until the server stops advertising more pages. When a
+  bounded `client.query` walk stops at the cap while the server still
+  reports more features (`exceededTransferLimit`), a `ResourceWarning`
+  is emitted so a large iterate never silently truncates — raise
+  `max_pages`, set it to `None`, or pass a `limit` to acknowledge it.
 
 ```python
 from honua_sdk import Query
@@ -69,7 +74,55 @@ from honua_sdk import Query
 q = Query(where="1=1", page_size=500, max_pages=20)
 for feature in source.iter_features(q):
     process(feature)
+
+# Unbounded drain (no hidden 100-page cap):
+for feature in client.iter_query("parcels", page_size=1000, max_pages=None):
+    process(feature)
 ```
+
+## Server-side spatial filters and statistics (FeatureServer)
+
+`client.query` / `Source.query` accept an arbitrary-geometry spatial
+filter and server-side statistics on the GeoServices FeatureServer path,
+mirroring Esri's `query(geometry=..., spatial_relationship=...)` and
+arcpy summary-statistics queries.
+
+```python
+# "Select by location": features WITHIN a polygon (Esri JSON, GeoJSON, or
+# any shapely/`__geo_interface__` geometry are accepted).
+result = client.query(
+    "parcels",
+    spatial_filter={
+        "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+        "relationship": "within",     # intersects / within / contains / crosses / touches / overlaps / within-distance
+        "in_sr": 4326,
+    },
+)
+
+# Within-distance ("buffer" select):
+client.query(
+    "stations",
+    spatial_filter={"geometry": {"x": -73.0, "y": 40.7}, "relationship": "within-distance",
+                    "distance": 500, "units": "meters"},
+)
+
+# Server-side statistics + group-by:
+summary = client.query(
+    "parcels",
+    out_statistics=[{"statistic_type": "sum", "on_statistic_field": "area", "out_statistic_field_name": "total_area"}],
+    group_by="zone",
+)
+
+# Distinct values / count-only:
+client.query("parcels", return_distinct_values=True, out_fields="zone")
+client.query("parcels", where="area > 1000", return_count_only=True)
+```
+
+On the `Source` facade these route through `Query.spatial_filter` and the
+`Query.aggregation` mapping (`out_statistics` / `group_by` /
+`return_distinct_values` / `return_count_only`). Both are GeoServices-only
+request shapes; supplying them for a non-FeatureServer source raises
+`ValueError` rather than silently dropping the predicate.
 
 ## Worked recipes
 

--- a/packages/honua-sdk/honua_sdk/_geoservices_query.py
+++ b/packages/honua-sdk/honua_sdk/_geoservices_query.py
@@ -1,0 +1,347 @@
+"""GeoServices REST request-construction helpers for spatial filters and statistics.
+
+The Honua FeatureServer (GeoServices REST) ``query`` endpoint already supports
+arbitrary-geometry spatial filters (``geometry`` + ``geometryType`` +
+``spatialRel`` + ``inSR`` + ``distance``/``units``) and server-side
+statistics/aggregation (``outStatistics`` + ``groupByFieldsForStatistics`` +
+``returnDistinctValues`` + ``returnCountOnly``). The SDK previously only
+emitted the bbox-envelope form of a spatial filter and exposed
+statistics/aggregation solely on the gRPC surface.
+
+This module is the SDK-side translation layer that turns a Pythonic
+spatial-filter mapping (accepting Esri JSON, GeoJSON, or any object exposing
+``__geo_interface__`` such as a ``shapely`` geometry) plus a chosen spatial
+relationship into the GeoServices query parameters, and turns a list of
+statistic definitions / group-by fields into their GeoServices equivalents.
+It is pure request construction — no server change is required.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Spatial relationships
+# ---------------------------------------------------------------------------
+
+#: Canonical spatial-relationship tokens accepted on a spatial filter, mapped to
+#: their GeoServices ``spatialRel`` values. Accepts the bare relationship name
+#: (``"intersects"``), the gRPC-style ``SCREAMING_SNAKE`` form
+#: (``"WITHIN_DISTANCE"``), and the raw Esri token (``"esriSpatialRelWithin"``).
+_SPATIAL_REL: dict[str, str] = {
+    "intersects": "esriSpatialRelIntersects",
+    "envelope-intersects": "esriSpatialRelEnvelopeIntersects",
+    "envelopeintersects": "esriSpatialRelEnvelopeIntersects",
+    "contains": "esriSpatialRelContains",
+    "within": "esriSpatialRelWithin",
+    "crosses": "esriSpatialRelCrosses",
+    "touches": "esriSpatialRelTouches",
+    "overlaps": "esriSpatialRelOverlaps",
+    "relation": "esriSpatialRelRelation",
+    # Distance-based relationships have no dedicated ``spatialRel`` token in
+    # GeoServices; they are expressed as ``geometry`` + ``distance`` + ``units``
+    # against an intersects relation. Mapped here so callers can name the intent.
+    "within-distance": "esriSpatialRelIntersects",
+    "withindistance": "esriSpatialRelIntersects",
+}
+
+#: Relationship tokens that imply a distance-based query (``distance`` + ``units``).
+_DISTANCE_RELATIONSHIPS = frozenset({"within-distance", "withindistance"})
+
+
+def normalize_spatial_relationship(value: str) -> str:
+    """Map a relationship name to its GeoServices ``spatialRel`` token.
+
+    Accepts the canonical lower-case names (``"intersects"``, ``"within"``,
+    ``"within-distance"``, ...), the gRPC ``SpatialRelationship`` enum member
+    name (``"WITHIN_DISTANCE"``), or a raw ``esriSpatialRel*`` token (returned
+    unchanged). Raises :class:`ValueError` on an unrecognised relationship.
+    """
+    text = str(value).strip()
+    if text.startswith("esriSpatialRel"):
+        return text
+    key = text.lower().replace("_", "-")
+    try:
+        return _SPATIAL_REL[key]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_SPATIAL_REL))
+        raise ValueError(
+            f"Unsupported spatial relationship {value!r}. Expected one of: {supported}."
+        ) from exc
+
+
+def _is_distance_relationship(value: str) -> bool:
+    return str(value).strip().lower().replace("_", "-") in _DISTANCE_RELATIONSHIPS
+
+
+# ---------------------------------------------------------------------------
+# Geometry coercion (Esri JSON / GeoJSON / __geo_interface__) → Esri JSON
+# ---------------------------------------------------------------------------
+
+#: Index of the first non-planar ordinate (z) in an ``[x, y, z]`` coordinate.
+_XY_LEN = 2
+
+_GEOJSON_TO_ESRI_TYPE = {
+    "Point": "esriGeometryPoint",
+    "MultiPoint": "esriGeometryMultipoint",
+    "LineString": "esriGeometryPolyline",
+    "MultiLineString": "esriGeometryPolyline",
+    "Polygon": "esriGeometryPolygon",
+    "MultiPolygon": "esriGeometryPolygon",
+}
+
+
+def coerce_geometry(geometry: Any, *, default_type: str | None = None) -> tuple[dict[str, Any], str]:
+    """Coerce a geometry to ``(esri_json, esriGeometryType)``.
+
+    Accepts:
+
+    * Esri JSON mappings (``{"x", "y"}``, ``{"rings": ...}``, ``{"paths": ...}``,
+      ``{"points": ...}``, or an envelope ``{"xmin", "ymin", "xmax", "ymax"}``) —
+      passed through with the geometry type inferred from its keys.
+    * GeoJSON geometry mappings (``{"type", "coordinates"}``).
+    * Any object exposing ``__geo_interface__`` (e.g. a ``shapely`` geometry),
+      which yields a GeoJSON geometry.
+
+    ``default_type`` is an explicit ``esriGeometryType`` override; when provided
+    it is used verbatim for an Esri-JSON mapping whose shape can't be inferred,
+    instead of raising.
+
+    Returns the Esri JSON geometry dict and its ``geometryType`` token.
+    """
+    if geometry is None:
+        raise ValueError("spatial_filter requires a geometry.")
+    # shapely / GeoJSON-like objects expose __geo_interface__.
+    if not isinstance(geometry, Mapping) and hasattr(geometry, "__geo_interface__"):
+        geometry = geometry.__geo_interface__
+    if not isinstance(geometry, Mapping):
+        raise TypeError(
+            "spatial_filter geometry must be an Esri JSON mapping, a GeoJSON "
+            "geometry, or an object exposing __geo_interface__ (e.g. shapely)."
+        )
+
+    # GeoJSON geometry: has a "type" + "coordinates".
+    if "type" in geometry and "coordinates" in geometry:
+        return _geojson_geometry_to_esri(geometry), _GEOJSON_TO_ESRI_TYPE.get(
+            str(geometry.get("type")), "esriGeometryPolygon"
+        )
+
+    if default_type is not None:
+        return dict(geometry), default_type
+    return dict(geometry), _esri_geometry_type(geometry)
+
+
+def _esri_geometry_type(geometry: Mapping[str, Any]) -> str:
+    if "x" in geometry and "y" in geometry:
+        return "esriGeometryPoint"
+    if "rings" in geometry:
+        return "esriGeometryPolygon"
+    if "paths" in geometry:
+        return "esriGeometryPolyline"
+    if "points" in geometry:
+        return "esriGeometryMultipoint"
+    if {"xmin", "ymin", "xmax", "ymax"} <= set(geometry):
+        return "esriGeometryEnvelope"
+    raise ValueError(
+        "Could not infer the Esri geometry type from the spatial_filter geometry; "
+        "provide an explicit 'geometryType' in the spatial_filter mapping."
+    )
+
+
+def _geojson_geometry_to_esri(geometry: Mapping[str, Any]) -> dict[str, Any]:
+    gtype = str(geometry.get("type"))
+    coords = geometry.get("coordinates")
+    if gtype == "Point":
+        point = list(coords or [])
+        result: dict[str, Any] = {"x": point[0], "y": point[1]}
+        if len(point) > _XY_LEN:
+            result["z"] = point[_XY_LEN]
+        return result
+    if gtype == "MultiPoint":
+        return {"points": [list(c) for c in coords or []]}
+    if gtype == "LineString":
+        return {"paths": [[list(c) for c in coords or []]]}
+    if gtype == "MultiLineString":
+        return {"paths": [[list(c) for c in line] for line in coords or []]}
+    if gtype == "Polygon":
+        return {"rings": [[list(c) for c in ring] for ring in coords or []]}
+    if gtype == "MultiPolygon":
+        rings: list[list[list[float]]] = []
+        for polygon in coords or []:
+            for ring in polygon:
+                rings.append([list(c) for c in ring])
+        return {"rings": rings}
+    raise ValueError(f"Unsupported GeoJSON geometry type: {gtype!r}.")
+
+
+# ---------------------------------------------------------------------------
+# Spatial-filter mapping → GeoServices params
+# ---------------------------------------------------------------------------
+
+
+def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] is not None:
+            return mapping[key]
+    return None
+
+
+def _sr_wkid(value: Any) -> int | str | None:
+    """Extract a wkid (or wkt string) from an SR mapping / int / string."""
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        wkid = _first(value, "wkid", "latestWkid", "latest_wkid")
+        if wkid is not None:
+            return int(wkid) if not isinstance(wkid, bool) else None
+        wkt = value.get("wkt")
+        return str(wkt) if wkt else None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | str):
+        return value
+    return str(value)
+
+
+def spatial_filter_params(spatial_filter: Mapping[str, Any]) -> dict[str, Any]:
+    """Translate a spatial-filter mapping into GeoServices ``query`` params.
+
+    Recognised keys (case-insensitive aliases accepted):
+
+    * ``geometry`` — Esri JSON / GeoJSON / ``__geo_interface__`` geometry (required).
+    * ``relationship`` / ``spatial_relationship`` / ``relation`` — relationship
+      token (default ``"intersects"``). See :data:`_SPATIAL_REL`.
+    * ``geometry_type`` / ``geometryType`` — explicit Esri geometry type
+      override (otherwise inferred from the geometry).
+    * ``in_sr`` / ``sr`` / ``spatial_reference`` — input spatial reference
+      (EPSG/wkid; defaults to the geometry's embedded ``spatialReference`` or 4326).
+    * ``distance`` and ``units`` / ``distance_unit`` — distance-based filter
+      (required when the relationship is ``within-distance``).
+    """
+    geometry_value = _first(spatial_filter, "geometry", "geom", "shape")
+    explicit_type = _first(spatial_filter, "geometry_type", "geometryType")
+    esri_geometry, inferred_type = coerce_geometry(geometry_value, default_type=explicit_type)
+    geometry_type = explicit_type or inferred_type
+
+    relationship = (
+        _first(spatial_filter, "relationship", "spatial_relationship", "spatialRelationship", "relation")
+        or "intersects"
+    )
+    spatial_rel = normalize_spatial_relationship(str(relationship))
+
+    params: dict[str, Any] = {
+        "geometry": json.dumps(esri_geometry, separators=(",", ":")),
+        "geometryType": geometry_type,
+        "spatialRel": spatial_rel,
+    }
+
+    in_sr = _sr_wkid(
+        _first(spatial_filter, "in_sr", "inSR", "sr", "spatial_reference", "spatialReference")
+    )
+    if in_sr is None:
+        in_sr = _sr_wkid(esri_geometry.get("spatialReference")) if isinstance(esri_geometry, Mapping) else None
+    if in_sr is None:
+        in_sr = 4326
+    params["inSR"] = in_sr
+
+    distance = _first(spatial_filter, "distance")
+    units = _first(spatial_filter, "units", "distance_unit", "distanceUnit")
+    if _is_distance_relationship(str(relationship)) and distance is None:
+        raise ValueError("A 'within-distance' spatial filter requires a 'distance' value.")
+    if distance is not None:
+        params["distance"] = distance
+        if units is not None:
+            params["units"] = _distance_units(units)
+
+    return params
+
+
+_DISTANCE_UNITS = {
+    "meters": "esriSRUnit_Meter",
+    "meter": "esriSRUnit_Meter",
+    "m": "esriSRUnit_Meter",
+    "kilometers": "esriSRUnit_Kilometer",
+    "kilometer": "esriSRUnit_Kilometer",
+    "km": "esriSRUnit_Kilometer",
+    "feet": "esriSRUnit_Foot",
+    "foot": "esriSRUnit_Foot",
+    "ft": "esriSRUnit_Foot",
+    "miles": "esriSRUnit_StatuteMile",
+    "mile": "esriSRUnit_StatuteMile",
+    "mi": "esriSRUnit_StatuteMile",
+}
+
+
+def _distance_units(value: Any) -> str:
+    text = str(value).strip()
+    if text.startswith("esriSRUnit"):
+        return text
+    try:
+        return _DISTANCE_UNITS[text.lower()]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_DISTANCE_UNITS))
+        raise ValueError(
+            f"Unsupported distance unit {value!r}. Expected one of: {supported}."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Statistics / aggregation → GeoServices params
+# ---------------------------------------------------------------------------
+
+_STATISTIC_TYPES = frozenset({"count", "sum", "min", "max", "avg", "stddev", "var"})
+
+
+def _statistic_definition(stat: Mapping[str, Any]) -> dict[str, Any]:
+    stat_type = _first(stat, "statisticType", "statistic_type", "type")
+    on_field = _first(stat, "onStatisticField", "on_statistic_field", "field", "on")
+    out_name = _first(stat, "outStatisticFieldName", "out_statistic_field_name", "out", "as", "alias")
+    if stat_type is None or on_field is None:
+        raise ValueError(
+            "Each out_statistics entry requires a 'statistic_type' and an 'on_statistic_field'."
+        )
+    normalized_type = str(stat_type).strip().lower()
+    if normalized_type not in _STATISTIC_TYPES:
+        supported = ", ".join(sorted(_STATISTIC_TYPES))
+        raise ValueError(
+            f"Unsupported statistic type {stat_type!r}. Expected one of: {supported}."
+        )
+    definition: dict[str, Any] = {
+        "statisticType": normalized_type,
+        "onStatisticField": str(on_field),
+    }
+    definition["outStatisticFieldName"] = str(out_name) if out_name else f"{normalized_type}_{on_field}"
+    return definition
+
+
+def statistics_params(
+    *,
+    out_statistics: Sequence[Mapping[str, Any]] | None = None,
+    group_by: str | Sequence[str] | None = None,
+    return_distinct_values: bool | None = None,
+    return_count_only: bool | None = None,
+) -> dict[str, Any]:
+    """Translate statistics/aggregation inputs into GeoServices ``query`` params.
+
+    Mirrors the arcpy / ArcGIS-API summary-statistics surface:
+
+    * ``out_statistics`` → ``outStatistics`` (a JSON array of statistic defs).
+    * ``group_by`` → ``groupByFieldsForStatistics`` (comma-joined).
+    * ``return_distinct_values`` → ``returnDistinctValues``.
+    * ``return_count_only`` → ``returnCountOnly``.
+    """
+    params: dict[str, Any] = {}
+    if out_statistics:
+        definitions = [_statistic_definition(stat) for stat in out_statistics]
+        params["outStatistics"] = json.dumps(definitions, separators=(",", ":"))
+    if group_by is not None:
+        params["groupByFieldsForStatistics"] = (
+            group_by if isinstance(group_by, str) else ",".join(str(field) for field in group_by)
+        )
+    if return_distinct_values:
+        params["returnDistinctValues"] = "true"
+    if return_count_only:
+        params["returnCountOnly"] = "true"
+    return params

--- a/packages/honua-sdk/honua_sdk/_query.py
+++ b/packages/honua-sdk/honua_sdk/_query.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from typing import Any
 
+from ._geoservices_query import spatial_filter_params, statistics_params
 from .models import Feature, FeatureQuery, QueryFeature, QueryProtocol, normalize_protocol
 
 
@@ -18,8 +19,13 @@ def resolve_feature_query(
     where: str | None = None,
     filter: str | None = None,
     bbox: str | Sequence[int | float] | None = None,
+    spatial_filter: Mapping[str, Any] | None = None,
     fields: str | Sequence[str] | None = None,
     return_geometry: bool | None = None,
+    out_statistics: Sequence[Mapping[str, Any]] | None = None,
+    group_by: str | Sequence[str] | None = None,
+    return_distinct_values: bool | None = None,
+    return_count_only: bool | None = None,
     page_size: int | None = None,
     limit: int | None = None,
     max_pages: int | None = None,
@@ -36,11 +42,24 @@ def resolve_feature_query(
             where=where if where is not None else source.where,
             filter=filter if filter is not None else source.filter,
             bbox=bbox if bbox is not None else source.bbox,
+            spatial_filter=spatial_filter if spatial_filter is not None else source.spatial_filter,
             fields=fields if fields is not None else source.fields,
             return_geometry=return_geometry if return_geometry is not None else source.return_geometry,
+            out_statistics=out_statistics if out_statistics is not None else source.out_statistics,
+            group_by=group_by if group_by is not None else source.group_by,
+            return_distinct_values=(
+                return_distinct_values if return_distinct_values is not None else source.return_distinct_values
+            ),
+            return_count_only=(
+                return_count_only if return_count_only is not None else source.return_count_only
+            ),
             page_size=page_size if page_size is not None else source.page_size,
             limit=limit if limit is not None else source.limit,
-            max_pages=max_pages if max_pages is not None else source.max_pages,
+            # A pre-built FeatureQuery owns its own page cap: per the
+            # ``client.query`` contract the per-call kwargs are ignored for a
+            # pre-built query, so ``source.max_pages`` (``None`` = unbounded)
+            # wins outright and the method-level default never clobbers it.
+            max_pages=source.max_pages,
             extra_params=merged_extra_params,
         )
 
@@ -56,8 +75,13 @@ def resolve_feature_query(
         where=where,
         filter=filter,
         bbox=bbox,
+        spatial_filter=spatial_filter,
         fields=fields,
         return_geometry=True if return_geometry is None else return_geometry,
+        out_statistics=out_statistics,
+        group_by=group_by,
+        return_distinct_values=bool(return_distinct_values),
+        return_count_only=bool(return_count_only),
         page_size=page_size,
         limit=limit,
         max_pages=max_pages,
@@ -113,7 +137,14 @@ def bbox_text(value: str | Sequence[int | float] | None) -> str | None:
 
 def feature_server_extra_params(query: FeatureQuery) -> dict[str, Any]:
     params = dict(query.extra_params)
-    if query.bbox is not None:
+    # An explicit spatial_filter (arbitrary geometry + relationship + SR +
+    # optional distance) takes precedence over the bbox envelope shorthand; the
+    # two are mutually exclusive request shapes for the FeatureServer ``query``
+    # endpoint, so we never emit both ``geometry`` sources.
+    if query.spatial_filter is not None:
+        for key, value in spatial_filter_params(query.spatial_filter).items():
+            params.setdefault(key, value)
+    elif query.bbox is not None:
         bbox = _bbox_values(query.bbox)
         params.setdefault(
             "geometry",
@@ -131,6 +162,14 @@ def feature_server_extra_params(query: FeatureQuery) -> dict[str, Any]:
         params.setdefault("geometryType", "esriGeometryEnvelope")
         params.setdefault("spatialRel", "esriSpatialRelIntersects")
         params.setdefault("inSR", 4326)
+
+    for key, value in statistics_params(
+        out_statistics=query.out_statistics,
+        group_by=query.group_by,
+        return_distinct_values=query.return_distinct_values,
+        return_count_only=query.return_count_only,
+    ).items():
+        params.setdefault(key, value)
     return params
 
 

--- a/packages/honua-sdk/honua_sdk/_query_dispatch.py
+++ b/packages/honua-sdk/honua_sdk/_query_dispatch.py
@@ -24,6 +24,7 @@ Public helpers (callable from both ``client.py`` and ``async_client.py``):
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from typing import Any
 
@@ -36,7 +37,6 @@ from ._query import (
     field_text,
     odata_layer_id,
     query_filter,
-    query_max_pages,
     query_page_size,
 )
 from .models import FeatureQuery
@@ -66,6 +66,32 @@ def validate_filter_routing(query: FeatureQuery, normalized_protocol: str) -> No
             "(CQL2-text) when targeting OGC Features or STAC. To accept "
             "silent forwarding, pass where_as_cql=True explicitly."
         )
+
+
+def warn_if_truncated(query: FeatureQuery, *, exceeded: bool, pages_seen: int) -> None:
+    """Warn when a bounded page walk stopped with more features still available.
+
+    A million-feature iterate that silently halts at the page cap is a footgun.
+    When ``query.max_pages`` is a finite cap, the walk reached it
+    (``pages_seen >= max_pages``), and the server still advertises more
+    (``exceeded`` is its ``exceededTransferLimit`` / next-link signal), we emit
+    a :class:`ResourceWarning` so the truncation is visible. Pass
+    ``max_pages=None`` for an unbounded walk to suppress the cap entirely; a
+    ``limit`` (the caller's own ceiling) also suppresses it.
+    """
+    if query.limit is not None:
+        return
+    max_pages = query.max_pages
+    if not exceeded or max_pages is None or pages_seen < max_pages:
+        return
+    warnings.warn(
+        f"Query stopped after the max_pages={max_pages} cap with more features "
+        "still available on the server (exceededTransferLimit). Increase "
+        "max_pages, set max_pages=None for an unbounded walk, or pass a limit "
+        "to acknowledge the truncation.",
+        ResourceWarning,
+        stacklevel=3,
+    )
 
 
 def merge_idempotency_into_headers(
@@ -144,7 +170,12 @@ def feature_server_pages_kwargs(
         "return_geometry": query.return_geometry,
         "page_size": query_page_size(query, 1000),
         "limit": query.limit,
-        "max_pages": query_max_pages(query, 100),
+        # ``query.max_pages`` is passed through verbatim: ``None`` means
+        # *unbounded* (walk every page the server advertises) rather than the
+        # old silent 100-page cap. The canonical ``query``/``iter_query`` and
+        # ``Source`` methods default the cap to 100 at their own signatures, so
+        # ``None`` here only ever arrives when a caller explicitly opted in.
+        "max_pages": query.max_pages,
         "extra_params": feature_server_extra_params(query),
         "timeout": timeout,
         "extra_headers": extra_headers,
@@ -296,4 +327,5 @@ __all__ = [
     "stac_items_kwargs",
     "stac_pages_kwargs",
     "validate_filter_routing",
+    "warn_if_truncated",
 ]

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -46,6 +46,7 @@ from ._query_dispatch import (
     stac_items_kwargs,
     stac_pages_kwargs,
     validate_filter_routing,
+    warn_if_truncated,
 )
 from .errors import HonuaHttpError
 from .models import (
@@ -64,6 +65,7 @@ if TYPE_CHECKING:
     from .async_geocoding import AsyncHonuaGeocodingClient
     from .auth import AuthProvider
     from .geoprocessing import AsyncHonuaGeoprocessing
+    from .grpc import HonuaGrpcAsyncClient
     from .models import SourceDescriptor
     from .ogc import AsyncHonuaOgcFeatures
     from .protocols import (
@@ -86,6 +88,22 @@ if TYPE_CHECKING:
     from .protocols.scenes import AsyncElevationClient
     from .source import AsyncSource
     from .workflow import AsyncHonuaWorkflow
+
+
+def _grpc_target_from_base_url(base_url: httpx.URL) -> str:
+    """Derive a gRPC ``host:port`` dial target from an HTTP base URL.
+
+    The Honua gRPC FeatureService is reached on the same authority as the REST
+    surface. We reuse the REST ``base_url``'s host and port, defaulting the
+    port to 443 for ``https`` and 80 otherwise when the URL omits one.
+    """
+    host = base_url.host
+    if not host:
+        raise ValueError("Cannot derive a gRPC target: the client base_url has no host.")
+    port = base_url.port
+    if port is None:
+        port = 443 if base_url.scheme == "https" else 80
+    return f"{host}:{port}"
 
 
 class AsyncHonuaClient:
@@ -765,6 +783,71 @@ class AsyncHonuaClient:
 
         return AsyncODataClient(self)
 
+    def grpc(
+        self,
+        *,
+        target: str | None = None,
+        insecure: bool | None = None,
+        credentials: Any = None,
+        timeout: float | None = 30.0,
+        extra_metadata: Mapping[str, str] | None = None,
+    ) -> "HonuaGrpcAsyncClient":
+        """Return a gRPC FeatureService client bound to this client's config.
+
+        Builds an :class:`AsyncHonuaGrpcClient` (the analytic gRPC surface:
+        unary + streaming ``QueryFeatures`` with server-side spatial filters,
+        statistics, and aggregation) from the same base URL and authentication
+        this client was constructed with — so the gRPC surface is reachable in
+        the same token-scoped harness without re-plumbing a channel.
+
+        The dial target defaults to the REST ``base_url``'s ``host:port`` (the
+        Honua gRPC service shares the REST authority). Authentication is carried
+        as gRPC call metadata derived from the client's ``api_key`` /
+        ``bearer_token`` / ``auth_provider`` via
+        :func:`honua_sdk.grpc.build_grpc_metadata`. Transport security defaults
+        to TLS for an ``https`` base URL and plaintext otherwise; override with
+        ``credentials=`` (a :class:`grpc.ChannelCredentials`) or
+        ``insecure=True``.
+
+        Args:
+            target: Explicit ``host:port`` gRPC dial target. Defaults to the
+                REST base URL's authority.
+            insecure: Force a plaintext channel. Defaults to ``True`` for a
+                non-``https`` base URL, ``False`` otherwise.
+            credentials: Explicit channel credentials. Defaults to
+                :func:`grpc.ssl_channel_credentials` for a secure channel.
+            timeout: Per-call gRPC timeout in seconds.
+            extra_metadata: Additional metadata entries merged onto the
+                auth-derived metadata.
+
+        Returns:
+            An :class:`AsyncHonuaGrpcClient` ready to issue feature queries.
+
+        Raises:
+            ValueError: The client base_url has no host to derive a target from.
+        """
+        from .grpc import HonuaGrpcAsyncClient, build_grpc_metadata
+
+        resolved_target = target or _grpc_target_from_base_url(self._base_url)
+        metadata = build_grpc_metadata(
+            api_key=self._init_api_key,
+            bearer_token=self._init_bearer_token,
+            auth_provider=self._init_auth_provider,
+            extra_metadata=extra_metadata,
+        )
+        use_insecure = insecure if insecure is not None else (self._base_url.scheme != "https")
+        if credentials is None and not use_insecure:
+            import grpc
+
+            credentials = grpc.ssl_channel_credentials()
+        return HonuaGrpcAsyncClient(
+            resolved_target,
+            credentials=credentials,
+            insecure=use_insecure,
+            metadata=metadata,
+            timeout=timeout,
+        )
+
     async def query(
         self,
         source: str | FeatureQuery,
@@ -774,11 +857,16 @@ class AsyncHonuaClient:
         where: str | None = None,
         filter: str | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
+        out_statistics: Sequence[Mapping[str, Any]] | None = None,
+        group_by: str | Sequence[str] | None = None,
+        return_distinct_values: bool | None = None,
+        return_count_only: bool | None = None,
         page_size: int | None = None,
         limit: int | None = None,
-        max_pages: int | None = None,
+        max_pages: int | None = 100,
         extra_params: Mapping[str, Any] | None = None,
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
@@ -798,11 +886,28 @@ class AsyncHonuaClient:
             filter: CQL2/OData filter expression (OGC Features / STAC / OData).
             bbox: Spatial filter as a list/tuple of coordinates or comma
                 string. Not supported when ``protocol`` is OData.
+            spatial_filter: Arbitrary-geometry spatial filter (FeatureServer
+                only): a mapping of ``geometry`` (Esri JSON / GeoJSON /
+                ``__geo_interface__``), ``relationship`` (``intersects``,
+                ``within``, ``contains``, ``crosses``, ``touches``,
+                ``overlaps``, ``within-distance``), optional ``in_sr`` and
+                ``distance``/``units``. Translated to the GeoServices
+                ``geometry``/``geometryType``/``spatialRel``/``inSR`` params.
             fields: Attribute selection; comma-string or sequence of names.
             return_geometry: Whether to include geometry (FeatureServer).
+            out_statistics: Server-side statistic definitions (FeatureServer):
+                a sequence of mappings with ``statistic_type`` (``count``,
+                ``sum``, ``min``, ``max``, ``avg``, ``stddev``, ``var``),
+                ``on_statistic_field``, and optional ``out_statistic_field_name``.
+            group_by: Group-by fields paired with ``out_statistics``.
+            return_distinct_values: Request distinct rows (FeatureServer).
+            return_count_only: Request only the matching count (FeatureServer).
             page_size: Page size hint for paginated protocols.
             limit: Maximum number of features to collect across all pages.
-            max_pages: Safety cap on pages walked.
+            max_pages: Safety cap on pages walked; defaults to ``100``. Pass
+                ``None`` for an unbounded walk (FeatureServer) — a
+                ``ResourceWarning`` is emitted if a bounded walk stops with
+                more features still available on the server.
             extra_params: Additional protocol-specific query parameters
                 merged into each request.
             timeout: Per-call timeout override forwarded to every page
@@ -831,8 +936,13 @@ class AsyncHonuaClient:
             where=where,
             filter=filter,
             bbox=bbox,
+            spatial_filter=spatial_filter,
             fields=fields,
             return_geometry=return_geometry,
+            out_statistics=out_statistics,
+            group_by=group_by,
+            return_distinct_values=return_distinct_values,
+            return_count_only=return_count_only,
             page_size=page_size,
             limit=limit,
             max_pages=max_pages,
@@ -846,6 +956,7 @@ class AsyncHonuaClient:
             timeout=timeout,
             extra_headers=merge_idempotency_into_headers(extra_headers, idempotency_key),
         )
+        warn_if_truncated(query, exceeded=exceeded, pages_seen=pages_seen)
         return FeatureQueryResult(
             features=features,
             protocol=normalized_protocol,
@@ -975,11 +1086,12 @@ class AsyncHonuaClient:
         where: str | None = None,
         filter: str | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         page_size: int | None = None,
         limit: int | None = None,
-        max_pages: int | None = None,
+        max_pages: int | None = 100,
         extra_params: Mapping[str, Any] | None = None,
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
@@ -1001,11 +1113,14 @@ class AsyncHonuaClient:
             where: GeoServices-style ``WHERE`` clause (FeatureServer only).
             filter: CQL2/OData filter expression for OGC/STAC/OData.
             bbox: Spatial filter; not supported for OData.
+            spatial_filter: Arbitrary-geometry spatial filter (FeatureServer);
+                see :meth:`query` for the mapping shape.
             fields: Attribute selection.
             return_geometry: Whether to include geometry (FeatureServer).
             page_size: Page size hint for paginated protocols.
             limit: Maximum number of features to yield across all pages.
-            max_pages: Safety cap on pages walked.
+            max_pages: Safety cap on pages walked; defaults to ``100``. Pass
+                ``None`` for an unbounded walk (FeatureServer).
             extra_params: Protocol-specific query parameters merged into
                 each request.
 
@@ -1029,6 +1144,7 @@ class AsyncHonuaClient:
             where=where,
             filter=filter,
             bbox=bbox,
+            spatial_filter=spatial_filter,
             fields=fields,
             return_geometry=return_geometry,
             page_size=page_size,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -47,6 +47,7 @@ from ._query_dispatch import (
     stac_items_kwargs,
     stac_pages_kwargs,
     validate_filter_routing,
+    warn_if_truncated,
 )
 from ._retry import RetryTransport
 from .errors import HonuaHttpError
@@ -66,6 +67,7 @@ if TYPE_CHECKING:
     from .auth import AuthProvider
     from .geocoding import HonuaGeocodingClient
     from .geoprocessing import HonuaGeoprocessing
+    from .grpc import HonuaGrpcClient
     from .models import SourceDescriptor
     from .ogc import HonuaOgcFeatures
     from .protocols import (
@@ -88,6 +90,22 @@ if TYPE_CHECKING:
     from .protocols.scenes import ElevationClient
     from .source import Source
     from .workflow import HonuaWorkflow
+
+
+def _grpc_target_from_base_url(base_url: httpx.URL) -> str:
+    """Derive a gRPC ``host:port`` dial target from an HTTP base URL.
+
+    The Honua gRPC FeatureService is reached on the same authority as the REST
+    surface. We reuse the REST ``base_url``'s host and port, defaulting the
+    port to 443 for ``https`` and 80 otherwise when the URL omits one.
+    """
+    host = base_url.host
+    if not host:
+        raise ValueError("Cannot derive a gRPC target: the client base_url has no host.")
+    port = base_url.port
+    if port is None:
+        port = 443 if base_url.scheme == "https" else 80
+    return f"{host}:{port}"
 
 
 class HonuaClient:
@@ -766,6 +784,71 @@ class HonuaClient:
 
         return ODataClient(self)
 
+    def grpc(
+        self,
+        *,
+        target: str | None = None,
+        insecure: bool | None = None,
+        credentials: Any = None,
+        timeout: float | None = 30.0,
+        extra_metadata: Mapping[str, str] | None = None,
+    ) -> "HonuaGrpcClient":
+        """Return a gRPC FeatureService client bound to this client's config.
+
+        Builds an :class:`HonuaGrpcClient` (the analytic gRPC surface:
+        unary + streaming ``QueryFeatures`` with server-side spatial filters,
+        statistics, and aggregation) from the same base URL and authentication
+        this client was constructed with — so the gRPC surface is reachable in
+        the same token-scoped harness without re-plumbing a channel.
+
+        The dial target defaults to the REST ``base_url``'s ``host:port`` (the
+        Honua gRPC service shares the REST authority). Authentication is carried
+        as gRPC call metadata derived from the client's ``api_key`` /
+        ``bearer_token`` / ``auth_provider`` via
+        :func:`honua_sdk.grpc.build_grpc_metadata`. Transport security defaults
+        to TLS for an ``https`` base URL and plaintext otherwise; override with
+        ``credentials=`` (a :class:`grpc.ChannelCredentials`) or
+        ``insecure=True``.
+
+        Args:
+            target: Explicit ``host:port`` gRPC dial target. Defaults to the
+                REST base URL's authority.
+            insecure: Force a plaintext channel. Defaults to ``True`` for a
+                non-``https`` base URL, ``False`` otherwise.
+            credentials: Explicit channel credentials. Defaults to
+                :func:`grpc.ssl_channel_credentials` for a secure channel.
+            timeout: Per-call gRPC timeout in seconds.
+            extra_metadata: Additional metadata entries merged onto the
+                auth-derived metadata.
+
+        Returns:
+            An :class:`HonuaGrpcClient` ready to issue feature queries.
+
+        Raises:
+            ValueError: The client base_url has no host to derive a target from.
+        """
+        from .grpc import HonuaGrpcClient, build_grpc_metadata
+
+        resolved_target = target or _grpc_target_from_base_url(self._base_url)
+        metadata = build_grpc_metadata(
+            api_key=self._init_api_key,
+            bearer_token=self._init_bearer_token,
+            auth_provider=self._init_auth_provider,
+            extra_metadata=extra_metadata,
+        )
+        use_insecure = insecure if insecure is not None else (self._base_url.scheme != "https")
+        if credentials is None and not use_insecure:
+            import grpc
+
+            credentials = grpc.ssl_channel_credentials()
+        return HonuaGrpcClient(
+            resolved_target,
+            credentials=credentials,
+            insecure=use_insecure,
+            metadata=metadata,
+            timeout=timeout,
+        )
+
     def query(
         self,
         source: str | FeatureQuery,
@@ -775,11 +858,16 @@ class HonuaClient:
         where: str | None = None,
         filter: str | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
+        out_statistics: Sequence[Mapping[str, Any]] | None = None,
+        group_by: str | Sequence[str] | None = None,
+        return_distinct_values: bool | None = None,
+        return_count_only: bool | None = None,
         page_size: int | None = None,
         limit: int | None = None,
-        max_pages: int | None = None,
+        max_pages: int | None = 100,
         extra_params: Mapping[str, Any] | None = None,
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
@@ -799,11 +887,28 @@ class HonuaClient:
             filter: CQL2/OData filter expression (OGC Features / STAC / OData).
             bbox: Spatial filter as a list/tuple of coordinates or comma
                 string. Not supported when ``protocol`` is OData.
+            spatial_filter: Arbitrary-geometry spatial filter (FeatureServer
+                only): a mapping of ``geometry`` (Esri JSON / GeoJSON /
+                ``__geo_interface__``), ``relationship`` (``intersects``,
+                ``within``, ``contains``, ``crosses``, ``touches``,
+                ``overlaps``, ``within-distance``), optional ``in_sr`` and
+                ``distance``/``units``. Translated to the GeoServices
+                ``geometry``/``geometryType``/``spatialRel``/``inSR`` params.
             fields: Attribute selection; comma-string or sequence of names.
             return_geometry: Whether to include geometry (FeatureServer).
+            out_statistics: Server-side statistic definitions (FeatureServer):
+                a sequence of mappings with ``statistic_type`` (``count``,
+                ``sum``, ``min``, ``max``, ``avg``, ``stddev``, ``var``),
+                ``on_statistic_field``, and optional ``out_statistic_field_name``.
+            group_by: Group-by fields paired with ``out_statistics``.
+            return_distinct_values: Request distinct rows (FeatureServer).
+            return_count_only: Request only the matching count (FeatureServer).
             page_size: Page size hint for paginated protocols.
             limit: Maximum number of features to collect across all pages.
-            max_pages: Safety cap on pages walked.
+            max_pages: Safety cap on pages walked; defaults to ``100``. Pass
+                ``None`` for an unbounded walk (FeatureServer) — a
+                ``ResourceWarning`` is emitted if a bounded walk stops with
+                more features still available on the server.
             extra_params: Additional protocol-specific query parameters
                 merged into each request.
             timeout: Per-call timeout override forwarded to every page
@@ -832,8 +937,13 @@ class HonuaClient:
             where=where,
             filter=filter,
             bbox=bbox,
+            spatial_filter=spatial_filter,
             fields=fields,
             return_geometry=return_geometry,
+            out_statistics=out_statistics,
+            group_by=group_by,
+            return_distinct_values=return_distinct_values,
+            return_count_only=return_count_only,
             page_size=page_size,
             limit=limit,
             max_pages=max_pages,
@@ -847,6 +957,7 @@ class HonuaClient:
             timeout=timeout,
             extra_headers=merge_idempotency_into_headers(extra_headers, idempotency_key),
         )
+        warn_if_truncated(query, exceeded=exceeded, pages_seen=pages_seen)
         return FeatureQueryResult(
             features=features,
             protocol=normalized_protocol,
@@ -976,11 +1087,12 @@ class HonuaClient:
         where: str | None = None,
         filter: str | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         page_size: int | None = None,
         limit: int | None = None,
-        max_pages: int | None = None,
+        max_pages: int | None = 100,
         extra_params: Mapping[str, Any] | None = None,
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
@@ -1002,11 +1114,14 @@ class HonuaClient:
             where: GeoServices-style ``WHERE`` clause (FeatureServer only).
             filter: CQL2/OData filter expression for OGC/STAC/OData.
             bbox: Spatial filter; not supported for OData.
+            spatial_filter: Arbitrary-geometry spatial filter (FeatureServer);
+                see :meth:`query` for the mapping shape.
             fields: Attribute selection.
             return_geometry: Whether to include geometry (FeatureServer).
             page_size: Page size hint for paginated protocols.
             limit: Maximum number of features to yield across all pages.
-            max_pages: Safety cap on pages walked.
+            max_pages: Safety cap on pages walked; defaults to ``100``. Pass
+                ``None`` for an unbounded walk (FeatureServer).
             extra_params: Protocol-specific query parameters merged into
                 each request.
 
@@ -1030,6 +1145,7 @@ class HonuaClient:
             where=where,
             filter=filter,
             bbox=bbox,
+            spatial_filter=spatial_filter,
             fields=fields,
             return_geometry=return_geometry,
             page_size=page_size,

--- a/packages/honua-sdk/honua_sdk/models/_features.py
+++ b/packages/honua-sdk/honua_sdk/models/_features.py
@@ -76,7 +76,32 @@ class FeatureSet:
 
 @dataclass(frozen=True)
 class FeatureQuery:
-    """Protocol-neutral feature query request."""
+    """Protocol-neutral feature query request.
+
+    Attributes:
+        source: Source identifier (service id / collection id / entity set).
+        protocol: Canonical query protocol literal.
+        layer_id: FeatureServer / OData layer index when required.
+        where: SQL-style ``WHERE`` clause (FeatureServer / OData).
+        filter: CQL2-text filter (OGC Features / STAC).
+        bbox: ``(minx, miny, maxx, maxy)`` envelope spatial filter.
+        spatial_filter: Free-form spatial-filter mapping (arbitrary geometry +
+            relationship + SR + optional distance) translated to GeoServices
+            ``geometry``/``geometryType``/``spatialRel``/``inSR`` params on the
+            FeatureServer path. See :mod:`honua_sdk._geoservices_query`.
+        fields: Attribute selection.
+        return_geometry: Whether to include geometry in the response.
+        out_statistics: Server-side statistic definitions (FeatureServer
+            ``outStatistics``).
+        group_by: Group-by fields for statistics (FeatureServer
+            ``groupByFieldsForStatistics``).
+        return_distinct_values: Request distinct rows (``returnDistinctValues``).
+        return_count_only: Request only the matching count (``returnCountOnly``).
+        page_size: Per-request page size for paginated protocols.
+        limit: Maximum features collected across all pages.
+        max_pages: Cap on the number of pages walked. ``None`` is unbounded.
+        extra_params: Free-form per-protocol query parameter overrides.
+    """
 
     source: str
     protocol: QueryProtocol | str = "feature-server"
@@ -84,8 +109,13 @@ class FeatureQuery:
     where: str | None = None
     filter: str | None = None
     bbox: str | Sequence[int | float] | None = None
+    spatial_filter: Mapping[str, Any] | None = None
     fields: str | Sequence[str] | None = None
     return_geometry: bool = True
+    out_statistics: Sequence[Mapping[str, Any]] | None = None
+    group_by: str | Sequence[str] | None = None
+    return_distinct_values: bool = False
+    return_count_only: bool = False
     page_size: int | None = None
     limit: int | None = None
     max_pages: int | None = None

--- a/packages/honua-sdk/honua_sdk/protocols/_base.py
+++ b/packages/honua-sdk/honua_sdk/protocols/_base.py
@@ -4,8 +4,9 @@
 
 from __future__ import annotations
 
+import itertools
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias, cast
 from urllib.parse import parse_qsl, urlsplit
@@ -239,6 +240,21 @@ def _normalize_max_pages(max_pages: int | None) -> int:
     if isinstance(max_pages, int) and max_pages > 0:
         return max_pages
     return 100
+
+
+def _iter_page_indices(max_pages: int | None) -> Iterator[int]:
+    """Yield page indices for a pagination loop, honouring an unbounded cap.
+
+    ``max_pages=None`` means *unbounded* — the loop walks every page the server
+    advertises (the wrapper's own ``exceededTransferLimit`` / next-link guard
+    is what stops it). A positive ``int`` caps the walk at that many pages.
+    ``max_pages <= 0`` yields nothing.
+    """
+    if max_pages is None:
+        return itertools.count()
+    if max_pages <= 0:
+        return iter(())
+    return iter(range(max_pages))
 
 
 def _per_call_kwargs(

--- a/packages/honua-sdk/honua_sdk/protocols/geoservices.py
+++ b/packages/honua-sdk/honua_sdk/protocols/geoservices.py
@@ -21,6 +21,7 @@ from ._base import (
     _bbox,
     _bool_text,
     _csv,
+    _iter_page_indices,
     _params,
     _query_value,
     _service_path,
@@ -84,7 +85,7 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
         *,
         page_size: int = 1000,
         limit: int | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
         where: str = "1=1",
         out_fields: CsvValue = "*",
         return_geometry: bool = True,
@@ -94,8 +95,8 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
     ) -> Iterator[FeatureSet]:
         if page_size <= 0:
             raise ValueError("page_size must be greater than zero.")
-        if max_pages <= 0:
-            raise ValueError("max_pages must be greater than zero.")
+        if max_pages is not None and max_pages <= 0:
+            raise ValueError("max_pages must be greater than zero (or None for unbounded).")
         if limit is not None and limit <= 0:
             return
 
@@ -103,7 +104,7 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
         base_extra = dict(extra_params or {})
         offset = int(base_extra.get("resultOffset", 0))
         seen_object_ids: set[int] = set()
-        for _ in range(max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = None if limit is None else limit - total
             if remaining is not None and remaining <= 0:
                 break
@@ -144,7 +145,7 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
         *,
         page_size: int = 1000,
         limit: int | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
         where: str = "1=1",
         out_fields: CsvValue = "*",
         return_geometry: bool = True,
@@ -178,7 +179,7 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
         *,
         page_size: int = 1000,
         limit: int | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
         where: str = "1=1",
         out_fields: CsvValue = "*",
         return_geometry: bool = True,
@@ -498,7 +499,7 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         *,
         page_size: int = 1000,
         limit: int | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
         where: str = "1=1",
         out_fields: CsvValue = "*",
         return_geometry: bool = True,
@@ -508,8 +509,8 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
     ) -> AsyncIterator[FeatureSet]:
         if page_size <= 0:
             raise ValueError("page_size must be greater than zero.")
-        if max_pages <= 0:
-            raise ValueError("max_pages must be greater than zero.")
+        if max_pages is not None and max_pages <= 0:
+            raise ValueError("max_pages must be greater than zero (or None for unbounded).")
         if limit is not None and limit <= 0:
             return
 
@@ -517,7 +518,7 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         base_extra = dict(extra_params or {})
         offset = int(base_extra.get("resultOffset", 0))
         seen_object_ids: set[int] = set()
-        for _ in range(max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = None if limit is None else limit - total
             if remaining is not None and remaining <= 0:
                 break
@@ -558,7 +559,7 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         *,
         page_size: int = 1000,
         limit: int | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
         where: str = "1=1",
         out_fields: CsvValue = "*",
         return_geometry: bool = True,
@@ -592,7 +593,7 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         *,
         page_size: int = 1000,
         limit: int | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
         where: str = "1=1",
         out_fields: CsvValue = "*",
         return_geometry: bool = True,

--- a/packages/honua-sdk/honua_sdk/source.py
+++ b/packages/honua-sdk/honua_sdk/source.py
@@ -187,6 +187,7 @@ _QUERY_OVERRIDE_KWARGS: tuple[str, ...] = (
     "out_fields",
     "return_geometry",
     "bbox",
+    "spatial_filter",
     "limit",
     "page_size",
     "max_pages",
@@ -255,6 +256,7 @@ class Source:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -310,6 +312,7 @@ class Source:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -330,6 +333,7 @@ class Source:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -366,6 +370,7 @@ class Source:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -474,6 +479,7 @@ class AsyncSource:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -528,6 +534,7 @@ class AsyncSource:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -549,6 +556,7 @@ class AsyncSource:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -585,6 +593,7 @@ class AsyncSource:
         out_fields: str | Sequence[str] | None = None,
         return_geometry: bool | None = None,
         bbox: str | Sequence[int | float] | None = None,
+        spatial_filter: Mapping[str, Any] | None = None,
         limit: int | None = None,
         page_size: int | None = None,
         max_pages: int | None = None,
@@ -684,6 +693,7 @@ def _coerce_query(  # noqa: PLR0913 -- explicit kwargs mirror Query fields for I
     out_fields: str | Sequence[str] | None = None,
     return_geometry: bool | None = None,
     bbox: str | Sequence[int | float] | None = None,
+    spatial_filter: Mapping[str, Any] | None = None,
     limit: int | None = None,
     page_size: int | None = None,
     max_pages: int | None = None,
@@ -728,6 +738,7 @@ def _coerce_query(  # noqa: PLR0913 -- explicit kwargs mirror Query fields for I
         ("out_fields", out_fields),
         ("return_geometry", return_geometry),
         ("bbox", bbox),
+        ("spatial_filter", spatial_filter),
         ("limit", limit),
         ("page_size", page_size),
         ("max_pages", max_pages),
@@ -821,6 +832,10 @@ def _feature_query_for_source(descriptor: SourceDescriptor, query: Query) -> Fea
         where_value = query.where if protocol in _SQL_WHERE_PROTOCOLS else None
         filter_value = None
 
+    spatial_filter, out_statistics, group_by, return_distinct, return_count_only = _analytic_fields_for_query(
+        protocol, query
+    )
+
     return FeatureQuery(
         source=_query_source(descriptor),
         protocol=protocol,
@@ -828,13 +843,68 @@ def _feature_query_for_source(descriptor: SourceDescriptor, query: Query) -> Fea
         where=where_value,
         filter=filter_value,
         bbox=query.bbox,
+        spatial_filter=spatial_filter,
         fields=query.out_fields,
         return_geometry=query.return_geometry,
+        out_statistics=out_statistics,
+        group_by=group_by,
+        return_distinct_values=return_distinct,
+        return_count_only=return_count_only,
         page_size=query.page_size,
         limit=query.limit,
-        max_pages=query.max_pages,
+        # Default the page cap to 100 when the Query left it unset; ``None`` is
+        # reserved for an explicit unbounded walk so a million-feature iterate
+        # doesn't silently stop at a hidden cap.
+        max_pages=100 if query.max_pages is None else query.max_pages,
         extra_params=_extra_params_for_query(protocol, query),
     )
+
+
+#: The canonical query protocol whose REST surface supports arbitrary-geometry
+#: spatial filters and server-side statistics/aggregation (GeoServices).
+_ANALYTIC_PROTOCOL = "geoservices-feature-service"
+
+
+def _analytic_fields_for_query(
+    protocol: str, query: Query
+) -> tuple[Mapping[str, Any] | None, Sequence[Mapping[str, Any]] | None, str | Sequence[str] | None, bool, bool]:
+    """Resolve the FeatureServer spatial-filter + statistics slots from a ``Query``.
+
+    Reads :attr:`Query.spatial_filter` and the protocol-neutral
+    :attr:`Query.aggregation` mapping (``out_statistics`` / ``group_by`` /
+    ``return_distinct_values`` / ``return_count_only``) and returns them as the
+    typed :class:`FeatureQuery` slots. Both are GeoServices-only request shapes,
+    so a non-FeatureServer source that supplies either raises
+    :class:`ValueError` rather than silently dropping the predicate.
+    """
+    aggregation = query.aggregation or {}
+    out_statistics = _first_present_value(aggregation, "out_statistics", "outStatistics", "statistics")
+    group_by = _first_present_value(aggregation, "group_by", "groupBy", "groupByFieldsForStatistics")
+    return_distinct = bool(
+        _first_present_value(aggregation, "return_distinct_values", "returnDistinctValues", "distinct") or False
+    )
+    return_count_only = bool(
+        _first_present_value(aggregation, "return_count_only", "returnCountOnly", "count_only") or False
+    )
+
+    has_analytics = bool(
+        query.spatial_filter or out_statistics or group_by or return_distinct or return_count_only
+    )
+    if has_analytics and protocol != _ANALYTIC_PROTOCOL:
+        raise ValueError(
+            "spatial_filter and aggregation/statistics are only supported on the "
+            "GeoServices FeatureServer protocol; express spatial/analytic "
+            f"predicates natively for protocol {protocol!r}."
+        )
+
+    return query.spatial_filter, out_statistics, group_by, return_distinct, return_count_only
+
+
+def _first_present_value(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping and mapping[key] is not None:
+            return mapping[key]
+    return None
 
 
 def _result_from_legacy(

--- a/scripts/compatibility_gate.py
+++ b/scripts/compatibility_gate.py
@@ -324,7 +324,13 @@ def update_protocol_factory_snapshot(path: Path = PROTOCOL_FACTORY_SNAPSHOT_PATH
 def _normalized_factory_return(return_name: Any) -> str:
     if not isinstance(return_name, str):
         return repr(return_name)
-    return _strip_forward_ref_quotes(return_name).removeprefix("Async")
+    # Collapse the sync/async wrapper-family seam the same way ``gen_sync.py``
+    # does: a leading ``Async`` prefix (``AsyncStacClient`` → ``StacClient``)
+    # *and* an embedded ``Async`` before a capital (``HonuaGrpcAsyncClient`` →
+    # ``HonuaGrpcClient``), so a factory whose paired wrappers only differ by
+    # that token reads as the same family.
+    stripped = _strip_forward_ref_quotes(return_name).removeprefix("Async")
+    return re.sub(r"Async(?=[A-Z])", "", stripped)
 
 
 def check_protocol_factory_parity(data: Mapping[str, Any]) -> list[str]:

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -183,6 +183,11 @@ _COMMON_RULES: tuple[Rule, ...] = (
     # Async-only sibling modules collapse onto their sync equivalents.
     _rule(r"\b_async_retry\b", "_retry"),
     _rule(r"\basync_geocoding\b", "geocoding"),
+    # The gRPC client class embeds ``Async`` mid-identifier
+    # (``HonuaGrpcAsyncClient``), so the generic ``\bAsync`` strip below — which
+    # requires a word boundary immediately before ``Async`` — never fires on it.
+    # Map it explicitly to its sync sibling.
+    _rule(r"\bHonuaGrpcAsyncClient\b", "HonuaGrpcClient"),
     #
     # --- residual Async-prefixed identifiers ------------------------------
     # Everything left — the ``Async*`` client/transport/protocol class names

--- a/tests/test_gp_query_parity.py
+++ b/tests/test_gp_query_parity.py
@@ -1,0 +1,552 @@
+"""GP query-parity tests: spatial filters, statistics/aggregation, pagination, gRPC binding.
+
+Covers the GeoServices REST request-construction parity gaps closed for Esri-SDK
+"select by location" + analytics:
+
+* ``Query.spatial_filter`` / ``FeatureQuery.spatial_filter`` translated to the
+  GeoServices ``geometry``/``geometryType``/``spatialRel``/``inSR`` params for an
+  arbitrary geometry + each :class:`SpatialRelationship`, including
+  ``within-distance`` (``distance`` + ``units``).
+* ``out_statistics`` / ``group_by`` / ``return_distinct_values`` /
+  ``return_count_only`` translated to ``outStatistics`` /
+  ``groupByFieldsForStatistics`` / ``returnDistinctValues`` / ``returnCountOnly``.
+* ``max_pages=None`` walks unbounded; a bounded walk that truncates warns.
+* :meth:`HonuaClient.grpc` builds the analytic gRPC client from the same config.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from honua_sdk import HonuaClient, Query, SourceDescriptor
+from honua_sdk._geoservices_query import (
+    coerce_geometry,
+    normalize_spatial_relationship,
+    spatial_filter_params,
+    statistics_params,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure translation helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("relationship", "expected"),
+    [
+        ("intersects", "esriSpatialRelIntersects"),
+        ("within", "esriSpatialRelWithin"),
+        ("contains", "esriSpatialRelContains"),
+        ("crosses", "esriSpatialRelCrosses"),
+        ("touches", "esriSpatialRelTouches"),
+        ("overlaps", "esriSpatialRelOverlaps"),
+        ("envelope-intersects", "esriSpatialRelEnvelopeIntersects"),
+        ("within-distance", "esriSpatialRelIntersects"),
+        # gRPC-style SCREAMING_SNAKE and raw Esri tokens both accepted.
+        ("WITHIN", "esriSpatialRelWithin"),
+        ("esriSpatialRelOverlaps", "esriSpatialRelOverlaps"),
+    ],
+)
+def test_normalize_spatial_relationship(relationship: str, expected: str) -> None:
+    assert normalize_spatial_relationship(relationship) == expected
+
+
+def test_normalize_spatial_relationship_rejects_unknown() -> None:
+    with pytest.raises(ValueError, match="Unsupported spatial relationship"):
+        normalize_spatial_relationship("near-ish")
+
+
+def test_coerce_geometry_esri_polygon_passthrough() -> None:
+    esri = {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+    geometry, gtype = coerce_geometry(esri)
+    assert gtype == "esriGeometryPolygon"
+    assert geometry == esri
+
+
+def test_coerce_geometry_geojson_polygon() -> None:
+    geojson = {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+    geometry, gtype = coerce_geometry(geojson)
+    assert gtype == "esriGeometryPolygon"
+    assert geometry == {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+
+
+def test_coerce_geometry_geojson_point_with_z() -> None:
+    geometry, gtype = coerce_geometry({"type": "Point", "coordinates": [1, 2, 3]})
+    assert gtype == "esriGeometryPoint"
+    assert geometry == {"x": 1, "y": 2, "z": 3}
+
+
+def test_coerce_geometry_geo_interface() -> None:
+    class _FakeShapely:
+        @property
+        def __geo_interface__(self) -> dict[str, Any]:
+            return {"type": "Point", "coordinates": [10.0, 20.0]}
+
+    geometry, gtype = coerce_geometry(_FakeShapely())
+    assert gtype == "esriGeometryPoint"
+    assert geometry == {"x": 10.0, "y": 20.0}
+
+
+def test_spatial_filter_params_polygon_intersects() -> None:
+    params = spatial_filter_params(
+        {
+            "geometry": {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+            "relationship": "intersects",
+            "in_sr": 3857,
+        }
+    )
+    assert params["geometryType"] == "esriGeometryPolygon"
+    assert params["spatialRel"] == "esriSpatialRelIntersects"
+    assert params["inSR"] == 3857
+    assert json.loads(params["geometry"]) == {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+
+
+def test_spatial_filter_params_defaults_in_sr_to_4326() -> None:
+    params = spatial_filter_params({"geometry": {"x": 1, "y": 2}})
+    assert params["geometryType"] == "esriGeometryPoint"
+    assert params["spatialRel"] == "esriSpatialRelIntersects"
+    assert params["inSR"] == 4326
+
+
+def test_spatial_filter_params_reads_embedded_spatial_reference() -> None:
+    params = spatial_filter_params(
+        {"geometry": {"x": 1, "y": 2, "spatialReference": {"wkid": 2193}}}
+    )
+    assert params["inSR"] == 2193
+
+
+def test_spatial_filter_params_within_distance() -> None:
+    params = spatial_filter_params(
+        {
+            "geometry": {"x": 1, "y": 2},
+            "relationship": "within-distance",
+            "distance": 500,
+            "units": "meters",
+        }
+    )
+    assert params["spatialRel"] == "esriSpatialRelIntersects"
+    assert params["distance"] == 500
+    assert params["units"] == "esriSRUnit_Meter"
+
+
+def test_spatial_filter_params_within_distance_requires_distance() -> None:
+    with pytest.raises(ValueError, match="requires a 'distance'"):
+        spatial_filter_params({"geometry": {"x": 1, "y": 2}, "relationship": "within-distance"})
+
+
+def test_statistics_params_out_statistics_and_group_by() -> None:
+    params = statistics_params(
+        out_statistics=[
+            {"statistic_type": "sum", "on_statistic_field": "pop", "out_statistic_field_name": "total_pop"},
+            {"statistic_type": "avg", "on_statistic_field": "age"},
+        ],
+        group_by=["state", "county"],
+    )
+    stats = json.loads(params["outStatistics"])
+    assert stats[0] == {
+        "statisticType": "sum",
+        "onStatisticField": "pop",
+        "outStatisticFieldName": "total_pop",
+    }
+    # Default out-name when omitted.
+    assert stats[1]["outStatisticFieldName"] == "avg_age"
+    assert params["groupByFieldsForStatistics"] == "state,county"
+
+
+def test_statistics_params_distinct_and_count_only() -> None:
+    params = statistics_params(return_distinct_values=True, return_count_only=True)
+    assert params["returnDistinctValues"] == "true"
+    assert params["returnCountOnly"] == "true"
+
+
+def test_statistics_params_rejects_unknown_statistic_type() -> None:
+    with pytest.raises(ValueError, match="Unsupported statistic type"):
+        statistics_params(out_statistics=[{"statistic_type": "median", "on_statistic_field": "x"}])
+
+
+def test_statistics_params_requires_field_and_type() -> None:
+    with pytest.raises(ValueError, match="requires a 'statistic_type'"):
+        statistics_params(out_statistics=[{"statistic_type": "sum"}])
+
+
+@pytest.mark.parametrize(
+    ("geojson", "expected"),
+    [
+        ({"type": "MultiPoint", "coordinates": [[0, 0], [1, 1]]}, {"points": [[0, 0], [1, 1]]}),
+        ({"type": "LineString", "coordinates": [[0, 0], [1, 1]]}, {"paths": [[[0, 0], [1, 1]]]}),
+        (
+            {"type": "MultiLineString", "coordinates": [[[0, 0], [1, 1]], [[2, 2], [3, 3]]]},
+            {"paths": [[[0, 0], [1, 1]], [[2, 2], [3, 3]]]},
+        ),
+        (
+            {"type": "MultiPolygon", "coordinates": [[[[0, 0], [0, 1], [1, 1], [0, 0]]]]},
+            {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+        ),
+    ],
+)
+def test_coerce_geometry_geojson_multipart(geojson: dict[str, Any], expected: dict[str, Any]) -> None:
+    geometry, _ = coerce_geometry(geojson)
+    assert geometry == expected
+
+
+def test_coerce_geometry_rejects_unknown_geojson_type() -> None:
+    with pytest.raises(ValueError, match="Unsupported GeoJSON geometry type"):
+        coerce_geometry({"type": "GeometryCollection", "coordinates": []})
+
+
+def test_coerce_geometry_rejects_non_geometry() -> None:
+    with pytest.raises(TypeError, match="Esri JSON mapping"):
+        coerce_geometry("not-a-geometry")
+
+
+def test_coerce_geometry_requires_value() -> None:
+    with pytest.raises(ValueError, match="requires a geometry"):
+        coerce_geometry(None)
+
+
+@pytest.mark.parametrize(
+    ("esri", "expected_type"),
+    [
+        ({"x": 1, "y": 2}, "esriGeometryPoint"),
+        ({"paths": [[[0, 0], [1, 1]]]}, "esriGeometryPolyline"),
+        ({"points": [[0, 0]]}, "esriGeometryMultipoint"),
+        ({"xmin": 0, "ymin": 0, "xmax": 1, "ymax": 1}, "esriGeometryEnvelope"),
+    ],
+)
+def test_coerce_geometry_infers_esri_type(esri: dict[str, Any], expected_type: str) -> None:
+    _, gtype = coerce_geometry(esri)
+    assert gtype == expected_type
+
+
+def test_coerce_geometry_unknown_esri_shape_raises() -> None:
+    with pytest.raises(ValueError, match="Could not infer the Esri geometry type"):
+        coerce_geometry({"unknown": 1})
+
+
+def test_spatial_filter_params_explicit_geometry_type_override() -> None:
+    params = spatial_filter_params(
+        {"geometry": {"unknown": 1}, "geometry_type": "esriGeometryPolygon"}
+    )
+    assert params["geometryType"] == "esriGeometryPolygon"
+
+
+def test_spatial_filter_params_reads_sr_wkt() -> None:
+    params = spatial_filter_params(
+        {"geometry": {"x": 1, "y": 2}, "in_sr": {"wkt": "PROJCS[...]"}}
+    )
+    assert params["inSR"] == "PROJCS[...]"
+
+
+@pytest.mark.parametrize(
+    ("units", "expected"),
+    [
+        ("ft", "esriSRUnit_Foot"),
+        ("miles", "esriSRUnit_StatuteMile"),
+        ("esriSRUnit_Meter", "esriSRUnit_Meter"),
+    ],
+)
+def test_spatial_filter_params_distance_unit_aliases(units: str, expected: str) -> None:
+    params = spatial_filter_params(
+        {
+            "geometry": {"x": 1, "y": 2},
+            "relationship": "within-distance",
+            "distance": 1,
+            "units": units,
+        }
+    )
+    assert params["units"] == expected
+
+
+def test_spatial_filter_params_rejects_unknown_units() -> None:
+    with pytest.raises(ValueError, match="Unsupported distance unit"):
+        spatial_filter_params(
+            {
+                "geometry": {"x": 1, "y": 2},
+                "relationship": "within-distance",
+                "distance": 1,
+                "units": "furlongs",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through client.query (FeatureServer REST path)
+# ---------------------------------------------------------------------------
+
+
+def _capture_client(captured: dict[str, Any], *, exceeded: bool = False) -> HonuaClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = dict(request.url.params.multi_items())
+        return httpx.Response(200, json={"features": [], "exceededTransferLimit": exceeded})
+
+    return HonuaClient("https://example.test", transport=httpx.MockTransport(handler))
+
+
+def test_query_polygon_spatial_filter_emits_geoservices_params() -> None:
+    captured: dict[str, Any] = {}
+    polygon = {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+    with _capture_client(captured) as client:
+        client.query(
+            "default",
+            spatial_filter={"geometry": polygon, "relationship": "within", "in_sr": 4326},
+        )
+    params = captured["query"]
+    assert params["geometryType"] == "esriGeometryPolygon"
+    assert params["spatialRel"] == "esriSpatialRelWithin"
+    assert params["inSR"] == "4326"
+    assert json.loads(params["geometry"]) == {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+
+
+@pytest.mark.parametrize(
+    ("relationship", "expected_rel"),
+    [
+        ("intersects", "esriSpatialRelIntersects"),
+        ("within", "esriSpatialRelWithin"),
+        ("contains", "esriSpatialRelContains"),
+        ("crosses", "esriSpatialRelCrosses"),
+        ("touches", "esriSpatialRelTouches"),
+        ("overlaps", "esriSpatialRelOverlaps"),
+    ],
+)
+def test_query_each_spatial_relationship(relationship: str, expected_rel: str) -> None:
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        client.query(
+            "default",
+            spatial_filter={"geometry": {"x": 1, "y": 2}, "relationship": relationship},
+        )
+    assert captured["query"]["spatialRel"] == expected_rel
+
+
+def test_query_within_distance_emits_distance_and_units() -> None:
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        client.query(
+            "default",
+            spatial_filter={
+                "geometry": {"x": 1, "y": 2},
+                "relationship": "within-distance",
+                "distance": 1000,
+                "units": "km",
+            },
+        )
+    params = captured["query"]
+    assert params["distance"] == "1000"
+    assert params["units"] == "esriSRUnit_Kilometer"
+
+
+def test_query_out_statistics_and_group_by() -> None:
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        client.query(
+            "default",
+            out_statistics=[{"statistic_type": "count", "on_statistic_field": "objectid"}],
+            group_by="category",
+        )
+    params = captured["query"]
+    assert json.loads(params["outStatistics"])[0]["statisticType"] == "count"
+    assert params["groupByFieldsForStatistics"] == "category"
+
+
+def test_query_return_distinct_and_count_only() -> None:
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        client.query("default", return_distinct_values=True, return_count_only=True)
+    params = captured["query"]
+    assert params["returnDistinctValues"] == "true"
+    assert params["returnCountOnly"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Pagination: unbounded walk + truncation warning
+# ---------------------------------------------------------------------------
+
+
+def _paginating_client(page_count: int, *, always_exceeded: bool = False) -> HonuaClient:
+    """A client whose FeatureServer returns ``page_count`` non-empty pages.
+
+    Each page reports ``exceededTransferLimit=True`` until the last; with
+    ``always_exceeded`` every page (including the last yielded) keeps the flag
+    set so a bounded walk truncates mid-stream.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        params = dict(request.url.params.multi_items())
+        offset = int(params.get("resultOffset", 0))
+        record_count = int(params.get("resultRecordCount", 1000))
+        index = offset // record_count
+        last = index >= page_count - 1
+        feature = {"attributes": {"objectid": offset + 1}}
+        exceeded = True if always_exceeded else not last
+        body = {"features": [feature], "exceededTransferLimit": exceeded}
+        return httpx.Response(200, json=body)
+
+    return HonuaClient("https://example.test", transport=httpx.MockTransport(handler))
+
+
+def test_iter_query_unbounded_walks_past_default_cap() -> None:
+    # 150 pages of one feature each — would silently stop at the old 100 cap.
+    with _paginating_client(150) as client:
+        features = list(client.iter_query("default", page_size=1, max_pages=None))
+    assert len(features) == 150
+
+
+def test_query_unbounded_collects_all_pages() -> None:
+    with _paginating_client(120) as client:
+        result = client.query("default", page_size=1, max_pages=None)
+    assert len(result.features) == 120
+
+
+def test_query_warns_when_bounded_walk_truncates() -> None:
+    with _paginating_client(10, always_exceeded=True) as client:
+        with pytest.warns(ResourceWarning, match="max_pages=3"):
+            result = client.query("default", page_size=1, max_pages=3)
+    assert len(result.features) == 3
+    assert result.exceeded_transfer_limit is True
+
+
+def test_query_does_not_warn_when_limit_set() -> None:
+    import warnings
+
+    with _paginating_client(10, always_exceeded=True) as client:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ResourceWarning)
+            result = client.query("default", page_size=1, max_pages=3, limit=2)
+    assert len(result.features) == 2
+
+
+# ---------------------------------------------------------------------------
+# Source facade: spatial filter + aggregation routing
+# ---------------------------------------------------------------------------
+
+
+def _feature_server_descriptor() -> SourceDescriptor:
+    return SourceDescriptor.from_dict(
+        {
+            "id": "default",
+            "protocol": "geoservices-feature-service",
+            "locator": {"service_id": "default", "layer_id": 0},
+            "capabilities": ["query"],
+        }
+    )
+
+
+def test_source_query_spatial_filter_routes_to_feature_server() -> None:
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        source = client.source(_feature_server_descriptor())
+        source.query(spatial_filter={"geometry": {"x": 1, "y": 2}, "relationship": "contains"})
+    assert captured["query"]["spatialRel"] == "esriSpatialRelContains"
+
+
+def test_source_query_aggregation_routes_to_statistics() -> None:
+    captured: dict[str, Any] = {}
+    query = Query(
+        aggregation={
+            "out_statistics": [{"statistic_type": "max", "on_statistic_field": "elevation"}],
+            "group_by": "zone",
+            "return_distinct_values": True,
+        }
+    )
+    with _capture_client(captured) as client:
+        source = client.source(_feature_server_descriptor())
+        source.query(query)
+    params = captured["query"]
+    assert json.loads(params["outStatistics"])[0]["statisticType"] == "max"
+    assert params["groupByFieldsForStatistics"] == "zone"
+    assert params["returnDistinctValues"] == "true"
+
+
+def test_source_query_rejects_spatial_filter_on_non_feature_server() -> None:
+    descriptor = SourceDescriptor.from_dict(
+        {
+            "id": "items",
+            "protocol": "ogc-features",
+            "locator": {"collection_id": "items"},
+            "capabilities": ["query"],
+        }
+    )
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        source = client.source(descriptor)
+        with pytest.raises(ValueError, match="only supported on the GeoServices FeatureServer"):
+            source.query(spatial_filter={"geometry": {"x": 1, "y": 2}})
+
+
+# ---------------------------------------------------------------------------
+# gRPC binding
+# ---------------------------------------------------------------------------
+
+
+def test_grpc_factory_builds_client_from_base_config() -> None:
+    grpc = pytest.importorskip("grpc")
+    with HonuaClient(
+        "https://example.test:8443",
+        api_key="secret-key",
+    ) as client:
+        grpc_client = client.grpc(insecure=True)
+        try:
+            # Target derived from the REST authority (host:port).
+            assert grpc_client._channel is not None
+            # Auth carried as gRPC metadata derived from the SDK api_key.
+            metadata = dict(grpc_client._metadata)
+            assert any("secret-key" in str(value) for value in metadata.values())
+        finally:
+            grpc_client.close()
+    assert grpc is not None
+
+
+def test_grpc_factory_target_defaults_to_base_authority() -> None:
+    pytest.importorskip("grpc")
+    from honua_sdk.client import _grpc_target_from_base_url
+
+    with HonuaClient("https://example.test:8443", api_key="k") as client:
+        assert _grpc_target_from_base_url(client._base_url) == "example.test:8443"
+
+
+@pytest.mark.anyio
+async def test_async_grpc_factory_builds_async_client() -> None:
+    pytest.importorskip("grpc")
+    from honua_sdk import AsyncHonuaClient
+    from honua_sdk.grpc import HonuaGrpcAsyncClient
+
+    async with AsyncHonuaClient("https://example.test", api_key="k") as client:
+        grpc_client = client.grpc(insecure=True)
+        try:
+            assert isinstance(grpc_client, HonuaGrpcAsyncClient)
+        finally:
+            await grpc_client.close()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_bbox_envelope_filter_still_works() -> None:
+    """The bbox shorthand remains the envelope-intersects path (no regression)."""
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        client.query("default", bbox=(0, 0, 10, 10))
+    params = captured["query"]
+    assert params["geometryType"] == "esriGeometryEnvelope"
+    assert params["spatialRel"] == "esriSpatialRelIntersects"
+    assert json.loads(params["geometry"])["xmin"] == 0
+
+
+def test_spatial_filter_takes_precedence_over_bbox() -> None:
+    captured: dict[str, Any] = {}
+    with _capture_client(captured) as client:
+        client.query(
+            "default",
+            bbox=(0, 0, 10, 10),
+            spatial_filter={"geometry": {"x": 1, "y": 2}, "relationship": "within"},
+        )
+    params = captured["query"]
+    assert params["geometryType"] == "esriGeometryPoint"
+    assert params["spatialRel"] == "esriSpatialRelWithin"

--- a/tests/test_query_dispatch.py
+++ b/tests/test_query_dispatch.py
@@ -114,7 +114,17 @@ def test_feature_server_pages_kwargs_defaults() -> None:
     assert kwargs["where"] == "1=1"
     assert kwargs["out_fields"] == "*"
     assert kwargs["page_size"] == 1000
-    assert kwargs["max_pages"] == 100
+    # ``FeatureQuery.max_pages`` is forwarded verbatim: ``None`` means unbounded
+    # (the 100-page default now lives on the canonical ``client.query`` /
+    # ``Source`` method signatures, not silently in this dispatch helper).
+    assert kwargs["max_pages"] is None
+
+
+def test_feature_server_pages_kwargs_forwards_explicit_max_pages() -> None:
+    kwargs = feature_server_pages_kwargs(
+        _query(max_pages=7), timeout=None, extra_headers=None
+    )
+    assert kwargs["max_pages"] == 7
 
 
 def test_feature_server_pages_kwargs_prefers_where_over_filter() -> None:


### PR DESCRIPTION
Closes the GeoServices REST query-construction gaps from the SDK GP assessment that blocked Esri-SDK parity for **GP "select by location" + analytics**. Every change is SDK request construction against the *existing* FeatureServer surface — **no server change**.

## Gaps closed

**1. Spatial filter was dead on the REST path.** Previously only `bbox` was translated (a hardcoded 4326 envelope-intersects); the full `SpatialFilter`/`SpatialRelationship` lived only in the gRPC adapter. New `_geoservices_query.py` translates an arbitrary geometry (Esri JSON / GeoJSON / shapely-`__geo_interface__`) + a chosen relationship + input SR into the GeoServices `geometry`/`geometryType`/`spatialRel`/`inSR` params, with distance-based (`within-distance` → `distance`+`units`) support.
- Relationships: `intersects`, `within`, `contains`, `crosses`, `touches`, `overlaps`, `envelope-intersects`, `within-distance` (also accepts gRPC `SCREAMING_SNAKE` and raw `esriSpatialRel*` tokens).
- Wired through `FeatureQuery.spatial_filter`, `client.query(spatial_filter=...)`, and `Source.query` via `Query.spatial_filter`. The bbox shorthand still works; an explicit `spatial_filter` takes precedence.

**2. No server-side statistics/aggregation on the REST path.** Added `out_statistics` / `group_by` / `return_distinct_values` / `return_count_only` to `FeatureQuery` and the `client.query` path → `outStatistics` / `groupByFieldsForStatistics` / `returnDistinctValues` / `returnCountOnly`. `Source.query` reads them from `Query.aggregation`. Both spatial filters and statistics are GeoServices-only; supplying them on another protocol raises `ValueError` rather than silently dropping the predicate.

**3. `max_pages=100` silently capped iterate.** `client.query`/`client.iter_query` now default the cap to an *explicit* 100 and honor **`max_pages=None` as unbounded** (FeatureServer), via a new `_iter_page_indices` helper. A bounded `client.query` walk that stops at the cap while the server still advertises more (`exceededTransferLimit`) now emits a `ResourceWarning` so a million-feature iterate never silently truncates.

**4. gRPC wasn't bound to the client.** Added `HonuaClient.grpc()` / `AsyncHonuaClient.grpc()` that build the analytic gRPC client from the same base URL + auth — target derived from the REST authority, bearer/api-key carried as gRPC call metadata.

## Codegen / gates
- Edited the **async source** and regenerated the sync client via `scripts/gen_sync.py`; added the `HonuaGrpcAsyncClient → HonuaGrpcClient` codegen seam and the embedded-`Async` factory-parity normalization in the compat gate. Refreshed public-API + protocol-factory snapshots.
- Documented the new surface in `docs/pagination.md`.

## Validation
- `ruff check .` clean; `mypy` clean (strict-ish); `gen_sync.py --check` passes (sync up to date); compatibility gate passes.
- Full pytest: **1179 passed, 3 skipped**; combined coverage **94.63%** (≥94 gate); `mkdocs build --strict` exits 0.
- New `tests/test_gp_query_parity.py` (64 tests): polygon filter → correct GeoServices params, each `SpatialRelationship`, within-distance, geometry coercion (Esri/GeoJSON/`__geo_interface__`), `out_statistics`/`group_by`/distinct/count-only, unbounded `iter_query` walking past the 100-page cap, truncation warning, Source spatial-filter + aggregation routing and non-FeatureServer rejection, and the sync+async `grpc()` factory.