### PR TITLE
fix(sdk): surface GeoServices error envelopes and correct query total_count

### DIFF
--- a/packages/honua-sdk/honua_sdk/_endpoints.py
+++ b/packages/honua-sdk/honua_sdk/_endpoints.py
@@ -22,7 +22,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from ._http import _encode_path_segment
+from ._http import _encode_path_segment, raise_for_geoservices_error
 from .models import (
     ApplyEditsResult,
     DataPlaneCapabilities,
@@ -288,6 +288,7 @@ def parse_json_response_body(response: "Any") -> dict[str, Any]:
     except ValueError:
         return {"raw": response.text}
     if isinstance(payload, Mapping):
+        raise_for_geoservices_error(response, payload)
         return dict(payload)
     return {"data": payload}
 

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -193,27 +193,14 @@ def parse_retry_after(value: str | None) -> float | None:
 _parse_retry_after = parse_retry_after
 
 
-def _to_http_error(response: httpx.Response) -> HonuaHttpError:
-    body: Any | None = None
-    message = response.reason_phrase or "Request failed"
-
-    if response.content:
-        try:
-            body = response.json()
-        except ValueError:
-            body = response.text
-    if isinstance(body, Mapping):
-        error = body.get("error")
-        if isinstance(error, Mapping):
-            candidate = error.get("message")
-            if isinstance(candidate, str) and candidate:
-                message = candidate
-        else:
-            candidate = body.get("detail") or body.get("message")
-            if isinstance(candidate, str) and candidate:
-                message = candidate
-
-    status_code = response.status_code
+def _build_http_error(
+    *,
+    status_code: int,
+    message: str,
+    body: Any | None,
+    response: httpx.Response,
+) -> HonuaHttpError:
+    """Construct the right :class:`HonuaHttpError` subtype for *status_code*."""
     request_id = (
         response.headers.get("x-request-id")
         or response.headers.get("honua-request-id")
@@ -244,6 +231,77 @@ def _to_http_error(response: httpx.Response) -> HonuaHttpError:
         body=body,
         request_id=request_id,
         headers=headers,
+    )
+
+
+def _to_http_error(response: httpx.Response) -> HonuaHttpError:
+    body: Any | None = None
+    message = response.reason_phrase or "Request failed"
+
+    if response.content:
+        try:
+            body = response.json()
+        except ValueError:
+            body = response.text
+    if isinstance(body, Mapping):
+        error = body.get("error")
+        if isinstance(error, Mapping):
+            candidate = error.get("message")
+            if isinstance(candidate, str) and candidate:
+                message = candidate
+        else:
+            candidate = body.get("detail") or body.get("message")
+            if isinstance(candidate, str) and candidate:
+                message = candidate
+
+    return _build_http_error(
+        status_code=response.status_code,
+        message=message,
+        body=body,
+        response=response,
+    )
+
+
+def raise_for_geoservices_error(response: httpx.Response, payload: Mapping[str, Any]) -> None:
+    """Raise if a successful (2xx) GeoServices JSON body carries an error envelope.
+
+    The Esri GeoServices REST protocol (FeatureServer / MapServer / ImageServer
+    / GeometryServer / GeocodeServer) reports failures as HTTP 200 with a body
+    of the form ``{"error": {"code": <int>, "message": <str>, "details": [...]}}``
+    rather than a non-success HTTP status. Without this check those errors flow
+    back to callers as ordinary success dicts (e.g. an ``applyEdits`` that the
+    server rejected would never raise). Detect that envelope and surface it
+    through the same :class:`HonuaHttpError` hierarchy used for transport-level
+    failures, carrying the server-reported error ``code``.
+
+    The detection is deliberately narrow — it only fires when ``error`` is a
+    mapping containing an integer ``code`` — so a legitimate payload that merely
+    happens to include an ``"error"`` field is left untouched.
+    """
+    error = payload.get("error")
+    if not isinstance(error, Mapping):
+        return
+    code = error.get("code")
+    if not isinstance(code, int) or isinstance(code, bool):
+        return
+
+    message = response.reason_phrase or "GeoServices request failed"
+    candidate = error.get("message")
+    if isinstance(candidate, str) and candidate:
+        message = candidate
+
+    body: Any | None = payload
+    if response.content:
+        try:
+            body = response.json()
+        except ValueError:
+            body = payload
+
+    raise _build_http_error(
+        status_code=code,
+        message=message,
+        body=body,
+        response=response,
     )
 
 

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -905,7 +905,12 @@ class AsyncHonuaClient:
                 ]
                 if _extend(page_features):
                     break
