### PR TITLE
fix(sdk): close auth credential leak on scheme downgrade and preserve base_url path prefix

### DIFF
--- a/.git-msg-pr2.txt
+++ b/.git-msg-pr2.txt
@@ -1,0 +1,24 @@
+fix(sdk): close auth credential leak on scheme downgrade and preserve base_url path prefix
+
+Two transport-layer defects from the pre-release audit (AUD-154, AUD-155/158/166).
+
+- Auth credential leak (AUD-154): the trusted-origin key used only
+  (host, port), ignoring the URL scheme. An https -> http redirect to
+  the same host normalizes to the same (host, port), so the SDK
+  re-attached Authorization / X-API-Key over plaintext after a
+  downgrade. Include the scheme in the trusted-origin key
+  (scheme, host, port) so credentials are stripped on https -> http
+  downgrades as well as host/port changes.
+
+- base_url path prefix dropped (AUD-155/158/166): every request URL was
+  built with copy_with(raw_path=...), which replaced the entire path and
+  silently discarded any path prefix on the configured base URL. A
+  deployment mounted behind a reverse proxy at a sub-path (e.g.
+  https://host/honua/) had every call rewritten to /rest/services/...,
+  hitting the wrong endpoint with no error. Join the endpoint path onto
+  the base URL's existing path via a new join_base_path helper; a root
+  base URL is unchanged.
+
+Refs #126 (credential-leak half; async non-blocking token refresh deferred)
+Refs #125 (S2 base_url-prefix items; S3 non-ASCII encoding and geocoding
+retry items deferred)

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -30,6 +30,27 @@ def _encode_path_segment(value: str) -> str:
     return quote(value, safe="")
 
 
