### PR TITLE
fix(ci/docs): stop gates and docs overstating enforcement/coverage

### DIFF
--- a/.git-msg-pr4.txt
+++ b/.git-msg-pr4.txt
@@ -1,0 +1,25 @@
+fix(ci/docs): stop gates and docs overstating enforcement/coverage
+
+Several gates and customer-facing claims described more enforcement or
+capability than they delivered (AUD-167/168/169/209).
+
+- Per-PR arcpy eval gate: the stub-mode (blocking) invocation only keyed
+  off the overall pass rate, which is dominated by expected-failure stub
+  scripts, so the supported surface could regress while the lane stayed
+  green. Add --require-supported-pass-rate 1.0 to the stub-mode
+  run_eval.py call (the harness and live-mode lane already support it).
+  Verified locally: stub mode reports supported 11/11 (100%).
+- Conformance lane honesty: document in AGENTS.md that an xfailed
+  (strict=False) case is non-enforcing for its whole assertion body, so
+  the feature_query_envelope case's core feature-read assertions are
+  currently advisory (not blocking) while it carries the
+  honua-server#1238 known_gap_issue; note splitting the JSONB assertion
+  into its own known_gap case as tracked follow-up.
+- honua-arcpy README: reword the headline to scope the claim to the
+  supported subset (feature-layer queries, cursors, GetCount) and point
+  at the compatibility matrix, instead of advertising end-to-end
+  no-rewrite compatibility against ~15% of functions mapped.
+- OGC Tiles coverage-uplift test: assert the constructed request paths
+  (mirroring the sibling OGC maps test) instead of only the mock body.
+
+Fixes #130

--- a/.github/workflows/honua-arcpy-eval.yml
+++ b/.github/workflows/honua-arcpy-eval.yml
@@ -71,11 +71,16 @@ jobs:
 
       - name: Run honua-arcpy eval (stub mode)
         run: |
+          # ``--require-supported-pass-rate 1.0`` makes this blocking per-PR
+          # lane fail on ANY regression in a *supported* (mapped) script,
+          # instead of staying green off the overall pass rate (which is
+          # dominated by expected-failure stub scripts).
           python packages/honua-arcpy/eval/run_eval.py \
             --output-json packages/honua-arcpy/eval-results.json \
             --output-junit packages/honua-arcpy/eval-results.xml \
             --audit-root packages/honua-arcpy/eval/.audit \
-            --pass-threshold 0.70
+            --pass-threshold 0.70 \
+            --require-supported-pass-rate 1.0
 
       - name: Upload eval artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,15 +175,23 @@ pyproject.toml                   # shared tool config ONLY (not installable)
   geospatial-grpc conformance fixtures** with `conformance/fetch-fixtures.sh`
   (version pinned in `conformance/FIXTURES_VERSION`, 1:1 with a `geospatial.v1`
   schema release), and exercises them against the live REST surfaces via the
-  `httpx` clients — failing on any drift. The seeded server must run with
+  `httpx` clients — failing on any drift **in a required (non-`known_gap`)
+  case**. The seeded server must run with
   `ASPNETCORE_ENVIRONMENT=Development` (the client-compat seed activates the
   metadata-v2 snapshot for `default`/`Development`/`Test`, not `Production`).