-            return tuple(collected), exceeded, len(collected), pages_seen
+            # FeatureServer ``query`` responses do not carry a grand total
+            # (no ``numberMatched`` equivalent), so ``total_count`` is unknown.
+            # Reporting ``len(collected)`` here is misleading because it is the
+            # number of features *returned* — capped by ``limit``/``max_pages``
+            # — not the server's total match count. Surface ``None`` instead.
+            return tuple(collected), exceeded, None, pages_seen
 
         if normalized_protocol == "ogc-features":
             last_page: Any = None

--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from ._async_retry import AsyncRetryTransport
+from ._endpoints import parse_json_response_body
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -152,6 +153,10 @@ class AsyncHonuaGeocodingClient:
 
         results: list[GeocodeResult] = []
         for candidate in data.get("candidates", []):
+            if not isinstance(candidate, Mapping):
+                # Skip malformed (non-object) entries rather than raising a raw
+                # AttributeError outside the Honua error contract.
+                continue
             coords = _extract_location_xy(candidate.get("location"))
             if coords is None:
                 # No usable location: skip rather than emit a (0, 0) result.
@@ -280,6 +285,10 @@ class AsyncHonuaGeocodingClient:
 
         results: list[GeocodeSuggestion] = []
         for suggestion in data.get("suggestions", []):