+def join_base_path(base_url: httpx.URL, path: str) -> str:
+    """Join an endpoint *path* onto the base URL's existing path prefix.
+
+    The core clients build each request URL by overriding the raw path on the
+    base URL (via ``copy_with(raw_path=...)``) so httpx does not percent-decode
+    already-encoded segments. That override would otherwise discard any path
+    prefix on the configured base URL — so a deployment mounted behind a reverse
+    proxy at a sub-path (e.g. ``https://host/honua/``) would have every call
+    silently rewritten to ``/rest/services/...`` and hit the wrong endpoint.
+
+    Prepend the base URL's path so sub-path hosting resolves correctly. A
+    root base URL (path ``"/"`` or empty) leaves *path* unchanged.
+    """
+    prefix = base_url.path.rstrip("/")
+    if not prefix:
+        return path
+    if not path.startswith("/"):
+        path = "/" + path
+    return prefix + path
+
+
 def _build_sensitive_auth_headers(
     *,
     api_key: str | None,
@@ -99,33 +120,37 @@ def _validate_external_client_auth_configuration(
     )
 
 
-def _extract_trusted_authority(url: httpx.URL) -> tuple[str, int | None]:
-    """Return ``(host, port)`` from *url* for use as a trusted-origin key.
+def _extract_trusted_authority(url: httpx.URL) -> tuple[str, str, int | None]:
+    """Return ``(scheme, host, port)`` from *url* for use as a trusted-origin key.
 
-    Using both host **and** port prevents credentials configured for
-    ``example.test:443`` from being sent to ``example.test:9999``
-    after a redirect.
+    Including the **scheme** alongside host and port prevents two distinct
+    leaks on redirects: credentials configured for ``example.test:443`` are not
+    sent to ``example.test:9999`` (different port), and — critically — they are
+    not re-attached after an ``https`` → ``http`` downgrade. Without the scheme,
+    ``https://api.example`` and ``http://api.example`` both normalize to host
+    ``api.example`` / port ``None`` and would compare equal, leaking the
+    ``Authorization`` / ``X-API-Key`` headers over plaintext.
     """
-    return (url.host, url.port)
+    return (url.scheme, url.host, url.port)
 
 
 def _apply_sensitive_auth_headers(
     request: httpx.Request,
     *,
-    trusted_authority: tuple[str, int | None] | None,
+    trusted_authority: tuple[str, str, int | None] | None,
     auth_headers: Mapping[str, str],
     auth_provider: AuthProvider | None = None,
 ) -> None:
     """Attach or strip sensitive headers depending on the request target.
 
-    Headers are only attached when the request's ``(host, port)`` matches
-    *trusted_authority* exactly; otherwise they are stripped to prevent
-    credential leakage on redirects.
+    Headers are only attached when the request's ``(scheme, host, port)``
+    matches *trusted_authority* exactly; otherwise they are stripped to prevent
+    credential leakage on redirects (including ``https`` → ``http`` downgrades).
     """
     if trusted_authority is None:
         return
 
-    request_authority = (request.url.host, request.url.port)
+    request_authority = (request.url.scheme, request.url.host, request.url.port)
     if request_authority == trusted_authority:
         dynamic_headers = _auth_provider_headers(auth_provider)
         for name, value in auth_headers.items():

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -21,6 +21,7 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
     _warn_deprecated_bearer_token,
+    join_base_path,
 )
 from ._query import (
     features_from_geojson_page,
@@ -1506,8 +1507,11 @@ class AsyncHonuaClient:
           same name in ``headers`` / ``extra_headers``.
         """
         # Build a full URL so httpx does not re-decode percent-encoded
-        # path segments during base-URL resolution.
-        url = self._base_url.copy_with(raw_path=path.encode("ascii"))
+        # path segments during base-URL resolution. Join onto the base URL's
+        # path prefix so sub-path deployments (e.g. behind a reverse proxy at
+        # ``/honua/``) are not silently rewritten to the bare endpoint path.
+        raw_path = join_base_path(self._base_url, path)
+        url = self._base_url.copy_with(raw_path=raw_path.encode("ascii"))
         merged_headers = merge_request_headers(headers, extra_headers, idempotency_key)
         request_kwargs: dict[str, Any] = {
             "method": method,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -22,6 +22,7 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
     _warn_deprecated_bearer_token,
+    join_base_path,
 )
 from ._query import (
     features_from_geojson_page,
@@ -1507,8 +1508,11 @@ class HonuaClient:
           same name in ``headers`` / ``extra_headers``.
         """
         # Build a full URL so httpx does not re-decode percent-encoded
-        # path segments during base-URL resolution.
-        url = self._base_url.copy_with(raw_path=path.encode("ascii"))
+        # path segments during base-URL resolution. Join onto the base URL's
+        # path prefix so sub-path deployments (e.g. behind a reverse proxy at
+        # ``/honua/``) are not silently rewritten to the bare endpoint path.
+        raw_path = join_base_path(self._base_url, path)
+        url = self._base_url.copy_with(raw_path=raw_path.encode("ascii"))
         merged_headers = merge_request_headers(headers, extra_headers, idempotency_key)
         request_kwargs: dict[str, Any] = {
             "method": method,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -773,6 +773,75 @@ def test_follow_redirects_does_not_forward_auth_provider_headers_to_different_ho
     ]
 
 
+def test_follow_redirects_does_not_forward_sensitive_headers_on_scheme_downgrade() -> None:
+    # An https -> http downgrade to the *same* host/port must strip credentials:
+    # without the scheme in the trusted-origin key both URLs normalize to the
+    # same (host, port) and the headers would leak over plaintext.
+    seen: list[tuple[str, str, str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            (
+                request.url.scheme,
+                request.url.host or "",
+                request.headers.get("x-api-key", ""),
+                request.headers.get("authorization", ""),
+            )
+        )
+        if request.url.scheme == "https":
+            return httpx.Response(
+                302,
+                headers={"Location": "http://api.example/healthz/ready"},
+            )
+        return httpx.Response(200, json={"status": "ready"})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient(
+        "https://api.example",
+        transport=transport,
+        api_key="test-key",
+        bearer_token="test-token",
+        follow_redirects=True,
+    ) as client:
+        response = client.readiness()
+
+    assert response == {"status": "ready"}
+    assert seen == [
+        ("https", "api.example", "test-key", "Bearer test-token"),
+        ("http", "api.example", "", ""),
+    ]
+
+
+def test_base_url_path_prefix_is_preserved_on_every_request() -> None:
+    # A base URL with a sub-path prefix (reverse-proxy mount) must be honored;
+    # the endpoint path is joined onto the prefix rather than replacing it.
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"status": "ready"})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("https://host.example/honua/", transport=transport) as client:
+        client.readiness()
+
+    assert seen == ["/honua/healthz/ready"]
+
+
+def test_root_base_url_leaves_request_path_unchanged() -> None:
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, json={"status": "ready"})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("https://host.example", transport=transport) as client:
+        client.readiness()
+
+    assert seen == ["/healthz/ready"]
+
+
 def test_transport_errors_are_normalized_to_honua_transport_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection failed", request=request)


### PR DESCRIPTION
## Summary

Transport-layer correctness/security fixes from the pre-release audit (register AUD-154, AUD-155/158/166).

### Auth credential leak on HTTPS -> HTTP redirect downgrade (S2, #126)
The trusted-origin key used only `(host, port)` and ignored the URL scheme. An `https://api.example` -> `http://api.example` redirect both normalize to host `api.example` / port `None`, so the SDK re-attached `Authorization` / `X-API-Key` over plaintext after a downgrade — the exact leak the mechanism's docstring claims to prevent.

- `_extract_trusted_authority` now returns `(scheme, host, port)` and `_apply_sensitive_auth_headers` compares the full triple, so credentials are stripped on `https` -> `http` downgrades as well as host/port changes.

### base_url path prefix silently dropped from every request (S2, #125)
Every request URL was built with `copy_with(raw_path=path.encode("ascii"))`, replacing the whole path and discarding any prefix on the configured base URL. A deployment behind a reverse proxy at a sub-path (e.g. `https://host/honua/`) had every call rewritten to `/rest/services/...`, hitting the wrong endpoint with no error.

- Added `join_base_path(base_url, path)` and use it in the core sync/async `_request`, so the endpoint path is joined onto the base URL's existing path. A root base URL is unchanged.

## Scope / deferred
- **#126** async non-blocking token refresh (the second S2 item: the async client calls the sync auth provider per request, blocking the loop on a refresh) is **not** in this PR — it needs a new awaitable auth-provider API and concurrency review. Tracked, issue left open.
- **#125** S3 items (let httpx percent-encode non-ASCII next-link paths; align geocoding's pre-encoded path + always-on retries) are **not** in this PR; the existing ASCII `copy_with` encoding is intentional to avoid percent-decoding already-encoded segments. Issue left open.

## Testing
- New `tests/test_client.py` cases: scheme-downgrade credential stripping, base_url sub-path preservation, and root base URL unchanged.
- `ruff check .`, `mypy`, `python scripts/gen_sync.py --check`, `python scripts/compatibility_gate.py` all pass; full `pytest tests/` green except the two pre-existing `test_wheel_contents` failures (Python-3.14 env: `packaging.licenses` missing), unrelated to this change.

Refs #126
Refs #125
