### PR TITLE
fix: correct GP interop CRS/ring-winding/job-id handling (#137)

### DIFF
--- a/packages/honua-sdk/honua_sdk/geopandas.py
+++ b/packages/honua-sdk/honua_sdk/geopandas.py
@@ -7,6 +7,7 @@ This module requires the optional ``geopandas`` extra::
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Mapping
 from datetime import date, datetime
@@ -50,6 +51,11 @@ _WKID_TO_EPSG: dict[int, str] = {
     4326: "EPSG:4326",
 }
 _GEOJSON_DEFAULT_CRS = "EPSG:4326"
+#: EPSG code for WGS84 longitude/latitude (the GeoJSON default CRS).
+_WGS84_EPSG = 4326
+#: EPSG code for Web Mercator, and the legacy Esri ``wkid`` for the same CRS.
+_WEB_MERCATOR_EPSG = 3857
+_WEB_MERCATOR_ESRI_WKID = 102100
 
 
 def _crs_from_spatial_reference(
@@ -121,6 +127,23 @@ def _normalize_geojson_crs_identifier(identifier: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _coord_is_missing(value: Any) -> bool:
+    """Whether an Esri point coordinate is absent/NaN and yields no geometry.
+
+    Esri encodes "no geometry" points as ``None`` or ``NaN`` coordinates.
+    Building ``Point(nan, nan)`` would produce an invalid geometry that leaks
+    NaN coordinates downstream, so such coordinates are treated as missing.
+    """
+    if value is None:
+        return True
+    if isinstance(value, float) and math.isnan(value):
+        return True
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
 def _esri_geometry_to_shapely(geom: dict[str, Any] | None) -> Any:  # noqa: PLR0911, PLR0912 -- geometry type dispatch
     """Convert a single Esri JSON geometry dict to a Shapely geometry.
 
@@ -134,7 +157,7 @@ def _esri_geometry_to_shapely(geom: dict[str, Any] | None) -> Any:  # noqa: PLR0
         x = geom["x"]
         y = geom["y"]
         # Esri represents null-island-style "no geometry" as NaN coords.
-        if x is None or y is None:
+        if _coord_is_missing(x) or _coord_is_missing(y):
             return None
         return Point(x, y)
 
@@ -233,6 +256,7 @@ def _shapely_to_esri_geometry(geom: Any) -> dict[str, Any] | None:  # noqa: PLR0
     from shapely.geometry import (
         Polygon as _Poly,
     )
+    from shapely.geometry.polygon import orient as _orient
 
     if isinstance(geom, _Pt):
         return {"x": geom.x, "y": geom.y}
@@ -247,18 +271,22 @@ def _shapely_to_esri_geometry(geom: Any) -> dict[str, Any] | None:  # noqa: PLR0
         return {"paths": [[list(c) for c in line.coords] for line in geom.geoms]}
 
     if isinstance(geom, _Poly):
+        # Esri convention: exterior rings are clockwise, holes counter-clockwise.
+        # ``orient(..., sign=-1.0)`` yields a CW exterior and CCW interiors.
+        oriented = _orient(geom, sign=-1.0)
         rings: list[list[list[float]]] = []
         # Exterior ring
-        rings.append([list(c) for c in geom.exterior.coords])
-        for interior in geom.interiors:
+        rings.append([list(c) for c in oriented.exterior.coords])
+        for interior in oriented.interiors:
             rings.append([list(c) for c in interior.coords])
         return {"rings": rings}
 
     if isinstance(geom, _MPoly):
         rings_all: list[list[list[float]]] = []
         for poly in geom.geoms:
-            rings_all.append([list(c) for c in poly.exterior.coords])
-            for interior in poly.interiors:
+            oriented = _orient(poly, sign=-1.0)
+            rings_all.append([list(c) for c in oriented.exterior.coords])
+            for interior in oriented.interiors:
                 rings_all.append([list(c) for c in interior.coords])
         return {"rings": rings_all}
 
@@ -495,6 +523,39 @@ def _geojson_feature_collection_to_geodataframe(
     return gdf
 
 
+def _reproject_to_wgs84(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Reproject *gdf* to ``EPSG:4326`` for GeoJSON export.
+
+    GeoJSON (RFC 7946) is defined in WGS84 longitude/latitude. A GeoDataFrame
+    in a projected CRS would otherwise be serialized verbatim and silently
+    mislabelled as ``EPSG:4326``, corrupting coordinates. When the frame
+    already uses ``EPSG:4326`` (or carries no CRS, where reprojection is
+    impossible) it is returned unchanged.
+    """
+    crs = gdf.crs
+    if crs is None or crs.to_epsg() == _WGS84_EPSG:
+        return gdf
+    return gdf.to_crs(epsg=_WGS84_EPSG)
+
+
+def _esri_spatial_reference_from_crs(crs: Any) -> dict[str, int] | None:
+    """Build an Esri ``spatialReference`` dict from a GeoDataFrame CRS.
+
+    Returns ``None`` when the CRS is absent or has no resolvable EPSG code, so
+    callers omit the key rather than guessing. Web Mercator is emitted with the
+    Esri ``wkid`` (``102100``) alongside ``latestWkid`` (``3857``) for maximum
+    interoperability with Esri clients.
+    """
+    if crs is None:
+        return None
+    epsg = crs.to_epsg()
+    if epsg is None:
+        return None
+    if epsg == _WEB_MERCATOR_EPSG:
+        return {"wkid": _WEB_MERCATOR_ESRI_WKID, "latestWkid": _WEB_MERCATOR_EPSG}
+    return {"wkid": epsg}
+
+
 def geodataframe_to_features(
     gdf: gpd.GeoDataFrame,
 ) -> list[dict[str, Any]]:
@@ -514,10 +575,13 @@ def geodataframe_to_features(
     list[dict]
         A list of ``{"attributes": {...}, "geometry": {...}}`` dicts
         ready for the ``adds`` or ``updates`` parameter of
-        ``apply_edits``.
+        ``apply_edits``. The frame's CRS is preserved by stamping an explicit
+        Esri ``spatialReference`` onto each emitted geometry, so a non-WGS84
+        frame is no longer silently mislabelled as ``EPSG:4326``.
     """
     _ensure_deps()
 
+    spatial_reference = _esri_spatial_reference_from_crs(gdf.crs)
     attr_columns = [col for col in gdf.columns if col != gdf.geometry.name]
 
     features: list[dict[str, Any]] = []
@@ -528,6 +592,8 @@ def geodataframe_to_features(
         esri_geom = _shapely_to_esri_geometry(geom_obj)
         feat: dict[str, Any] = {"attributes": attrs}
         if esri_geom is not None:
+            if spatial_reference is not None:
+                esri_geom["spatialReference"] = spatial_reference
             feat["geometry"] = esri_geom
         features.append(feat)
 
@@ -555,11 +621,14 @@ def geodataframe_to_geojson(
     -------
     dict
         A GeoJSON ``FeatureCollection`` mapping with a ``features`` list.
+        Geometries are reprojected to ``EPSG:4326`` (the GeoJSON default CRS)
+        when the frame carries a non-WGS84 CRS.
     """
     _ensure_deps()
 
     from shapely.geometry import mapping as _mapping
 
+    gdf = _reproject_to_wgs84(gdf)
     attr_columns = [col for col in gdf.columns if col != gdf.geometry.name]
 
     features: list[dict[str, Any]] = []

--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -40,11 +40,13 @@ reuse the bound :class:`~honua_sdk.client.HonuaClient` /
 
 from __future__ import annotations
 
+import contextlib
 import json
 import time
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard, cast
+from urllib.parse import unquote, urlsplit
 
 from ._http import _encode_path_segment
 from .errors import HonuaError
@@ -277,6 +279,41 @@ def _async_prefer_header(respond_async: bool) -> dict[str, str] | None:
     return {"Prefer": "respond-async"} if respond_async else None
 
 
+def _job_id_from_location(location: str | None) -> str | None:
+    """Extract a job id from an OGC Processes ``Location`` header.
+
+    The execution response points the ``Location`` header at the created job
+    (``.../ogc/processes/jobs/{jobId}``); the job id is its last path segment.
+    Returns ``None`` when the header is absent or carries no usable segment.
+    """
+    if not location:
+        return None
+    path = urlsplit(location).path.rstrip("/")
+    if not path:
+        return None
+    segment = path.rsplit("/", 1)[-1]
+    return unquote(segment) or None
+
+
+def _job_from_response(response: Any) -> GeoprocessingJob:
+    """Build a :class:`GeoprocessingJob` from an execution HTTP response.
+
+    The OGC ``StatusInfo`` body is the primary source for the job id, but a
+    ``201 Created`` with an empty body (or a synchronous execution that returns
+    no ``jobID``) still identifies the job via the ``Location`` header. Fall
+    back to parsing that header so the job stays pollable/dismissable.
+    """
+    body = response.json() if response.content else {}
+    if not isinstance(body, Mapping):
+        body = {}
+    job = GeoprocessingJob.from_status_info(body)
+    if not job.job_id:
+        location_id = _job_id_from_location(response.headers.get("Location"))
+        if location_id:
+            job = replace(job, job_id=location_id)
+    return job
+
+
 def _processes_path(root: str) -> str:
     return f"{root}/processes"
 
@@ -339,10 +376,7 @@ class HonuaGeoprocessing:
             json_body=payload,
             headers=_async_prefer_header(respond_async),
         )
-        body = response.json() if response.content else {}
-        if not isinstance(body, Mapping):
-            body = {}
-        return GeoprocessingJob.from_status_info(body)
+        return _job_from_response(response)
 
     def submit_raw(
         self,
@@ -363,10 +397,7 @@ class HonuaGeoprocessing:
             json_body=dict(body),
             headers=_async_prefer_header(respond_async),
         )
-        result = response.json() if response.content else {}
-        if not isinstance(result, Mapping):
-            result = {}
-        return GeoprocessingJob.from_status_info(result)
+        return _job_from_response(response)
 
     # -- single-geometry primitive ----------------------------------------
 
@@ -461,6 +492,7 @@ class HonuaGeoprocessing:
         """
         from .geopandas import geodataframe_to_geojson, ogc_features_to_geodataframe
 
+        source_crs = gdf.crs
         layer = LayerReference.from_geojson(geodataframe_to_geojson(gdf))
         result = self.execute(
             process_id,
@@ -469,7 +501,12 @@ class HonuaGeoprocessing:
             poll_interval=poll_interval,
             timeout=timeout,
         )
-        return ogc_features_to_geodataframe(_feature_collection_from_results(result))
+        out = ogc_features_to_geodataframe(_feature_collection_from_results(result))
+        # The result rides back as GeoJSON/WGS84; reapply the caller's source CRS
+        # so a projected-in / projected-out round-trip preserves coordinates.
+        if source_crs is not None and out.crs is not None:
+            out = out.to_crs(source_crs)
+        return out
 
     # -- canonical multi-step plan ----------------------------------------
 
@@ -517,6 +554,13 @@ class HonuaGeoprocessing:
         """Dismiss (cancel/forget) a job."""
         self.client._request_json("DELETE", _job_path(self.root, job_id))
 
+    def _safe_dismiss(self, job_id: str) -> None:
+        """Best-effort :meth:`dismiss`; never raises (cleanup-only path)."""
+        if not job_id:
+            return
+        with contextlib.suppress(Exception):
+            self.dismiss(job_id)
+
     def wait(
         self,
         job: GeoprocessingJob | str,
@@ -524,12 +568,17 @@ class HonuaGeoprocessing:
         poll_interval: float = 0.5,
         timeout: float | None = 120.0,
     ) -> GeoprocessingJob:
-        """Poll a job until it reaches a terminal status (or ``timeout``)."""
+        """Poll a job until it reaches a terminal status (or ``timeout``).
+
+        On timeout the pending server job is best-effort dismissed before the
+        :class:`TimeoutError` propagates so it is not left orphaned.
+        """
         job_id = job.job_id if isinstance(job, GeoprocessingJob) else str(job)
         current = job if isinstance(job, GeoprocessingJob) else self.job(job_id)
         deadline = None if timeout is None else time.monotonic() + timeout
         while not current.is_terminal:
             if deadline is not None and time.monotonic() >= deadline:
+                self._safe_dismiss(job_id)
                 raise TimeoutError(
                     f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
                     f"(last status: {current.status!r})."
@@ -577,10 +626,7 @@ class AsyncHonuaGeoprocessing:
             json_body=payload,
             headers=_async_prefer_header(respond_async),
         )
-        body = response.json() if response.content else {}
-        if not isinstance(body, Mapping):
-            body = {}
-        return GeoprocessingJob.from_status_info(body)
+        return _job_from_response(response)
 
     async def submit_raw(
         self,
@@ -596,10 +642,7 @@ class AsyncHonuaGeoprocessing:
             json_body=dict(body),
             headers=_async_prefer_header(respond_async),
         )
-        result = response.json() if response.content else {}
-        if not isinstance(result, Mapping):
-            result = {}
-        return GeoprocessingJob.from_status_info(result)
+        return _job_from_response(response)
 
     # -- single-geometry primitive ----------------------------------------
 
@@ -672,6 +715,7 @@ class AsyncHonuaGeoprocessing:
         """Run a vector process over a GeoDataFrame and return a GeoDataFrame."""
         from .geopandas import geodataframe_to_geojson, ogc_features_to_geodataframe
 
+        source_crs = gdf.crs
         layer = LayerReference.from_geojson(geodataframe_to_geojson(gdf))
         result = await self.execute(
             process_id,
@@ -680,7 +724,12 @@ class AsyncHonuaGeoprocessing:
             poll_interval=poll_interval,
             timeout=timeout,
         )
-        return ogc_features_to_geodataframe(_feature_collection_from_results(result))
+        out = ogc_features_to_geodataframe(_feature_collection_from_results(result))
+        # The result rides back as GeoJSON/WGS84; reapply the caller's source CRS
+        # so a projected-in / projected-out round-trip preserves coordinates.
+        if source_crs is not None and out.crs is not None:
+            out = out.to_crs(source_crs)
+        return out
 
     # -- canonical multi-step plan ----------------------------------------
 
@@ -726,6 +775,13 @@ class AsyncHonuaGeoprocessing:
         """Dismiss (cancel/forget) a job."""
         await self.client._request_json("DELETE", _job_path(self.root, job_id))
 
+    async def _safe_dismiss(self, job_id: str) -> None:
+        """Best-effort :meth:`dismiss`; never raises (cleanup-only path)."""
+        if not job_id:
+            return
+        with contextlib.suppress(Exception):
+            await self.dismiss(job_id)
+
     async def wait(
         self,
         job: GeoprocessingJob | str,
@@ -733,18 +789,28 @@ class AsyncHonuaGeoprocessing:
         poll_interval: float = 0.5,
         timeout: float | None = 120.0,
     ) -> GeoprocessingJob:
-        """Poll a job until it reaches a terminal status (or ``timeout``)."""
+        """Poll a job until it reaches a terminal status (or ``timeout``).
+
+        On timeout — or when the awaiting task is cancelled — the pending server
+        job is best-effort dismissed before the exception propagates so it is
+        not left orphaned.
+        """
         import asyncio
 
         job_id = job.job_id if isinstance(job, GeoprocessingJob) else str(job)
         current = job if isinstance(job, GeoprocessingJob) else await self.job(job_id)
         deadline = None if timeout is None else time.monotonic() + timeout
-        while not current.is_terminal:
-            if deadline is not None and time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
-                    f"(last status: {current.status!r})."
-                )
-            await asyncio.sleep(max(0.0, poll_interval))
-            current = await self.job(job_id)
+        try:
+            while not current.is_terminal:
+                if deadline is not None and time.monotonic() >= deadline:
+                    await self._safe_dismiss(job_id)
+                    raise TimeoutError(
+                        f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
+                        f"(last status: {current.status!r})."
+                    )
+                await asyncio.sleep(max(0.0, poll_interval))
+                current = await self.job(job_id)
+        except asyncio.CancelledError:
+            await self._safe_dismiss(job_id)
+            raise
         return current

--- a/tests/test_geopandas.py
+++ b/tests/test_geopandas.py
@@ -15,6 +15,7 @@ from shapely.geometry import LineString, MultiPoint, Point, Polygon
 from honua_sdk.geopandas import (
     features_to_geodataframe,
     geodataframe_to_features,
+    geodataframe_to_geojson,
     ogc_features_to_geodataframe,
     stac_items_to_geodataframe,
 )
@@ -461,3 +462,151 @@ class TestRoundTrip:
         assert type(attrs["count"]) is int
         assert attrs["missing"] is None
         assert attrs["observed_at"] == "2026-04-27T12:00:00+00:00"
+
+
+# ---------------------------------------------------------------------------
+# CRS reprojection on export (issue #137)
+# ---------------------------------------------------------------------------
+
+
+class TestExportReprojection:
+    def test_geojson_export_reprojects_non_wgs84_to_4326(self) -> None:
+        # A web-mercator frame must be reprojected to lon/lat for GeoJSON, not
+        # emitted verbatim and mislabelled as EPSG:4326.
+        src = gpd.GeoDataFrame(
+            {"id": [1]}, geometry=[Point(-157.8583, 21.3069)], crs="EPSG:4326"
+        )
+        projected = src.to_crs("EPSG:3857")
+
+        fc = geodataframe_to_geojson(projected)
+
+        lon, lat = fc["features"][0]["geometry"]["coordinates"]
+        assert lon == pytest.approx(-157.8583, abs=1e-4)
+        assert lat == pytest.approx(21.3069, abs=1e-4)
+
+    def test_geojson_export_without_crs_passes_through(self) -> None:
+        gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[Point(100.0, 200.0)])
+
+        fc = geodataframe_to_geojson(gdf)
+
+        lon, lat = fc["features"][0]["geometry"]["coordinates"]
+        assert (lon, lat) == (100.0, 200.0)
+
+    def test_geojson_export_wgs84_unchanged(self) -> None:
+        gdf = gpd.GeoDataFrame(
+            {"id": [1]}, geometry=[Point(-157.8583, 21.3069)], crs="EPSG:4326"
+        )
+
+        fc = geodataframe_to_geojson(gdf)
+
+        lon, lat = fc["features"][0]["geometry"]["coordinates"]
+        assert lon == pytest.approx(-157.8583)
+        assert lat == pytest.approx(21.3069)
+
+    def test_esri_features_export_stamps_spatial_reference(self) -> None:
+        # Esri JSON carries its own spatialReference, so the non-WGS84 frame is
+        # preserved verbatim with an explicit CRS rather than reprojected.
+        src = gpd.GeoDataFrame(
+            {"id": [1]}, geometry=[Point(-157.8583, 21.3069)], crs="EPSG:4326"
+        )
+        projected = src.to_crs("EPSG:3857")
+        projected_x, projected_y = (
+            projected.geometry.iloc[0].x,
+            projected.geometry.iloc[0].y,
+        )
+
+        features = geodataframe_to_features(projected)
+
+        geom = features[0]["geometry"]
+        assert geom["x"] == pytest.approx(projected_x)
+        assert geom["y"] == pytest.approx(projected_y)
+        assert geom["spatialReference"] == {"wkid": 102100, "latestWkid": 3857}
+
+    def test_esri_features_export_stamps_wgs84_spatial_reference(self) -> None:
+        gdf = gpd.GeoDataFrame(
+            {"id": [1]}, geometry=[Point(-157.8583, 21.3069)], crs="EPSG:4326"
+        )
+
+        features = geodataframe_to_features(gdf)
+
+        assert features[0]["geometry"]["spatialReference"] == {"wkid": 4326}
+
+    def test_esri_features_export_without_crs_omits_spatial_reference(self) -> None:
+        gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[Point(1.0, 2.0)])
+
+        features = geodataframe_to_features(gdf)
+
+        assert "spatialReference" not in features[0]["geometry"]
+
+
+# ---------------------------------------------------------------------------
+# Esri ring winding on export (issue #137)
+# ---------------------------------------------------------------------------
+
+
+class TestEsriRingWinding:
+    def test_features_export_orients_rings_esri_convention(self) -> None:
+        from shapely.geometry import LinearRing
+
+        # Shapely default: CCW exterior, CW hole. Esri requires the opposite:
+        # CW exterior, CCW holes.
+        exterior = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)]
+        hole = [(2.0, 2.0), (2.0, 4.0), (4.0, 4.0), (4.0, 2.0), (2.0, 2.0)]
+        poly = Polygon(exterior, [hole])
+        assert LinearRing(poly.exterior.coords).is_ccw  # sanity: CCW exterior
+
+        gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[poly], crs="EPSG:4326")
+        features = geodataframe_to_features(gdf)
+
+        rings = features[0]["geometry"]["rings"]
+        assert not LinearRing(rings[0]).is_ccw  # exterior is clockwise
+        assert LinearRing(rings[1]).is_ccw  # hole is counter-clockwise
+
+    def test_geojson_export_does_not_force_esri_winding(self) -> None:
+        # GeoJSON export must not borrow Esri orientation; shapely mapping keeps
+        # the polygon's own ring order.
+        from shapely.geometry import mapping
+
+        poly = Polygon([(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0)])
+        gdf = gpd.GeoDataFrame({"id": [1]}, geometry=[poly], crs="EPSG:4326")
+
+        fc = geodataframe_to_geojson(gdf)
+
+        assert fc["features"][0]["geometry"] == mapping(poly)
+
+
+# ---------------------------------------------------------------------------
+# NaN Esri point coordinates (issue #137)
+# ---------------------------------------------------------------------------
+
+
+class TestNaNPointCoords:
+    def test_nan_point_coords_become_none_geometry(self) -> None:
+        response: dict = {
+            "features": [
+                {
+                    "attributes": {"objectid": 1},
+                    "geometry": {"x": float("nan"), "y": float("nan")},
+                },
+                {
+                    "attributes": {"objectid": 2},
+                    "geometry": {"x": 1.0, "y": 2.0},
+                },
+            ],
+        }
+
+        gdf = features_to_geodataframe(response)
+
+        assert gdf.geometry.iloc[0] is None
+        assert isinstance(gdf.geometry.iloc[1], Point)
+
+    def test_single_nan_axis_becomes_none_geometry(self) -> None:
+        response: dict = {
+            "features": [
+                {"attributes": {"objectid": 1}, "geometry": {"x": 1.0, "y": float("nan")}},
+            ],
+        }
+
+        gdf = features_to_geodataframe(response)
+
+        assert gdf.geometry.iloc[0] is None

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -289,6 +289,72 @@ def test_wait_times_out() -> None:
             gp.wait("job-7", poll_interval=0.0, timeout=0.0)
 
 
+def test_wait_dismisses_job_on_timeout() -> None:
+    """A timed-out job is best-effort dismissed so it is not left orphaned."""
+    deleted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            deleted.append(request.url.path)
+            return httpx.Response(200, json=_status("job-to", "dismissed"))
+        return httpx.Response(200, json=_status("job-to", "running"))
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        with pytest.raises(TimeoutError):
+            gp.wait("job-to", poll_interval=0.0, timeout=0.0)
+
+    assert deleted == ["/ogc/processes/jobs/job-to"]
+
+
+def test_wait_timeout_swallows_dismiss_failure() -> None:
+    """Dismiss failure during timeout cleanup does not mask the TimeoutError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            return httpx.Response(500, json={"error": "boom"})
+        return httpx.Response(200, json=_status("job-tf", "running"))
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        with pytest.raises(TimeoutError):
+            gp.wait("job-tf", poll_interval=0.0, timeout=0.0)
+
+
+def test_submit_uses_location_header_when_body_lacks_job_id() -> None:
+    """A 201-empty-body response identifies the job via the Location header."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            headers={"Location": "http://example.test/ogc/processes/jobs/job-loc"},
+        )
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        job = client.geoprocessing().submit(
+            "geometry.buffer", LayerReference.from_geojson(FEATURE_COLLECTION)
+        )
+
+    assert job.job_id == "job-loc"
+
+
+def test_submit_raw_uses_location_header_when_body_lacks_job_id() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={"status": "accepted"},
+            headers={"Location": "http://example.test/ogc/processes/jobs/job%20raw"},
+        )
+
+    body = {"inputs": {"inputGeoJson": "{}"}}
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        job = client.geoprocessing().submit_raw("geometry.buffer", body)
+
+    # The id is URL-decoded from the trailing Location segment.
+    assert job.job_id == "job raw"
+    assert job.status == "accepted"
+
+
 def test_jobs_and_dismiss() -> None:
     seen: list[tuple[str, str]] = []
 
@@ -460,6 +526,41 @@ def test_execute_dataframe_raises_when_no_feature_collection_output() -> None:
             client.geoprocessing().execute_dataframe("geometry.area", gdf, poll_interval=0.0)
 
 
+def test_execute_dataframe_reprojects_input_and_reapplies_source_crs() -> None:
+    """A non-WGS84 frame is sent as WGS84 GeoJSON and returned in its source CRS."""
+    gpd = pytest.importorskip("geopandas")
+    from shapely.geometry import Point
+
+    captured: dict[str, Any] = {}
+    src = gpd.GeoDataFrame({"name": ["a"]}, geometry=[Point(-157.8583, 21.3069)], crs="EPSG:4326")
+    projected = src.to_crs("EPSG:3857")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST":
+            captured.update(json.loads(request.content))
+            return httpx.Response(201, json=_status("job-crs", "accepted"))
+        if path == "/ogc/processes/jobs/job-crs":
+            return httpx.Response(200, json=_status("job-crs", "successful"))
+        if path == "/ogc/processes/jobs/job-crs/results":
+            return httpx.Response(200, json={"outputFeatureLayer": FEATURE_COLLECTION})
+        raise AssertionError(f"unexpected {path}")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        out = client.geoprocessing().execute_dataframe(
+            "geometry.buffer", projected, poll_interval=0.0
+        )
+
+    # Input GeoJSON was reprojected to lon/lat before submission.
+    sent = json.loads(captured["inputs"]["inputGeoJson"])
+    lon, lat = sent["features"][0]["geometry"]["coordinates"]
+    assert lon == pytest.approx(-157.8583, abs=1e-4)
+    assert lat == pytest.approx(21.3069, abs=1e-4)
+    # The returned frame carries the caller's source CRS, not the GeoJSON 4326.
+    assert out.crs is not None
+    assert out.crs.to_epsg() == 3857
+
+
 # ---------------------------------------------------------------------------
 # Async parity
 # ---------------------------------------------------------------------------
@@ -548,3 +649,44 @@ async def test_async_error_path_and_lifecycle() -> None:
             await gp.execute(
                 "geometry.buffer", LayerReference.from_geojson(FEATURE_COLLECTION), poll_interval=0.0
             )
+
+
+@pytest.mark.anyio
+async def test_async_wait_dismisses_on_timeout() -> None:
+    deleted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            deleted.append(request.url.path)
+            return httpx.Response(200, json=_status("ajob-to", "dismissed"))
+        return httpx.Response(200, json=_status("ajob-to", "running"))
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        with pytest.raises(TimeoutError):
+            await gp.wait("ajob-to", poll_interval=0.0, timeout=0.0)
+
+    assert deleted == ["/ogc/processes/jobs/ajob-to"]
+
+
+@pytest.mark.anyio
+async def test_async_wait_dismisses_on_cancellation() -> None:
+    import asyncio
+
+    deleted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "DELETE":
+            deleted.append(request.url.path)
+            return httpx.Response(200, json=_status("ajob-c", "dismissed"))
+        return httpx.Response(200, json=_status("ajob-c", "running"))
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        task = asyncio.ensure_future(gp.wait("ajob-c", poll_interval=0.05, timeout=None))
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert deleted == ["/ogc/processes/jobs/ajob-c"]


### PR DESCRIPTION
Closes #137

## Summary

Correctness fixes for the Python SDK geoprocessing (GP) interop surface in `honua_sdk.geopandas` and `honua_sdk.geoprocessing`.

## Changes Made

- **CRS dropped on export (HIGH):** `geodataframe_to_geojson` now reprojects to `EPSG:4326` (RFC 7946) when the frame carries a non-WGS84 CRS; `geodataframe_to_features` stamps an explicit Esri `spatialReference` on each emitted geometry instead of silently mislabelling projected coordinates as 4326. `execute_dataframe` (sync + async) captures the caller's source CRS and reapplies it to the result frame so a projected-in / projected-out round-trip preserves coordinates.
- **Esri ring winding (HIGH):** the Shapely→Esri polygon/multipolygon path enforces Esri orientation (exterior clockwise, holes counter-clockwise) via `shapely.geometry.polygon.orient(..., sign=-1.0)` before serializing rings.
- **Job id (MED):** `submit_inputs` / `submit_raw` (sync + async) fall back to parsing the `Location` header for the job id when the response body lacks `jobID` (handles `201`-empty-body and synchronous execution).
- **Orphaned jobs (MED):** `wait()` best-effort `dismiss(job_id)` on `TimeoutError`, and the async `wait()` also dismisses on `asyncio.CancelledError`, before re-raising.
- **Esri Point NaN coords (MED):** point coordinates are guarded with `math.isnan` / `pd.isna` so `NaN`/`None` x or y yields a `None` geometry rather than `Point(nan, nan)`.
- Added/extended unit tests for each fix (sync and async).

## Breaking Changes

None. `geodataframe_to_features` now adds a `spatialReference` member to emitted geometries when the frame has a known CRS (previously absent); this is additive and valid Esri JSON.

## Testing

- `uv run pytest tests/test_geopandas.py tests/test_geoprocessing.py tests/test_geopandas_roundtrip_spatial.py tests/test_geopandas_coverage_uplift.py` — 107 passed.
- `ruff check` clean on all changed files.