+            if not isinstance(suggestion, Mapping):
+                # Skip malformed (non-object) entries rather than raising a raw
+                # AttributeError outside the Honua error contract.
+                continue
             results.append(
                 GeocodeSuggestion(
                     text=suggestion.get("text", ""),
@@ -309,17 +318,10 @@ class AsyncHonuaGeocodingClient:
             extra_headers=extra_headers,
             idempotency_key=idempotency_key,
         )
-        if not response.content:
-            return {}
-
-        try:
-            payload = response.json()
-        except ValueError:
-            return {"raw": response.text}
-
-        if isinstance(payload, Mapping):
-            return dict(payload)
-        return {"data": payload}
+        # Reuse the shared parser so GeocodeServer error envelopes returned as
+        # HTTP 200 (``{"error": {...}}``) surface as ``HonuaHttpError`` rather
+        # than flowing back as a success dict.
+        return parse_json_response_body(response)
 
     async def _request(
         self,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -906,7 +906,12 @@ class HonuaClient:
                 ]
                 if _extend(page_features):
                     break
-            return tuple(collected), exceeded, len(collected), pages_seen
+            # FeatureServer ``query`` responses do not carry a grand total
+            # (no ``numberMatched`` equivalent), so ``total_count`` is unknown.
+            # Reporting ``len(collected)`` here is misleading because it is the
+            # number of features *returned* — capped by ``limit``/``max_pages``
+            # — not the server's total match count. Surface ``None`` instead.
+            return tuple(collected), exceeded, None, pages_seen
 
         if normalized_protocol == "ogc-features":
             last_page: Any = None

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from ._endpoints import parse_json_response_body
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -190,6 +191,10 @@ class HonuaGeocodingClient:
 
         results: list[GeocodeResult] = []
         for candidate in data.get("candidates", []):
+            if not isinstance(candidate, Mapping):
+                # Skip malformed (non-object) entries rather than raising a raw
+                # AttributeError outside the Honua error contract.
+                continue
             coords = _extract_location_xy(candidate.get("location"))
             if coords is None:
                 # No usable location: skip rather than emit a (0, 0) result.
@@ -318,6 +323,10 @@ class HonuaGeocodingClient:
 
         results: list[GeocodeSuggestion] = []
         for suggestion in data.get("suggestions", []):
+            if not isinstance(suggestion, Mapping):
+                # Skip malformed (non-object) entries rather than raising a raw
+                # AttributeError outside the Honua error contract.
+                continue
             results.append(
                 GeocodeSuggestion(
                     text=suggestion.get("text", ""),
@@ -347,17 +356,10 @@ class HonuaGeocodingClient:
             extra_headers=extra_headers,
             idempotency_key=idempotency_key,
         )
-        if not response.content:
-            return {}
-
-        try:
-            payload = response.json()
-        except ValueError:
-            return {"raw": response.text}
-
-        if isinstance(payload, Mapping):
-            return dict(payload)
-        return {"data": payload}
+        # Reuse the shared parser so GeocodeServer error envelopes returned as
+        # HTTP 200 (``{"error": {...}}``) surface as ``HonuaHttpError`` rather
+        # than flowing back as a success dict.
+        return parse_json_response_body(response)
 
     def _request(
         self,

--- a/packages/honua-sdk/honua_sdk/source.py
+++ b/packages/honua-sdk/honua_sdk/source.py
@@ -855,15 +855,10 @@ def _result_from_legacy(
         replace(feature, protocol=descriptor.protocol, source=descriptor.id)
         for feature in legacy_result.features
     )
-    total_count = (
-        legacy_result.total_count
-        if legacy_result.total_count is not None
-        else len(normalized_features)
-    )
     return Result(
         features=normalized_features,
         exceeded_transfer_limit=bool(legacy_result.exceeded_transfer_limit),
-        total_count=total_count,
+        total_count=legacy_result.total_count,
         protocol=descriptor.protocol,
         source_id=descriptor.id,
         query=query,

--- a/tests/test_geoservices_error_envelope.py
+++ b/tests/test_geoservices_error_envelope.py
@@ -1,0 +1,90 @@
+"""GeoServices error-envelope handling (HTTP 200 + ``{"error": {...}}``).
+
+The Esri GeoServices REST protocol reports failures as an HTTP 200 response
+whose body is ``{"error": {"code": <int>, "message": <str>, ...}}``. These
+tests pin that such envelopes raise :class:`HonuaHttpError` instead of being
+returned to callers as success data (audit AUD-091, issue #122).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from honua_sdk import HonuaClient, HonuaGeocodingClient, HonuaHttpError
+from honua_sdk._endpoints import parse_json_response_body
+
+
+def _envelope_handler(code: int = 400, message: str = "Unable to complete operation.") -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"error": {"code": code, "message": message, "details": []}})
+
+    return httpx.MockTransport(handler)
+
+
+def test_query_features_raises_on_error_envelope() -> None:
+    with HonuaClient("http://example.test", transport=_envelope_handler(code=400)) as client:
+        with pytest.raises(HonuaHttpError) as excinfo:
+            client.query_features("Parcels", 0, where="1=1")
+    assert excinfo.value.status_code == 400
+    assert "Unable to complete" in str(excinfo.value)
+
+
+def test_apply_edits_raises_on_error_envelope() -> None:
+    with HonuaClient(
+        "http://example.test", transport=_envelope_handler(code=499, message="Token Required")
+    ) as client:
+        with pytest.raises(HonuaHttpError) as excinfo:
+            client.apply_edits("Parcels", 0, adds=[{"attributes": {"NAME": "x"}}])
+    assert excinfo.value.status_code == 499
+
+
+def test_list_services_raises_on_error_envelope() -> None:
+    with HonuaClient("http://example.test", transport=_envelope_handler(code=500)) as client:
+        with pytest.raises(HonuaHttpError):
+            client.list_services()
+
+
+def test_geocode_raises_on_error_envelope() -> None:
+    with HonuaGeocodingClient(
+        "http://example.test", transport=_envelope_handler(code=400, message="Invalid locator")
+    ) as client:
+        with pytest.raises(HonuaHttpError) as excinfo:
+            client.forward_geocode("123 Main St")
+    assert excinfo.value.status_code == 400
+
+
+def test_normal_payload_with_error_named_field_is_not_treated_as_envelope() -> None:
+    # A legitimate result that merely contains an ``error`` field that is not the
+    # GeoServices envelope (no integer ``code``) must pass through untouched.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"features": [], "error": "rate", "count": 0})
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        result = client.query_features("Parcels", 0)
+    assert result == {"features": [], "error": "rate", "count": 0}
+
+
+class _StubResponse:
+    def __init__(self, payload: object) -> None:
+        self.content = b"{}"
+        self._payload = payload
+        self.text = ""
+        self.reason_phrase = "OK"
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> object:
+        return self._payload
+
+
+def test_parse_json_response_body_raises_on_error_envelope() -> None:
+    response = _StubResponse({"error": {"code": 403, "message": "Forbidden"}})
+    with pytest.raises(HonuaHttpError) as excinfo:
+        parse_json_response_body(response)  # type: ignore[arg-type]
+    assert excinfo.value.status_code == 403
+
+
+def test_parse_json_response_body_ignores_bool_code() -> None:
+    # ``True`` is an ``int`` subclass; the envelope check must not fire on it.
+    response = _StubResponse({"error": {"code": True}})
+    assert parse_json_response_body(response) == {"error": {"code": True}}  # type: ignore[arg-type]

--- a/tests/test_sdk_contract.py
+++ b/tests/test_sdk_contract.py
@@ -112,7 +112,10 @@ def test_source_query_facade_uses_canonical_descriptor_and_returns_result() -> N
 
     assert result.protocol == "geoservices-feature-service"
     assert result.source_id == "parcels-fs"
-    assert result.total_count == 2
+    # FeatureServer query responses carry no grand total (no ``numberMatched``
+    # equivalent), so ``total_count`` is unknown rather than the count of
+    # features actually returned.
+    assert result.total_count is None
     assert [feature.id for feature in result.features] == [1, 2]
     assert result.features[0].protocol == "geoservices-feature-service"
     assert result.features[0].source == "parcels-fs"


### PR DESCRIPTION
## Summary

Data-plane response-handling correctness fixes from the pre-release audit (register AUD-091, AUD-159, AUD-202, AUD-203).

### GeoServices error envelopes returned as HTTP 200 (S1, #122)
The Esri GeoServices REST protocol reports failures as an HTTP 200 response whose body is `{"error": {"code": <int>, "message": <str>, ...}}`. The SDK only raised when the transport saw status >= 400, so these errors flowed back to callers as ordinary success dicts — including `applyEdits` requests the server rejected, which raised no exception.

- Added a narrow GeoServices-aware check in the shared `parse_json_response_body` (covering `query_features`, `apply_edits`, `list_services`, the geometry/map/image server wrappers, and OGC/STAC paths). It raises `HonuaHttpError` (carrying the server-reported `code`) only when a 2xx body is a mapping whose `error` is a mapping with an integer `code`, so legitimate payloads that merely contain an `error` field are untouched.
- Refactored `_to_http_error` to share the error-construction path.
- Routed the sync/async geocoding clients through the shared parser so GeocodeServer envelopes raise too.

### Query/geocode response handling (S2, #128)
- **`total_count`**: FeatureServer `query` responses carry no grand total (no `numberMatched` equivalent), so reporting `len(collected)` was misleading (it is the limit/`max_pages`-capped count returned, not the server total). Now reports `None` (unknown). Also removed the `Result` facade's fallback that re-fabricated `total_count` from `len(features)`, which contradicted its own docstring.
- **Malformed geocode entries**: non-mapping candidate/suggestion entries are now skipped instead of raising a raw `AttributeError` outside the Honua error contract.

## Testing
- New `tests/test_geoservices_error_envelope.py` (sync `query_features`/`apply_edits`/`list_services`, geocoding, the parser unit, and a false-positive guard).
- Updated the contract test to assert the corrected `total_count is None` semantic.
- `ruff check .`, `mypy`, `python scripts/gen_sync.py --check`, and `python scripts/compatibility_gate.py` all pass; full `pytest tests/` green (the two `test_wheel_contents` failures are a pre-existing Python-3.14 env issue — `packaging.licenses` missing — unrelated to this change).

Fixes #122
Fixes #128
