### PR TITLE
fix: round-1 audit fixes (geocoding base path, limit=0 crash, gRPC M-only geometry, conformance probes, license text)

### DIFF
--- a/packages/honua-admin/LICENSE
+++ b/packages/honua-admin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Honua
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/honua-admin/pyproject.toml
+++ b/packages/honua-admin/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.4"
 description = "Admin / control-plane client for Honua geospatial server"
 readme = "README.md"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [{ name = "Honua" }]
 keywords = ["geospatial", "admin", "gis", "honua", "control-plane"]

--- a/packages/honua-sdk/LICENSE
+++ b/packages/honua-sdk/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Honua
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -934,6 +934,7 @@ class AsyncHonuaClient:
             return tuple(collected), exceeded, total_count, pages_seen
 
         if normalized_protocol == "stac":
+            last_page = None
             async for page in self.stac().item_pages(  # type: ignore[assignment]
                 query.source,
                 **stac_pages_kwargs(
@@ -954,6 +955,7 @@ class AsyncHonuaClient:
             return tuple(collected), exceeded, total_count, pages_seen
 
         reject_odata_bbox(query)
+        last_page = None
         async for page in self.odata().features_pages(  # type: ignore[assignment]
             **odata_pages_kwargs(
                 query, timeout=timeout, extra_headers=extra_headers

--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -19,6 +19,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    join_base_path,
 )
 from .auth import AuthProvider
 from .geocoding import (
@@ -341,9 +342,16 @@ class AsyncHonuaGeocodingClient:
                 headers.update(extra_headers)
             if idempotency_key is not None:
                 headers["Idempotency-Key"] = idempotency_key
+        # Build a full URL the same way the core client does: prepend any
+        # base-URL path prefix (so sub-path hosting resolves) and override the
+        # raw path so httpx does not percent-decode already-encoded segments
+        # (e.g. a locator name containing a space or "/").
+        base_url = self._client.base_url
+        raw_path = join_base_path(base_url, path)
+        url = base_url.copy_with(raw_path=raw_path.encode("ascii"))
         request_kwargs: dict[str, Any] = {
             "method": method,
-            "url": path,
+            "url": url,
             "params": params,
             "json": json_body,
             "headers": headers,

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -935,6 +935,7 @@ class HonuaClient:
             return tuple(collected), exceeded, total_count, pages_seen
 
         if normalized_protocol == "stac":
+            last_page = None
             for page in self.stac().item_pages(  # type: ignore[assignment]
                 query.source,
                 **stac_pages_kwargs(
@@ -955,6 +956,7 @@ class HonuaClient:
             return tuple(collected), exceeded, total_count, pages_seen
 
         reject_odata_bbox(query)
+        last_page = None
         for page in self.odata().features_pages(  # type: ignore[assignment]
             **odata_pages_kwargs(
                 query, timeout=timeout, extra_headers=extra_headers

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -19,6 +19,7 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    join_base_path,
 )
 from ._retry import RetryTransport
 from .auth import AuthProvider
@@ -379,9 +380,16 @@ class HonuaGeocodingClient:
                 headers.update(extra_headers)
             if idempotency_key is not None:
                 headers["Idempotency-Key"] = idempotency_key
+        # Build a full URL the same way the core client does: prepend any
+        # base-URL path prefix (so sub-path hosting resolves) and override the
+        # raw path so httpx does not percent-decode already-encoded segments
+        # (e.g. a locator name containing a space or "/").
+        base_url = self._client.base_url
+        raw_path = join_base_path(base_url, path)
+        url = base_url.copy_with(raw_path=raw_path.encode("ascii"))
         request_kwargs: dict[str, Any] = {
             "method": method,
-            "url": path,
+            "url": url,
             "params": params,
             "json": json_body,
             "headers": headers,

--- a/packages/honua-sdk/honua_sdk/grpc/_proto_adapter.py
+++ b/packages/honua-sdk/honua_sdk/grpc/_proto_adapter.py
@@ -176,7 +176,36 @@ def _convert_attribute(attr: Any) -> Any:  # noqa: PLR0911 -- proto oneof dispat
     return None
 
 
-def _convert_geometry(geom: Any) -> dict[str, Any] | None:  # noqa: PLR0912, PLR0915 -- proto oneof + per-shape conversion
+def _array_vertex(c: Any) -> list[Any]:
+    """Build an Esri-JSON coordinate array for a proto coordinate.
+
+    Esri JSON never uses ``null`` placeholders inside coordinate arrays. A
+    vertex is ``[x, y]``; ``[x, y, z]`` when only Z is present; ``[x, y, m]``
+    when only M is present; and ``[x, y, z, m]`` when both are present. The
+    geometry-level ``hasZ``/``hasM`` flags (set by :func:`_with_zm_flags`)
+    disambiguate a trailing third ordinate.
+    """
+    vertex: list[Any] = [c.x, c.y]
+    if c.HasField("z"):
+        vertex.append(c.z)
+        if c.HasField("m"):
+            vertex.append(c.m)
+    elif c.HasField("m"):
+        vertex.append(c.m)
+    return vertex
+
+
+def _with_zm_flags(result: dict[str, Any], *, has_z: bool, has_m: bool) -> dict[str, Any]:
+    """Annotate a geometry dict with ``hasZ``/``hasM`` so a consumer can tell
+    whether a third coordinate ordinate is Z or M."""
+    if has_z:
+        result["hasZ"] = True
+    if has_m:
+        result["hasM"] = True
+    return result
+
+
+def _convert_geometry(geom: Any) -> dict[str, Any] | None:  # noqa: PLR0912 -- proto oneof + per-shape conversion
     """Convert a proto Geometry to Esri JSON dict."""
     which = geom.WhichOneof("shape")
     if which == "point":
@@ -190,65 +219,49 @@ def _convert_geometry(geom: Any) -> dict[str, Any] | None:  # noqa: PLR0912, PLR
     elif which == "multi_point":
         mp = geom.multi_point
         points = []
+        has_z = has_m = False
         for p in mp.points:
-            coords: list[Any] = [p.x, p.y]
-            if p.HasField("z"):
-                coords.append(p.z)
-            elif p.HasField("m"):
-                coords.append(None)
-            if p.HasField("m"):
-                coords.append(p.m)
-            points.append(coords)
-        return {"points": points}
+            points.append(_array_vertex(p))
+            has_z = has_z or p.HasField("z")
+            has_m = has_m or p.HasField("m")
+        return _with_zm_flags({"points": points}, has_z=has_z, has_m=has_m)
     elif which == "polyline":
         pl = geom.polyline
         paths = []
+        has_z = has_m = False
         for path in pl.paths:
             coords_list: list[list[Any]] = []
             for c in path.coords:
-                coords = [c.x, c.y]
-                if c.HasField("z"):
-                    coords.append(c.z)
-                elif c.HasField("m"):
-                    coords.append(None)
-                if c.HasField("m"):
-                    coords.append(c.m)
-                coords_list.append(coords)
+                coords_list.append(_array_vertex(c))
+                has_z = has_z or c.HasField("z")
+                has_m = has_m or c.HasField("m")
             paths.append(coords_list)
-        return {"paths": paths}
+        return _with_zm_flags({"paths": paths}, has_z=has_z, has_m=has_m)
     elif which == "polygon":
         pg = geom.polygon
         rings = []
+        has_z = has_m = False
         for ring in pg.rings:
             coords_list = []
             for c in ring.coords:
-                coords = [c.x, c.y]
-                if c.HasField("z"):
-                    coords.append(c.z)
-                elif c.HasField("m"):
-                    coords.append(None)
-                if c.HasField("m"):
-                    coords.append(c.m)
-                coords_list.append(coords)
+                coords_list.append(_array_vertex(c))
+                has_z = has_z or c.HasField("z")
+                has_m = has_m or c.HasField("m")
             rings.append(coords_list)
-        return {"rings": rings}
+        return _with_zm_flags({"rings": rings}, has_z=has_z, has_m=has_m)
     elif which == "multi_polygon":
         mpg = geom.multi_polygon
         rings = []
+        has_z = has_m = False
         for poly in mpg.polygons:
             for ring in poly.rings:
                 coords_list = []
                 for c in ring.coords:
-                    coords = [c.x, c.y]
-                    if c.HasField("z"):
-                        coords.append(c.z)
-                    elif c.HasField("m"):
-                        coords.append(None)
-                    if c.HasField("m"):
-                        coords.append(c.m)
-                    coords_list.append(coords)
+                    coords_list.append(_array_vertex(c))
+                    has_z = has_z or c.HasField("z")
+                    has_m = has_m or c.HasField("m")
                 rings.append(coords_list)
-        return {"rings": rings}
+        return _with_zm_flags({"rings": rings}, has_z=has_z, has_m=has_m)
     return None
 
 

--- a/packages/honua-sdk/pyproject.toml
+++ b/packages/honua-sdk/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.4"
 description = "Python SDK for Honua geospatial server -- feature queries, geocoding, and protocol clients"
 readme = "README.md"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 authors = [{ name = "Honua" }]
 keywords = ["geospatial", "mobile", "gis", "offline", "sync", "grpc", "honua"]

--- a/scripts/_conformance.py
+++ b/scripts/_conformance.py
@@ -508,24 +508,49 @@ def _run_temporal_query(
     """Temporal-filtered feature query contract (honua-server#1166).
 
     The seeded layer carries temporal attributes (``created_at``/``event_date``).
-    A FeatureServer ``time``-bounded query must return a feature envelope. Until
-    the tracked temporal support lands, this case is a known gap.
+    A FeatureServer ``time``-bounded query must actually *constrain* results by
+    the window — not merely accept and ignore an unknown ``time`` param. We
+    therefore compare three queries: unfiltered, an in-range window, and a
+    disjoint (pre-seed) window. A server that ignores ``time`` returns the same
+    set for the disjoint window as for the unfiltered query, which fails the
+    probe instead of producing a false green PASS. Until the tracked temporal
+    support lands, this case is a known gap.
     """
-    response = client._request_json(
-        "GET",
-        f"/rest/services/{target.service_id}/FeatureServer/{target.layer_id}/query",
-        params={
+    path = f"/rest/services/{target.service_id}/FeatureServer/{target.layer_id}/query"
+
+    def _query(time_window: str | None) -> list[Any]:
+        params: dict[str, Any] = {
             "f": "json",
             "where": "1=1",
             "outFields": "*",
             "returnGeometry": "false",
-            # Epoch-ms window spanning the seeded 2024 created_at range.
-            "time": "1704067200000,1735689600000",
-        },
+        }
+        if time_window is not None:
+            params["time"] = time_window
+        response = client._request_json("GET", path, params=params)
+        _require(isinstance(response, Mapping), "temporal query response is not an object")
+        return _as_list(response.get("features"), "temporal query response missing features[]")
+
+    unfiltered = _query(None)
+    # Epoch-ms window spanning the seeded 2024 created_at range.
+    in_window = _query("1704067200000,1735689600000")
+    # Disjoint window in 1970, strictly before any seeded 2024 data: a server
+    # that honors ``time`` must return fewer features here than the unfiltered
+    # baseline; one that ignores it returns the full set.
+    disjoint = _query("0,1")
+
+    _require(len(unfiltered) > 0, "baseline (unfiltered) query returned no features")
+    _require(
+        len(disjoint) < len(unfiltered),
+        "time filter not honored: a disjoint pre-seed window returned the same "
+        f"feature count ({len(disjoint)}) as the unfiltered query "
+        f"({len(unfiltered)})",
     )
-    _require(isinstance(response, Mapping), "temporal query response is not an object")
-    features = _as_list(response.get("features"), "temporal query response missing features[]")
-    return {"feature_count": len(features)}
+    return {
+        "feature_count": len(in_window),
+        "unfiltered_count": len(unfiltered),
+        "disjoint_count": len(disjoint),
+    }
 
 
 def _run_replica_surface(
@@ -540,7 +565,16 @@ def _run_replica_surface(
     metadata = client.feature_server(target.service_id).metadata()
     _require(isinstance(metadata, Mapping), "feature server metadata is not an object")
     caps = str(metadata.get("capabilities", ""))
-    sync_enabled = bool(metadata.get("syncEnabled")) or "Sync" in caps or "Create" in caps
+    # Gate strictly on sync/replica signals. The old ``"Create" in caps``
+    # disjunct matched the unrelated ``Create`` editing capability that *any*
+    # editable FeatureServer advertises, so this probe reported replica/sync
+    # support present when it was absent.
+    caps_tokens = {token.strip().lower() for token in caps.split(",")}
+    sync_enabled = (
+        bool(metadata.get("syncEnabled"))
+        or "sync" in caps_tokens
+        or "createreplica" in caps.lower()
+    )
     _require(
         sync_enabled,
         "FeatureServer does not advertise a replica/sync capability",

--- a/tests/grpc_sdk/test_proto_adapter.py
+++ b/tests/grpc_sdk/test_proto_adapter.py
@@ -451,7 +451,9 @@ class TestConvertGeometry:
 
         result = adapter._convert_geometry(geom)
 
-        assert result == {"points": [[1.0, 2.0, None, 9.0]]}
+        # M-only vertices are written [x, y, m] (no null Z placeholder) with a
+        # geometry-level hasM flag so a third ordinate reads as M, not Z.
+        assert result == {"points": [[1.0, 2.0, 9.0]], "hasM": True}
 
     def test_polyline(self, proto_polyline_feature: pb2.Feature) -> None:
         result = adapter._convert_geometry(proto_polyline_feature.geometry)
@@ -472,7 +474,10 @@ class TestConvertGeometry:
         result = adapter._convert_geometry(geom)
 
         assert result is not None
-        assert result["paths"][0][0] == [0.0, 0.0, None, 3.0]
+        # M-only vertex: [x, y, m] with hasM at the geometry level (no null Z).
+        assert result["paths"][0][0] == [0.0, 0.0, 3.0]
+        assert result["hasM"] is True
+        assert "hasZ" not in result
 
     def test_polygon(self, proto_polygon_feature: pb2.Feature) -> None:
         result = adapter._convert_geometry(proto_polygon_feature.geometry)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -957,3 +957,26 @@ def test_dispatcher_accepts_filter_for_cql_protocols(protocol: str) -> None:
             limit=1,
         )
     assert result.protocol == protocol
+
+
+@pytest.mark.parametrize("protocol", ["stac", "odata"])
+def test_shared_query_limit_zero_returns_empty_without_crash(protocol: str) -> None:
+    """limit=0 must short-circuit to an empty result for STAC/OData just like it
+    already does for FeatureServer/OGC, rather than raising UnboundLocalError.
+
+    The STAC/OData pagination generators return zero pages for limit=0, so the
+    ``last_page`` reference in ``_collect_query_pages`` must be initialized
+    before the loop or the signal-extraction call crashes.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(
+            f"limit=0 should issue no requests; got {request.url}"
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        result = client.query("collection-1", protocol=protocol, limit=0)
+
+    assert result.protocol == protocol
+    assert len(result.features) == 0

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -423,3 +423,28 @@ def test_reverse_geocode_address_without_location_keeps_address() -> None:
 
     assert result is not None
     assert result.address == "123 Main St"
+
+
+def test_geocode_request_preserves_subpath_mount_and_encoded_locator() -> None:
+    """A sub-path base URL (reverse-proxy mount) and a percent-encoded locator
+    segment must both survive request-URL construction, matching the core
+    client's ``join_base_path``/``copy_with`` behavior rather than letting the
+    absolute path drop the mount or re-decode the segment."""
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["raw_path"] = request.url.raw_path.decode("ascii").split("?")[0]
+        return httpx.Response(200, json={"candidates": []})
+
+    transport = httpx.MockTransport(handler)
+    client = HonuaGeocodingClient(
+        "https://host/honua/",
+        locator_name="World Locator/v2",
+        client=httpx.Client(base_url="https://host/honua/", transport=transport),
+    )
+    with client:
+        client.forward_geocode("123 Main St")
+
+    assert seen["raw_path"] == (
+        "/honua/rest/services/World%20Locator%2Fv2/GeocodeServer/findAddressCandidates"
+    )

--- a/tests/test_wheel_contents.py
+++ b/tests/test_wheel_contents.py
@@ -91,3 +91,35 @@ def test_wheel_ships_expected_contents(package: str) -> None:
         f"{package} wheel is missing expected contents: {missing}\n"
         f"wheel members:\n" + "\n".join(sorted(members))
     )
+
+
+@pytest.mark.parametrize("package", sorted(EXPECTED_CONTENTS))
+def test_wheel_ships_license_text(package: str) -> None:
+    """Each wheel must carry the actual Apache-2.0 license text, not just the
+    ``License`` metadata field.
+
+    Hatchling only auto-includes license files found in the package's build
+    root, so without a ``LICENSE`` in the package directory (and a matching
+    ``license-files`` declaration) the wheel advertises a license it does not
+    ship — a distribution-compliance gap that ``twine check`` does not catch.
+    """
+    package_dir = PACKAGES_DIR / package
+    assert package_dir.is_dir(), f"missing package source dir: {package_dir}"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wheel_path = _build_wheel(package_dir, Path(tmp))
+        with zipfile.ZipFile(wheel_path) as archive:
+            members = archive.namelist()
+
+    # PEP 639 places license files under ``*.dist-info/licenses/``; older
+    # hatchling layouts put them directly under ``*.dist-info/``. Accept either.
+    license_members = [
+        m
+        for m in members
+        if ".dist-info/" in m
+        and "LICENSE" in m.rsplit("/", 1)[-1].upper()
+    ]
+    assert license_members, (
+        f"{package} wheel ships no LICENSE file under *.dist-info/\n"
+        f"wheel members:\n" + "\n".join(sorted(members))
+    )


### PR DESCRIPTION
Addresses the confirmed S1/S2 release-audit findings for this repo. One coarse PR by theme; no merge intended (continuous merger handles that).

## Correctness / reliability (honua-sdk runtime)

- **Geocoding bypassed `join_base_path`; broke sub-path hosting** — `geocoding.py:394`, `async_geocoding.py:356`. The geocoding `_request` passed `url=path` straight to httpx instead of building the URL the way the core client does. Now uses `join_base_path` + `copy_with(raw_path=...)`, preserving a sub-path base URL (reverse-proxy mount) and sending already percent-encoded locator segments verbatim.
- **`_collect_query_pages` `UnboundLocalError` for STAC/OData when `limit=0`** — `client.py:954/973`, `async_client.py:953/972`. `last_page` was only initialized in the OGC branch; STAC/OData read it after a loop that yields zero pages for `limit=0`, crashing while FeatureServer/OGC returned empty. `last_page` is now initialized before both loops.
- **gRPC→Esri-JSON emitted invalid null Z placeholder for M-only vertices** — `grpc/_proto_adapter.py:196`. Array shapes (multipoint/polyline/polygon/multipolygon) produced `[x, y, null, m]`. They now produce `[x, y, m]` with geometry-level `hasM` (and `[x, y, z, m]` + `hasZ`/`hasM` when both are present). Esri JSON never uses null inside coordinate arrays.

## Test integrity (live conformance probes)

- **Replica/sync probe false-passed on any editable FeatureServer** — `scripts/_conformance.py:543`. Dropped the `"Create" in caps` disjunct; gate on `syncEnabled` / `Sync` / `createReplica` only.
- **Temporal probe never verified the time filter constrained results** — `scripts/_conformance.py:528`. Now compares unfiltered vs in-range vs a disjoint pre-seed window so a server that ignores `time` fails instead of producing a false green PASS.

## Licensing

- **honua-sdk and honua-admin wheels shipped without the Apache-2.0 LICENSE text** — `packages/honua-sdk/pyproject.toml:10`, same for honua-admin. Added `LICENSE` to each package dir and `license-files = ["LICENSE"]` so the text ships in the wheel `*.dist-info/`.

## Verification

- Full suite: `pytest tests/` -> 1135 passed, 1 skipped.
- `ruff check .` clean; `mypy` clean (61 files).
- `scripts/gen_sync.py --check` clean (sync `client.py` regenerated from the async source-of-truth edit).
- New regression tests: geocoding sub-path/encoded-locator URL, `limit=0` STAC/OData query, M-only gRPC geometry conversion, and wheel license text.