-  Known, already-tracked nightly server gaps are marked `xfail` with explicit
-  issue references in `scripts/_conformance.py::KNOWN_SERVER_GAPS`
+  Known, already-tracked nightly server gaps are marked `xfail` (strict=False)
+  with explicit issue references in `scripts/_conformance.py::KNOWN_SERVER_GAPS`
   (honua-server#1238 JSONB-attribute projection is the live-checked one today;
   #1166 temporal, #1167 replica, #1237 analysis list/estimate are reserved);
   when a fix lands, clear the case's `known_gap_issue` to make it required.
-  New/untracked drift still fails the lane — never blanket `continue-on-error`.
+  **Caveat:** an `xfail`ed case is non-enforcing for its *whole* assertion body,
+  not just the tracked-gap line — so the `feature_query_envelope` case's core
+  feature-read assertions (a `features[]` array, `exceededTransferLimit`, etc.)
+  are currently **advisory**, not blocking, while it carries the
+  honua-server#1238 `known_gap_issue`. Splitting the JSONB-projection assertion
+  into its own `known_gap` case so the core read contract is enforced
+  unconditionally is tracked follow-up work. New/untracked drift in a required
+  case still fails the lane — never blanket `continue-on-error`.
 - CI runs on the `trunk` branch (lint, typecheck, test matrix, compatibility,
   security-audit, package smoke-install of built wheels, and the live-server
   conformance lane).

--- a/packages/honua-arcpy/README.md
+++ b/packages/honua-arcpy/README.md
@@ -1,9 +1,14 @@
 # honua-arcpy
 
-**Proprietary** drop-in compatibility shim that lets existing `arcpy` Python
-scripts run end-to-end against a Honua deployment without a rewrite. Distributed
-as a closed-source package; this directory carries its own `LICENSE` that
-overrides the surrounding monorepo Apache-2.0 grant.
+**Proprietary** compatibility shim that lets a **supported subset** of `arcpy`
+Python scripts -- feature-layer queries, search/insert/update cursors, and
+`GetCount`-style workflows -- run against a Honua deployment without a rewrite.
+Coverage is partial (roughly the mapped functions in the table below; see
+[`docs/compatibility-matrix.md`](docs/compatibility-matrix.md) for the
+authoritative matrix); unmapped functions raise a clear `ExecuteError` rather
+than silently succeeding. Distributed as a closed-source package; this directory
+carries its own `LICENSE` that overrides the surrounding monorepo Apache-2.0
+grant.
 
 Customers replace `import arcpy` with `import honua_arcpy as arcpy` and point
 the shim at a Honua base URL. Every shim call dispatches through one of three

--- a/tests/test_protocols_coverage_uplift.py
+++ b/tests/test_protocols_coverage_uplift.py
@@ -73,6 +73,19 @@ def test_ogc_tiles_landing_conformance_collection_matrix_and_dataset_paths() -> 
         assert tiles.collection_tilesets("imagery")["ok"] is True
         assert tiles.tile("WebMercatorQuad", "0", 0, 0) == b"tile-bytes"
 
+    # Assert the constructed request paths (mirroring the sibling OGC maps
+    # test) so the coverage-uplift test pins behavior, not just the mock body.
+    assert seen == [
+        "/ogc/tiles",
+        "/ogc/tiles/conformance",
+        "/ogc/tiles/collections/imagery",
+        "/ogc/tiles/tileMatrixSets",
+        "/ogc/tiles/tileMatrixSets/WebMercatorQuad",
+        "/ogc/tiles/tiles",
+        "/ogc/tiles/collections/imagery/tiles",
+        "/ogc/tiles/tiles/WebMercatorQuad/0/0/0",
+    ]
+
 
 def test_ogc_coverages_collections_collection_and_coverage_paths() -> None:
     seen: list[str] = []


### PR DESCRIPTION
## Summary

Stops several blocking gates and customer-facing claims from describing more enforcement/capability than they actually deliver (register AUD-167/168/169/209).

### Per-PR arcpy eval gate could stay green while the supported surface collapses (S2)
The stub-mode (blocking, per-PR) `run_eval.py` invocation keyed only off the overall pass rate (`--pass-threshold 0.70`), which is dominated by expected-failure stub scripts — so a regression across the *supported* (mapped) scripts could ship green. The live-mode lane already passes `--require-supported-pass-rate 1.0`; this adds the same gate to the stub-mode step.
- Verified locally in stub mode: `supported 11/11 (100%)`, so the gate passes today and will fail on any supported-script regression.

### "Blocking, fails on any drift" conformance lane (S2)
An `xfail(strict=False)` case is non-enforcing for its **whole** assertion body, not just the tracked-gap line — so `feature_query_envelope`'s core feature-read assertions (`features[]`, `exceededTransferLimit`, geometry) are currently advisory while it carries the honua-server#1238 `known_gap_issue`. Documented this honestly in `AGENTS.md` (the recommendation's explicit alternative to enforcing). The stronger fix — splitting the JSONB-projection assertion into its own `known_gap` case so the core read contract is enforced unconditionally — is noted as tracked follow-up because it can only be safely validated by running the live conformance lane (seeded `honua-server` + `HONUA_BASE_URL`), which isn't available here.

### honua-arcpy README over-advertised end-to-end no-rewrite compatibility (S2)
Reworded the headline to scope the claim to the supported subset (feature-layer queries, search/insert/update cursors, `GetCount` workflows) and point at the compatibility matrix, instead of implying full end-to-end coverage against ~15% of functions actually mapped.

### OGC Tiles coverage-uplift test asserted only the mock body (S3)
Added `assert seen == [...]` on the constructed request paths, mirroring the sibling OGC maps test.

## Testing
- `ruff check .` passes; the OGC Tiles test and full `packages/honua-arcpy/tests` (131) pass; YAML validated; stub-mode eval verified at supported 11/11.

Fixes #130
