### PR TITLE
fix(sdk): emit spec-mandatory params for STAC/WMS/WMTS typed helpers

### DIFF
--- a/.git-msg-pr3.txt
+++ b/.git-msg-pr3.txt
@@ -1,0 +1,18 @@
+fix(sdk): emit spec-mandatory params for STAC/WMS/WMTS typed helpers
+
+The typed protocol convenience methods produced requests that
+spec-compliant servers reject by default (AUD-163/164/165).
+
+- STAC POST /search pagination re-issued the next link as a GET, losing
+  the POST continuation token/body. Now reads the full rel="next" link
+  object and, when method==POST, re-POSTs to the href with the link's
+  body (merged with the original request body when merge is true),
+  falling back to GET only when method is GET/absent.
+- WMS GetMap now always emits the mandatory STYLES parameter (empty =
+  default style) and GetFeatureInfo now sends the mandatory CRS and
+  INFO_FORMAT (plus STYLES). Documented the 1.3.0 EPSG:4326 lat/lon
+  BBOX axis order.
+- WMTS KVP GetTile now includes the mandatory STYLE parameter
+  (default "default").
+
+Fixes #127

--- a/packages/honua-sdk/honua_sdk/protocols/_base.py
+++ b/packages/honua-sdk/honua_sdk/protocols/_base.py
@@ -215,6 +215,25 @@ def _next_link(response: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _next_link_object(response: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the full ``rel="next"`` link object from a STAC response, if any.
+
+    Unlike :func:`_next_link` (which only yields the ``href`` string), this
+    preserves the ``method``/``body``/``merge`` fields so STAC POST ``/search``
+    pagination can honor the spec's method+body continuation contract instead of
+    silently re-issuing the next link as a GET.
+    """
+    links = response.get("links")
+    if not isinstance(links, Sequence) or isinstance(links, str):
+        return None
+    for link in links:
+        if not isinstance(link, Mapping):
+            continue
+        if link.get("rel") == "next" and isinstance(link.get("href"), str):
+            return link
+    return None
+
+
 def _path_and_params_from_href(href: str) -> tuple[str, dict[str, str]]:
     parsed = urlsplit(href)
     path = parsed.path or href

--- a/packages/honua-sdk/honua_sdk/protocols/stac.py
+++ b/packages/honua-sdk/honua_sdk/protocols/stac.py
@@ -18,12 +18,35 @@ from ._base import (
     _AsyncProtocol,
     _features_from_page,
     _next_link,
+    _next_link_object,
     _normalize_max_pages,
     _normalize_page_limit,
     _normalize_total_limit,
     _params,
+    _path_and_params_from_href,
     _SyncProtocol,
 )
+
+
+def _stac_post_next_request(
+    link: Mapping[str, Any],
+    original_body: Mapping[str, Any] | None,
+) -> tuple[str, dict[str, str], dict[str, Any]]:
+    """Build the (path, params, body) for a STAC POST ``next`` link.
+
+    Honors the STAC API pagination contract: when ``merge`` is true the link's
+    ``body`` is merged onto the original request body; otherwise the link body is
+    the complete next request body.
+    """
+    path, params = _path_and_params_from_href(str(link["href"]))
+    raw_link_body = link.get("body")
+    link_body = dict(raw_link_body) if isinstance(raw_link_body, Mapping) else {}
+    body = (
+        {**original_body, **link_body}
+        if link.get("merge") and original_body is not None
+        else link_body
+    )
+    return path, params, body
 
 
 class StacClient(_SyncProtocol):
@@ -212,6 +235,7 @@ class StacClient(_SyncProtocol):
             return
 
         fetched = 0
+        next_link: Mapping[str, Any] | None = None
         next_href: str | None = None
         offset = int((params or json_body or {}).get("offset", 0))
         for _ in range(effective_max_pages):
@@ -219,7 +243,19 @@ class StacClient(_SyncProtocol):
             if remaining < 1:
                 break
             page_limit = min(effective_page_size, remaining)
-            if next_href is not None:
+            if next_link is not None and str(next_link.get("method", "GET")).upper() == "POST":
+                # STAC POST /search continuation: re-POST to the next href with
+                # the link's body so the continuation token/body is preserved.
+                post_path, post_params, post_body = _stac_post_next_request(next_link, json_body)
+                page = self._json(
+                    "POST",
+                    post_path,
+                    params=post_params or None,
+                    json_body=post_body,
+                    timeout=timeout,
+                    extra_headers=extra_headers,
+                )
+            elif next_href is not None:
                 page = self._json_href(next_href, timeout=timeout, extra_headers=extra_headers)
             elif json_body is not None:
                 page_body = {**json_body, "limit": page_limit, "offset": offset}
@@ -235,6 +271,7 @@ class StacClient(_SyncProtocol):
             yield page
             page_items = _features_from_page(page)
             fetched += len(page_items)
+            next_link = _next_link_object(page)
             next_href = _next_link(page)
             if next_href is None:
                 if len(page_items) < page_limit:
@@ -471,6 +508,7 @@ class AsyncStacClient(_AsyncProtocol):
             return
 
         fetched = 0
+        next_link: Mapping[str, Any] | None = None
         next_href: str | None = None
         offset = int((params or json_body or {}).get("offset", 0))
         for _ in range(effective_max_pages):
@@ -478,7 +516,19 @@ class AsyncStacClient(_AsyncProtocol):
             if remaining < 1:
                 break
             page_limit = min(effective_page_size, remaining)
-            if next_href is not None:
+            if next_link is not None and str(next_link.get("method", "GET")).upper() == "POST":
+                # STAC POST /search continuation: re-POST to the next href with
+                # the link's body so the continuation token/body is preserved.
+                post_path, post_params, post_body = _stac_post_next_request(next_link, json_body)
+                page = await self._json(
+                    "POST",
+                    post_path,
+                    params=post_params or None,
+                    json_body=post_body,
+                    timeout=timeout,
+                    extra_headers=extra_headers,
+                )
+            elif next_href is not None:
                 page = await self._json_href(next_href, timeout=timeout, extra_headers=extra_headers)
             elif json_body is not None:
                 page_body = {**json_body, "limit": page_limit, "offset": offset}
@@ -494,6 +544,7 @@ class AsyncStacClient(_AsyncProtocol):
             yield page
             page_items = _features_from_page(page)
             fetched += len(page_items)
+            next_link = _next_link_object(page)
             next_href = _next_link(page)
             if next_href is None:
                 if len(page_items) < page_limit:

--- a/packages/honua-sdk/honua_sdk/protocols/wms.py
+++ b/packages/honua-sdk/honua_sdk/protocols/wms.py
@@ -42,13 +42,14 @@ class WmsClient(_SyncProtocol):
     def capabilities(self) -> str:
         return self.request("GetCapabilities").decode("utf-8")
 
-    def map(self, *, layers: CsvValue, bbox: BboxValue, width: int, height: int, crs: str = "EPSG:4326", image_format: str = "image/png", extra_params: Params = None) -> bytes:
+    def map(self, *, layers: CsvValue, bbox: BboxValue, width: int, height: int, crs: str = "EPSG:4326", styles: str = "", image_format: str = "image/png", extra_params: Params = None) -> bytes:
         return self.map_response(
             layers=layers,
             bbox=bbox,
             width=width,
             height=height,
             crs=crs,
+            styles=styles,
             image_format=image_format,
             extra_params=extra_params,
         ).content
@@ -61,13 +62,18 @@ class WmsClient(_SyncProtocol):
         width: int,
         height: int,
         crs: str = "EPSG:4326",
+        styles: str = "",
         image_format: OgcImageFormat = "image/png",
         extra_params: Params = None,
     ) -> BinaryResponse:
-        params = _params({"layers": _csv(layers), "bbox": _bbox(bbox), "width": width, "height": height, "crs": crs, "format": image_format}, extra_params)
+        # STYLES is a mandatory GetMap parameter in WMS 1.1.1/1.3.0 (an empty
+        # value selects each layer's default style), so it is always emitted.
+        # For 1.3.0 with a geographic CRS such as EPSG:4326 the BBOX axis order
+        # is lat/lon (miny,minx,maxy,maxx); callers must order ``bbox`` to match.
+        params = _params({"layers": _csv(layers), "styles": styles, "bbox": _bbox(bbox), "width": width, "height": height, "crs": crs, "format": image_format}, extra_params)
         return self.request_response("GetMap", params=params)
 
-    def feature_info(self, *, layers: CsvValue, query_layers: CsvValue, i: int, j: int, bbox: BboxValue, width: int, height: int, extra_params: Params = None) -> bytes:
+    def feature_info(self, *, layers: CsvValue, query_layers: CsvValue, i: int, j: int, bbox: BboxValue, width: int, height: int, crs: str = "EPSG:4326", info_format: str = "application/json", styles: str = "", extra_params: Params = None) -> bytes:
         return self.feature_info_response(
             layers=layers,
             query_layers=query_layers,
@@ -76,6 +82,9 @@ class WmsClient(_SyncProtocol):
             bbox=bbox,
             width=width,
             height=height,
+            crs=crs,
+            info_format=info_format,
+            styles=styles,
             extra_params=extra_params,
         ).content
 
@@ -89,9 +98,15 @@ class WmsClient(_SyncProtocol):
         bbox: BboxValue,
         width: int,
         height: int,
+        crs: str = "EPSG:4326",
+        info_format: str = "application/json",
+        styles: str = "",
         extra_params: Params = None,
     ) -> BinaryResponse:
-        params = _params({"layers": _csv(layers), "query_layers": _csv(query_layers), "i": i, "j": j, "bbox": _bbox(bbox), "width": width, "height": height}, extra_params)
+        # GetFeatureInfo embeds a GetMap request, so the mandatory map params
+        # (CRS, STYLES) plus the mandatory INFO_FORMAT must be present or
+        # spec-compliant servers reject the request.
+        params = _params({"layers": _csv(layers), "styles": styles, "query_layers": _csv(query_layers), "crs": crs, "info_format": info_format, "i": i, "j": j, "bbox": _bbox(bbox), "width": width, "height": height}, extra_params)
         return self.request_response("GetFeatureInfo", params=params)
 
 
@@ -115,7 +130,7 @@ class AsyncWmsClient(_AsyncProtocol):
     async def capabilities(self) -> str:
         return (await self.request("GetCapabilities")).decode("utf-8")
 
-    async def map(self, *, layers: CsvValue, bbox: BboxValue, width: int, height: int, crs: str = "EPSG:4326", image_format: str = "image/png", extra_params: Params = None) -> bytes:
+    async def map(self, *, layers: CsvValue, bbox: BboxValue, width: int, height: int, crs: str = "EPSG:4326", styles: str = "", image_format: str = "image/png", extra_params: Params = None) -> bytes:
         return (
             await self.map_response(
                 layers=layers,
@@ -123,6 +138,7 @@ class AsyncWmsClient(_AsyncProtocol):
                 width=width,
                 height=height,
                 crs=crs,
+                styles=styles,
                 image_format=image_format,
                 extra_params=extra_params,
             )
@@ -136,13 +152,18 @@ class AsyncWmsClient(_AsyncProtocol):
         width: int,
         height: int,
         crs: str = "EPSG:4326",
+        styles: str = "",
         image_format: OgcImageFormat = "image/png",
         extra_params: Params = None,
     ) -> BinaryResponse:
-        params = _params({"layers": _csv(layers), "bbox": _bbox(bbox), "width": width, "height": height, "crs": crs, "format": image_format}, extra_params)
+        # STYLES is a mandatory GetMap parameter in WMS 1.1.1/1.3.0 (an empty
+        # value selects each layer's default style), so it is always emitted.
+        # For 1.3.0 with a geographic CRS such as EPSG:4326 the BBOX axis order
+        # is lat/lon (miny,minx,maxy,maxx); callers must order ``bbox`` to match.
+        params = _params({"layers": _csv(layers), "styles": styles, "bbox": _bbox(bbox), "width": width, "height": height, "crs": crs, "format": image_format}, extra_params)
         return await self.request_response("GetMap", params=params)
 
-    async def feature_info(self, *, layers: CsvValue, query_layers: CsvValue, i: int, j: int, bbox: BboxValue, width: int, height: int, extra_params: Params = None) -> bytes:
+    async def feature_info(self, *, layers: CsvValue, query_layers: CsvValue, i: int, j: int, bbox: BboxValue, width: int, height: int, crs: str = "EPSG:4326", info_format: str = "application/json", styles: str = "", extra_params: Params = None) -> bytes:
         return (
             await self.feature_info_response(
                 layers=layers,
@@ -152,6 +173,9 @@ class AsyncWmsClient(_AsyncProtocol):
                 bbox=bbox,
                 width=width,
                 height=height,
+                crs=crs,
+                info_format=info_format,
+                styles=styles,
                 extra_params=extra_params,
             )
         ).content
@@ -166,7 +190,13 @@ class AsyncWmsClient(_AsyncProtocol):
         bbox: BboxValue,
         width: int,
         height: int,
+        crs: str = "EPSG:4326",
+        info_format: str = "application/json",
+        styles: str = "",
         extra_params: Params = None,
     ) -> BinaryResponse:
-        params = _params({"layers": _csv(layers), "query_layers": _csv(query_layers), "i": i, "j": j, "bbox": _bbox(bbox), "width": width, "height": height}, extra_params)
+        # GetFeatureInfo embeds a GetMap request, so the mandatory map params
+        # (CRS, STYLES) plus the mandatory INFO_FORMAT must be present or
+        # spec-compliant servers reject the request.
+        params = _params({"layers": _csv(layers), "styles": styles, "query_layers": _csv(query_layers), "crs": crs, "info_format": info_format, "i": i, "j": j, "bbox": _bbox(bbox), "width": width, "height": height}, extra_params)
         return await self.request_response("GetFeatureInfo", params=params)

--- a/packages/honua-sdk/honua_sdk/protocols/wmts.py
+++ b/packages/honua-sdk/honua_sdk/protocols/wmts.py
@@ -38,13 +38,14 @@ class WmtsClient(_SyncProtocol):
     def capabilities(self) -> str:
         return self.request("GetCapabilities").decode("utf-8")
 
-    def tile(self, *, layer: str, tile_matrix_set: str, tile_matrix: str, tile_row: int, tile_col: int, image_format: str = "image/png", extra_params: Params = None) -> bytes:
+    def tile(self, *, layer: str, tile_matrix_set: str, tile_matrix: str, tile_row: int, tile_col: int, style: str = "default", image_format: str = "image/png", extra_params: Params = None) -> bytes:
         return self.tile_response(
             layer=layer,
             tile_matrix_set=tile_matrix_set,
             tile_matrix=tile_matrix,
             tile_row=tile_row,
             tile_col=tile_col,
+            style=style,
             image_format=image_format,
             extra_params=extra_params,
         ).content
@@ -57,10 +58,13 @@ class WmtsClient(_SyncProtocol):
         tile_matrix: str,
         tile_row: int,
         tile_col: int,
+        style: str = "default",
         image_format: OgcImageFormat = "image/png",
         extra_params: Params = None,
     ) -> BinaryResponse:
-        params = _params({"layer": layer, "tileMatrixSet": tile_matrix_set, "tileMatrix": tile_matrix, "tileRow": tile_row, "tileCol": tile_col, "format": image_format}, extra_params)
+        # STYLE is a mandatory GetTile KVP parameter in WMTS 1.0.0; ``"default"``
+        # selects the layer's advertised default style.
+        params = _params({"layer": layer, "style": style, "tileMatrixSet": tile_matrix_set, "tileMatrix": tile_matrix, "tileRow": tile_row, "tileCol": tile_col, "format": image_format}, extra_params)
         return self.request_response("GetTile", params=params)
 
 
@@ -84,7 +88,7 @@ class AsyncWmtsClient(_AsyncProtocol):
     async def capabilities(self) -> str:
         return (await self.request("GetCapabilities")).decode("utf-8")
 
-    async def tile(self, *, layer: str, tile_matrix_set: str, tile_matrix: str, tile_row: int, tile_col: int, image_format: str = "image/png", extra_params: Params = None) -> bytes:
+    async def tile(self, *, layer: str, tile_matrix_set: str, tile_matrix: str, tile_row: int, tile_col: int, style: str = "default", image_format: str = "image/png", extra_params: Params = None) -> bytes:
         return (
             await self.tile_response(
                 layer=layer,
@@ -92,6 +96,7 @@ class AsyncWmtsClient(_AsyncProtocol):
                 tile_matrix=tile_matrix,
                 tile_row=tile_row,
                 tile_col=tile_col,
+                style=style,
                 image_format=image_format,
                 extra_params=extra_params,
             )
@@ -105,8 +110,11 @@ class AsyncWmtsClient(_AsyncProtocol):
         tile_matrix: str,
         tile_row: int,
         tile_col: int,
+        style: str = "default",
         image_format: OgcImageFormat = "image/png",
         extra_params: Params = None,
     ) -> BinaryResponse:
-        params = _params({"layer": layer, "tileMatrixSet": tile_matrix_set, "tileMatrix": tile_matrix, "tileRow": tile_row, "tileCol": tile_col, "format": image_format}, extra_params)
+        # STYLE is a mandatory GetTile KVP parameter in WMTS 1.0.0; ``"default"``
+        # selects the layer's advertised default style.
+        params = _params({"layer": layer, "style": style, "tileMatrixSet": tile_matrix_set, "tileMatrix": tile_matrix, "tileRow": tile_row, "tileCol": tile_col, "format": image_format}, extra_params)
         return await self.request_response("GetTile", params=params)

--- a/tests/test_protocol_conformance.py
+++ b/tests/test_protocol_conformance.py
@@ -1,0 +1,121 @@
+"""OGC/STAC request-conformance regressions (issue #127, AUD-163/164/165).
+
+These pin the mandatory parameters that spec-compliant WMS/WMTS servers require
+by default, and the STAC POST ``/search`` method+body pagination contract.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from honua_sdk import HonuaClient
+
+
+def test_wms_getmap_always_emits_styles_and_crs() -> None:
+    seen: list[dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(dict(request.url.params.multi_items()))
+        return httpx.Response(200, content=b"img", headers={"content-type": "image/png"})
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        client.wms("basemap").map(layers=["roads"], bbox=[-158, 21, -157, 22], width=256, height=256)
+
+    params = seen[0]
+    assert params["request"] == "GetMap"
+    # STYLES is mandatory in WMS 1.1.1/1.3.0 (empty value = default style).
+    assert params["styles"] == ""
+    assert params["crs"] == "EPSG:4326"
+
+
+def test_wms_getfeatureinfo_emits_mandatory_crs_and_info_format() -> None:
+    seen: list[dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(dict(request.url.params.multi_items()))
+        return httpx.Response(200, content=b"{}", headers={"content-type": "application/json"})
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        client.wms("basemap").feature_info(
+            layers=["roads"],
+            query_layers=["roads"],
+            i=128,
+            j=128,
+            bbox=[-158, 21, -157, 22],
+            width=256,
+            height=256,
+        )
+
+    params = seen[0]
+    assert params["request"] == "GetFeatureInfo"
+    assert params["info_format"] == "application/json"
+    assert params["crs"] == "EPSG:4326"
+    assert params["styles"] == ""
+
+
+def test_wmts_gettile_emits_mandatory_style() -> None:
+    seen: list[dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(dict(request.url.params.multi_items()))
+        return httpx.Response(200, content=b"img", headers={"content-type": "image/png"})
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        client.wmts("basemap").tile(
+            layer="basemap",
+            tile_matrix_set="WebMercatorQuad",
+            tile_matrix="0",
+            tile_row=0,
+            tile_col=0,
+        )
+
+    params = seen[0]
+    assert params["request"] == "GetTile"
+    # STYLE is mandatory in WMTS 1.0.0 GetTile KVP; defaults to "default".
+    assert params["style"] == "default"
+
+
+def test_stac_post_search_pagination_reposts_next_link_with_body() -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content) if request.content else {}
+        calls.append((request.method, body))
+        if body.get("token") == "page-2":
+            # Continuation page (reached only by honoring the POST next link).
+            return httpx.Response(
+                200,
+                json={"type": "FeatureCollection", "features": [{"type": "Feature", "id": "s-2"}], "links": []},
+            )
+        return httpx.Response(
+            200,
+            json={
+                "type": "FeatureCollection",
+                "features": [{"type": "Feature", "id": "s-1"}],
+                "links": [
+                    {
+                        "rel": "next",
+                        "method": "POST",
+                        "href": "http://example.test/stac/search",
+                        "merge": True,
+                        "body": {"token": "page-2"},
+                    }
+                ],
+            },
+        )
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        items = client.stac().search_items(
+            json_body={"collections": ["imagery"], "offset": 0},
+            page_size=1,
+            limit=2,
+        )
+
+    assert [item["id"] for item in items] == ["s-1", "s-2"]
+    # Both requests are POSTs (the continuation is not silently downgraded to GET)
+    assert [method for method, _ in calls] == ["POST", "POST"]
+    # The continuation merges the link body onto the original request body.
+    assert calls[1][1]["token"] == "page-2"
+    assert calls[1][1]["collections"] == ["imagery"]


### PR DESCRIPTION
## Summary

Makes the typed OGC/STAC/WMS/WMTS convenience methods emit the parameters spec-compliant servers require by default, so callers no longer have to hand-patch them via `extra_params` (register AUD-163/164/165).

### STAC POST `/search` pagination (S2)
`search_pages` followed the `rel="next"` link with a GET, discarding the POST continuation token/body. Added `_next_link_object` (returns the full link mapping) and `_stac_post_next_request`; when the next link's `method == "POST"`, the SDK re-POSTs to its `href` with the link `body` (merged onto the original request body when `merge` is true), falling back to GET when method is GET/absent. Applied to both sync and async clients.

### WMS mandatory params (S2)
- `GetMap` now always emits `STYLES` (mandatory in WMS 1.1.1/1.3.0; empty value selects the default style) via a new `styles: str = ""` keyword.
- `GetFeatureInfo` now sends the mandatory `CRS` and `INFO_FORMAT` (plus `STYLES`) via new `crs` / `info_format` / `styles` keywords.
- Documented the WMS 1.3.0 EPSG:4326 lat/lon BBOX axis order.

### WMTS mandatory param (S2)
- KVP `GetTile` now includes the mandatory `STYLE` parameter via a new `style: str = "default"` keyword.

## Testing
- New `tests/test_protocol_conformance.py` asserts the emitted query params for GetMap/GetFeatureInfo/GetTile and that STAC POST `/search` pagination re-POSTs the continuation with the merged body (not a GET).
- `ruff check .`, `mypy`, `python scripts/gen_sync.py --check`, `python scripts/compatibility_gate.py` all pass; full `pytest tests/` green except the two pre-existing `test_wheel_contents` failures (Python-3.14 env: `packaging.licenses` missing), unrelated to this change.

Fixes #127
