### PR TITLE
fix(sdk): harden core client transport, async auth, and de-duplicate geocoding

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -3666,8 +3666,10 @@
     "honua_sdk": {
       "exports": [
         "ApplyEditsResult",
+        "AsyncAuthProvider",
         "AsyncHonuaClient",
         "AsyncHonuaGeocodingClient",
+        "AsyncRefreshableBearerTokenProvider",
         "AsyncSource",
         "AuthProvider",
         "BearerToken",
@@ -3757,6 +3759,19 @@
           "module": "honua_sdk.models",
           "qualname": "ApplyEditsResult",
           "signature": "(add_results: 'tuple[EditOperationResult, ...]' = (), update_results: 'tuple[EditOperationResult, ...]' = (), delete_results: 'tuple[EditOperationResult, ...]' = (), raw: 'Mapping[str, Any]' = <factory>) -> None"
+        },
+        "AsyncAuthProvider": {
+          "kind": "class",
+          "methods": {
+            "auth_headers_async": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'Mapping[str, str]'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "AsyncAuthProvider",
+          "signature": "(*args, **kwargs)"
         },
         "AsyncHonuaClient": {
           "kind": "class",
@@ -3958,6 +3973,34 @@
           "module": "honua_sdk.async_geocoding",
           "qualname": "AsyncHonuaGeocodingClient",
           "signature": "(base_url: 'str', *, locator_name: 'str' = 'World', timeout: 'float' = 30.0, api_key: 'str | None' = None, bearer_token: 'str | None' = None, auth_provider: 'AuthProvider | None' = None, client: 'httpx.AsyncClient | None' = None, transport: 'httpx.AsyncBaseTransport | None' = None, max_retries: 'int' = 3) -> 'None'"
+        },
+        "AsyncRefreshableBearerTokenProvider": {
+          "kind": "class",
+          "methods": {
+            "auth_headers_async": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'Mapping[str, str]'"
+            },
+            "get_token": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'BearerToken'"
+            },
+            "refresh": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'BearerToken'"
+            },
+            "revoke": {
+              "async": true,
+              "kind": "method",
+              "signature": "(self) -> 'None'"
+            }
+          },
+          "module": "honua_sdk.auth",
+          "qualname": "AsyncRefreshableBearerTokenProvider",
+          "signature": "(refresh: 'Callable[[], Awaitable[BearerToken | Mapping[str, Any] | str]]', *, initial_token: 'BearerToken | Mapping[str, Any] | str | None' = None, token_store: 'TokenStore | None' = None, refresh_window_seconds: 'int | float' = 60, revoke: 'Callable[[BearerToken], Awaitable[None]] | None' = None) -> 'None'"
         },
         "AsyncSource": {
           "kind": "class",
@@ -4541,7 +4584,7 @@
             }
           ],
           "kind": "class",
-          "module": "honua_sdk.geocoding",
+          "module": "honua_sdk._geocoding_models",
           "qualname": "GeocodeResult",
           "signature": "(address: 'str', latitude: 'float', longitude: 'float', score: 'float', attributes: 'dict[str, str | None]') -> None"
         },
@@ -4561,7 +4604,7 @@
             }
           ],
           "kind": "class",
-          "module": "honua_sdk.geocoding",
+          "module": "honua_sdk._geocoding_models",
           "qualname": "GeocodeSuggestion",
           "signature": "(text: 'str', magic_key: 'str', is_collection: 'bool') -> None"
         },
@@ -5182,7 +5225,7 @@
             }
           ],
           "kind": "class",
-          "module": "honua_sdk.geocoding",
+          "module": "honua_sdk._geocoding_models",
           "qualname": "ReverseGeocodeResult",
           "signature": "(address: 'str', latitude: 'float', longitude: 'float', attributes: 'dict[str, str | None]') -> None"
         },

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -32,9 +32,16 @@ try:
 except Exception:  # pragma: no cover -- editable / not-installed fallback
     __version__ = "0.0.0.dev0"
 
+from ._geocoding_models import (
+    GeocodeResult,
+    GeocodeSuggestion,
+    ReverseGeocodeResult,
+)
 from .async_client import AsyncHonuaClient
 from .async_geocoding import AsyncHonuaGeocodingClient
 from .auth import (
+    AsyncAuthProvider,
+    AsyncRefreshableBearerTokenProvider,
     AuthProvider,
     BearerToken,
     CallableAuthProvider,
@@ -54,12 +61,7 @@ from .errors import (
     HonuaTimeoutError,
     HonuaTransportError,
 )
-from .geocoding import (
-    GeocodeResult,
-    GeocodeSuggestion,
-    HonuaGeocodingClient,
-    ReverseGeocodeResult,
-)
+from .geocoding import HonuaGeocodingClient
 from .models import (
     CAPABILITIES,
     DEFAULT_CAPABILITIES,
@@ -145,6 +147,8 @@ __all__ = [  # noqa: RUF022 -- grouped by category for human discoverability
     "default_capabilities",
     # Auth
     "AuthProvider",
+    "AsyncAuthProvider",
+    "AsyncRefreshableBearerTokenProvider",
     "BearerToken",
     "CallableAuthProvider",
     "InMemoryTokenStore",

--- a/packages/honua-sdk/honua_sdk/_async_retry.py
+++ b/packages/honua-sdk/honua_sdk/_async_retry.py
@@ -120,15 +120,11 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
         override = request.extensions.get("honua_max_retries")
         retries_remaining = override if isinstance(override, int) else self._max_retries
         attempt = 0
-        response: httpx.Response | None = None
-        last_exc: Exception | None = None
 
         while True:
             try:
                 response = await self._wrapped.handle_async_request(request)
-                last_exc = None
-            except _RETRIABLE_TRANSPORT_EXCEPTIONS as exc:
-                last_exc = exc
+            except _RETRIABLE_TRANSPORT_EXCEPTIONS:
                 if retries_remaining <= 0:
                     raise
                 delay = self._compute_backoff(attempt)
@@ -152,12 +148,6 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
 
             retries_remaining -= 1
             attempt += 1
-
-        # Unreachable: the loop only exits via ``return`` or by re-raising.
-        if last_exc is not None:  # pragma: no cover
-            raise last_exc
-        assert response is not None  # noqa: S101 -- type narrowing for unreachable branch  # pragma: no cover
-        return response
 
     def _compute_delay(self, response: httpx.Response, attempt: int) -> float:
         return compute_delay(

--- a/packages/honua-sdk/honua_sdk/_geocoding_models.py
+++ b/packages/honua-sdk/honua_sdk/_geocoding_models.py
@@ -1,0 +1,58 @@
+"""Shared data models for the sync/async GeocodeServer clients.
+
+These types are defined once here and imported by both the asynchronous
+source-of-truth (:mod:`honua_sdk.async_geocoding`) and its generated
+synchronous mirror (:mod:`honua_sdk.geocoding`), so the codegen transform in
+``scripts/gen_sync.py`` only has to mirror the client class — the models do
+not differ between the two transports.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class GeocodeResult:
+    address: str
+    latitude: float
+    longitude: float
+    score: float
+    attributes: dict[str, str | None]
+
+
+@dataclass
+class ReverseGeocodeResult:
+    address: str
+    latitude: float
+    longitude: float
+    attributes: dict[str, str | None]
+
+
+@dataclass
+class GeocodeSuggestion:
+    text: str
+    magic_key: str
+    is_collection: bool
+
+
+def _extract_location_xy(location: Any) -> tuple[float, float] | None:
+    """Return ``(longitude, latitude)`` from a GeocodeServer ``location``.
+
+    Returns ``None`` when the location is missing, not a mapping, or lacks a
+    usable ``x``/``y`` pair. Defaulting absent coordinates to ``0`` would
+    silently emit a valid-looking ``(0, 0)`` "null island" result that masks
+    a geocode miss — so a missing location is treated as "no result" instead.
+    """
+    if not isinstance(location, Mapping):
+        return None
+    raw_x = location.get("x")
+    raw_y = location.get("y")
+    if raw_x is None or raw_y is None:
+        return None
+    try:
+        return float(raw_x), float(raw_y)
+    except (TypeError, ValueError):
+        return None

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import quote
 
 import httpx
+from anyio import to_thread
 
 from .auth import SENSITIVE_AUTH_HEADER_NAMES, AuthProvider, normalize_auth_headers
 from .errors import (
@@ -49,6 +50,29 @@ def join_base_path(base_url: httpx.URL, path: str) -> str:
     if not path.startswith("/"):
         path = "/" + path
     return prefix + path
+
+
+def encode_request_path(raw_path: str) -> bytes:
+    """Encode a joined request path to bytes for ``URL.copy_with(raw_path=…)``.
+
+    The core clients override the raw path on the base URL so httpx does not
+    percent-decode already-encoded segments — which requires an ASCII byte
+    string. A server-controlled pagination ``next``-link path may however carry
+    non-ASCII characters; ``str.encode("ascii")`` would raise an unwrapped
+    :class:`UnicodeEncodeError` and crash the pagination walk.
+
+    Encode the common all-ASCII case directly, and otherwise percent-encode
+    **only** the non-ASCII characters (as UTF-8), leaving any existing
+    percent-encoding (and reserved delimiters) untouched so already-encoded
+    segments are not double-encoded.
+    """
+    try:
+        return raw_path.encode("ascii")
+    except UnicodeEncodeError:
+        encoded = "".join(
+            char if ord(char) < 128 else quote(char, safe="") for char in raw_path
+        )
+        return encoded.encode("ascii")
 
 
 def _build_sensitive_auth_headers(
@@ -167,6 +191,57 @@ def _auth_provider_headers(auth_provider: AuthProvider | None) -> dict[str, str]
     if auth_provider is None:
         return {}
     return normalize_auth_headers(auth_provider.auth_headers())
+
+
+async def _resolve_dynamic_auth_headers_async(
+    auth_provider: AuthProvider | None,
+) -> dict[str, str]:
+    """Resolve dynamic provider headers without blocking the event loop.
+
+    Prefers an awaitable ``auth_headers_async`` (see
+    :class:`~honua_sdk.auth.AsyncAuthProvider`) so a network token refresh is
+    awaited rather than run inline. A purely synchronous provider's
+    ``auth_headers`` is executed in a worker thread so a blocking refresh does
+    not stall the event loop.
+    """
+    if auth_provider is None:
+        return {}
+    async_getter = getattr(auth_provider, "auth_headers_async", None)
+    if async_getter is not None:
+        return normalize_auth_headers(await async_getter())
+    headers = await to_thread.run_sync(auth_provider.auth_headers)
+    return normalize_auth_headers(headers)
+
+
+async def _apply_sensitive_auth_headers_async(
+    request: httpx.Request,
+    *,
+    trusted_authority: tuple[str, str, int | None] | None,
+    auth_headers: Mapping[str, str],
+    auth_provider: AuthProvider | None = None,
+) -> None:
+    """Async variant of :func:`_apply_sensitive_auth_headers`.
+
+    Resolves dynamic provider headers via
+    :func:`_resolve_dynamic_auth_headers_async` so a refreshable bearer
+    provider does not block the event loop, then applies the same
+    trusted-origin gate (attach only on an exact ``(scheme, host, port)``
+    match; strip the sensitive headers otherwise).
+    """
+    if trusted_authority is None:
+        return
+
+    request_authority = (request.url.scheme, request.url.host, request.url.port)
+    if request_authority == trusted_authority:
+        dynamic_headers = await _resolve_dynamic_auth_headers_async(auth_provider)
+        for name, value in auth_headers.items():
+            request.headers.setdefault(name, value)
+        for name, value in dynamic_headers.items():
+            request.headers.setdefault(name, value)
+        return
+
+    for name in SENSITIVE_AUTH_HEADER_NAMES:
+        request.headers.pop(name, None)
 
 
 def parse_retry_after(value: str | None) -> float | None:

--- a/packages/honua-sdk/honua_sdk/_retry.py
+++ b/packages/honua-sdk/honua_sdk/_retry.py
@@ -122,15 +122,11 @@ class RetryTransport(httpx.BaseTransport):
         override = request.extensions.get("honua_max_retries")
         retries_remaining = override if isinstance(override, int) else self._max_retries
         attempt = 0
-        response: httpx.Response | None = None
-        last_exc: Exception | None = None
 
         while True:
             try:
                 response = self._wrapped.handle_request(request)
-                last_exc = None
-            except _RETRIABLE_TRANSPORT_EXCEPTIONS as exc:
-                last_exc = exc
+            except _RETRIABLE_TRANSPORT_EXCEPTIONS:
                 if retries_remaining <= 0:
                     raise
                 delay = self._compute_backoff(attempt)
@@ -154,12 +150,6 @@ class RetryTransport(httpx.BaseTransport):
 
             retries_remaining -= 1
             attempt += 1
-
-        # Unreachable: the loop only exits via ``return`` or by re-raising.
-        if last_exc is not None:  # pragma: no cover
-            raise last_exc
-        assert response is not None  # noqa: S101 -- type narrowing for unreachable branch  # pragma: no cover
-        return response
 
     def _compute_delay(self, response: httpx.Response, attempt: int) -> float:
         return compute_delay(

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -12,7 +12,7 @@ import httpx
 from . import _endpoints
 from ._async_retry import AsyncRetryTransport
 from ._http import (
-    _apply_sensitive_auth_headers,
+    _apply_sensitive_auth_headers_async,
     _build_sensitive_auth_headers,
     _extract_trusted_authority,
     _normalize_base_url,
@@ -21,6 +21,7 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
     _warn_deprecated_bearer_token,
+    encode_request_path,
     join_base_path,
 )
 from ._query import (
@@ -203,7 +204,7 @@ class AsyncHonuaClient:
         auth_headers = _build_sensitive_auth_headers(api_key=api_key, bearer_token=bearer_token)
 
         async def _request_hook(request: httpx.Request) -> None:
-            _apply_sensitive_auth_headers(
+            await _apply_sensitive_auth_headers_async(
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
@@ -1613,6 +1614,7 @@ class AsyncHonuaClient:
         *,
         params: Mapping[str, Any] | None = None,
         json_body: Mapping[str, Any] | None = None,
+        content: bytes | None = None,
         headers: Mapping[str, str] | None = None,
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
@@ -1628,21 +1630,30 @@ class AsyncHonuaClient:
         * ``idempotency_key``: when set, attaches an ``Idempotency-Key``
           header to the outbound request, overriding any header of the
           same name in ``headers`` / ``extra_headers``.
+
+        ``content`` sends a raw request body (used by the protocol text path
+        for OData ``$metadata`` / WFS operations); it is mutually exclusive
+        with ``json_body``.
         """
         # Build a full URL so httpx does not re-decode percent-encoded
         # path segments during base-URL resolution. Join onto the base URL's
         # path prefix so sub-path deployments (e.g. behind a reverse proxy at
         # ``/honua/``) are not silently rewritten to the bare endpoint path.
         raw_path = join_base_path(self._base_url, path)
-        url = self._base_url.copy_with(raw_path=raw_path.encode("ascii"))
+        url = self._base_url.copy_with(raw_path=encode_request_path(raw_path))
         merged_headers = merge_request_headers(headers, extra_headers, idempotency_key)
         request_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,
             "params": params,
-            "json": json_body,
             "headers": merged_headers,
         }
+        # ``json`` and ``content`` are mutually exclusive in httpx; prefer a
+        # raw body when supplied, otherwise serialize ``json_body``.
+        if content is not None:
+            request_kwargs["content"] = content
+        else:
+            request_kwargs["json"] = json_body
         if timeout is not None:
             request_kwargs["timeout"] = (
                 timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)

--- a/packages/honua-sdk/honua_sdk/async_geocoding.py
+++ b/packages/honua-sdk/honua_sdk/async_geocoding.py
@@ -9,8 +9,14 @@ import httpx
 
 from ._async_retry import AsyncRetryTransport
 from ._endpoints import parse_json_response_body
+from ._geocoding_models import (
+    GeocodeResult,
+    GeocodeSuggestion,
+    ReverseGeocodeResult,
+    _extract_location_xy,
+)
 from ._http import (
-    _apply_sensitive_auth_headers,
+    _apply_sensitive_auth_headers_async,
     _build_sensitive_auth_headers,
     _encode_path_segment,
     _extract_trusted_authority,
@@ -19,19 +25,14 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    encode_request_path,
     join_base_path,
 )
 from .auth import AuthProvider
-from .geocoding import (
-    GeocodeResult,
-    GeocodeSuggestion,
-    ReverseGeocodeResult,
-    _extract_location_xy,
-)
 
 
 class AsyncHonuaGeocodingClient:
-    """Async task-oriented client for Honua GeocodeServer workflows."""
+    """Asynchronous task-oriented client for Honua GeocodeServer workflows."""
 
     def __init__(
         self,
@@ -67,17 +68,21 @@ class AsyncHonuaGeocodingClient:
         auth_headers = _build_sensitive_auth_headers(api_key=api_key, bearer_token=bearer_token)
 
         async def _request_hook(request: httpx.Request) -> None:
-            _apply_sensitive_auth_headers(
+            await _apply_sensitive_auth_headers_async(
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,
                 auth_provider=auth_provider,
             )
 
-        effective_transport = transport
-        if max_retries > 0:
-            inner = effective_transport or httpx.AsyncHTTPTransport()
-            effective_transport = AsyncRetryTransport(inner, max_retries=max_retries)
+        # Always wrap with the retry transport — even at ``max_retries == 0`` —
+        # matching the core client so retry installation is consistent across
+        # the SDK. The transport only retries when its budget is positive, so a
+        # zero budget is a single attempt (no behaviour change).
+        inner = transport or httpx.AsyncHTTPTransport()
+        effective_transport: httpx.AsyncBaseTransport = AsyncRetryTransport(
+            inner, max_retries=max_retries
+        )
 
         self._client = httpx.AsyncClient(
             base_url=normalized_base_url,
@@ -348,7 +353,7 @@ class AsyncHonuaGeocodingClient:
         # (e.g. a locator name containing a space or "/").
         base_url = self._client.base_url
         raw_path = join_base_path(base_url, path)
-        url = base_url.copy_with(raw_path=raw_path.encode("ascii"))
+        url = base_url.copy_with(raw_path=encode_request_path(raw_path))
         request_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,

--- a/packages/honua-sdk/honua_sdk/auth.py
+++ b/packages/honua-sdk/honua_sdk/auth.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+import asyncio
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from threading import RLock
@@ -16,6 +17,22 @@ class AuthProvider(Protocol):
     """Provider interface used by SDK clients to resolve auth headers per request."""
 
     def auth_headers(self) -> Mapping[str, str]:
+        """Return sensitive auth headers for the next request."""
+
+
+@runtime_checkable
+class AsyncAuthProvider(Protocol):
+    """Awaitable provider interface for non-blocking auth on the async client.
+
+    The async client prefers this over the synchronous :class:`AuthProvider`
+    when a provider exposes :meth:`auth_headers_async`, so a token refresh that
+    performs network I/O can be awaited rather than blocking the event loop.
+    A plain synchronous :class:`AuthProvider` passed to the async client is
+    still honoured — its :meth:`~AuthProvider.auth_headers` is invoked in a
+    worker thread so a blocking refresh does not stall the loop.
+    """
+
+    async def auth_headers_async(self) -> Mapping[str, str]:
         """Return sensitive auth headers for the next request."""
 
 
@@ -173,6 +190,65 @@ class RefreshableBearerTokenProvider:
 
     def _refresh_locked(self) -> BearerToken:
         token = _coerce_token(self._refresh())
+        self._store.set(token)
+        return token
+
+
+class AsyncRefreshableBearerTokenProvider:
+    """Async counterpart of :class:`RefreshableBearerTokenProvider`.
+
+    Awaits an async ``refresh`` callback so the async client can renew an
+    expiring bearer token without blocking the event loop. The token cache is
+    guarded by an :class:`asyncio.Lock`, so concurrent requests that arrive
+    while a refresh is in flight wait for the single refresh rather than each
+    firing their own.
+    """
+
+    def __init__(
+        self,
+        refresh: Callable[[], Awaitable[BearerToken | Mapping[str, Any] | str]],
+        *,
+        initial_token: BearerToken | Mapping[str, Any] | str | None = None,
+        token_store: TokenStore | None = None,
+        refresh_window_seconds: int | float = 60,
+        revoke: Callable[[BearerToken], Awaitable[None]] | None = None,
+    ) -> None:
+        if refresh_window_seconds < 0:
+            raise ValueError("refresh_window_seconds must be non-negative.")
+        self._refresh = refresh
+        self._store = token_store or InMemoryTokenStore(initial_token)
+        if token_store is not None and initial_token is not None:
+            token_store.set(_coerce_token(initial_token))
+        self._refresh_window = timedelta(seconds=float(refresh_window_seconds))
+        self._revoke = revoke
+        self._lock = asyncio.Lock()
+
+    async def auth_headers_async(self) -> Mapping[str, str]:
+        token = await self.get_token()
+        return {"Authorization": token.authorization_value}
+
+    async def get_token(self) -> BearerToken:
+        async with self._lock:
+            token = self._store.get()
+            if token is None or token.expires_within(self._refresh_window):
+                token = await self._refresh_locked()
+            return token
+
+    async def refresh(self) -> BearerToken:
+        """Force a token refresh and store the result."""
+        async with self._lock:
+            return await self._refresh_locked()
+
+    async def revoke(self) -> None:
+        """Call the optional revocation hook and clear the cached token."""
+        async with self._lock:
+            token = self._store.get()
+            if token is not None and self._revoke is not None:
+                await self._revoke(token)
+            self._store.clear()
+
+    async def _refresh_locked(self) -> BearerToken:
+        token = _coerce_token(await self._refresh())
         self._store.set(token)
         return token
 

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -22,6 +22,7 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
     _warn_deprecated_bearer_token,
+    encode_request_path,
     join_base_path,
 )
 from ._query import (
@@ -1614,6 +1615,7 @@ class HonuaClient:
         *,
         params: Mapping[str, Any] | None = None,
         json_body: Mapping[str, Any] | None = None,
+        content: bytes | None = None,
         headers: Mapping[str, str] | None = None,
         timeout: float | httpx.Timeout | None = None,
         extra_headers: Mapping[str, str] | None = None,
@@ -1629,21 +1631,30 @@ class HonuaClient:
         * ``idempotency_key``: when set, attaches an ``Idempotency-Key``
           header to the outbound request, overriding any header of the
           same name in ``headers`` / ``extra_headers``.
+
+        ``content`` sends a raw request body (used by the protocol text path
+        for OData ``$metadata`` / WFS operations); it is mutually exclusive
+        with ``json_body``.
         """
         # Build a full URL so httpx does not re-decode percent-encoded
         # path segments during base-URL resolution. Join onto the base URL's
         # path prefix so sub-path deployments (e.g. behind a reverse proxy at
         # ``/honua/``) are not silently rewritten to the bare endpoint path.
         raw_path = join_base_path(self._base_url, path)
-        url = self._base_url.copy_with(raw_path=raw_path.encode("ascii"))
+        url = self._base_url.copy_with(raw_path=encode_request_path(raw_path))
         merged_headers = merge_request_headers(headers, extra_headers, idempotency_key)
         request_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,
             "params": params,
-            "json": json_body,
             "headers": merged_headers,
         }
+        # ``json`` and ``content`` are mutually exclusive in httpx; prefer a
+        # raw body when supplied, otherwise serialize ``json_body``.
+        if content is not None:
+            request_kwargs["content"] = content
+        else:
+            request_kwargs["json"] = json_body
         if timeout is not None:
             request_kwargs["timeout"] = (
                 timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)

--- a/packages/honua-sdk/honua_sdk/geocoding.py
+++ b/packages/honua-sdk/honua_sdk/geocoding.py
@@ -1,14 +1,21 @@
 """Synchronous HTTP client for Honua GeocodeServer APIs."""
+# AUTO-GENERATED from packages/honua-sdk/honua_sdk/async_geocoding.py by scripts/gen_sync.py — do not edit by hand.
+# Edit the async source-of-truth and run `python scripts/gen_sync.py`.
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 from typing import Any
 
 import httpx
 
 from ._endpoints import parse_json_response_body
+from ._geocoding_models import (
+    GeocodeResult,
+    GeocodeSuggestion,
+    ReverseGeocodeResult,
+    _extract_location_xy,
+)
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -19,58 +26,15 @@ from ._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    encode_request_path,
     join_base_path,
 )
 from ._retry import RetryTransport
 from .auth import AuthProvider
 
 
-@dataclass
-class GeocodeResult:
-    address: str
-    latitude: float
-    longitude: float
-    score: float
-    attributes: dict[str, str | None]
-
-
-@dataclass
-class ReverseGeocodeResult:
-    address: str
-    latitude: float
-    longitude: float
-    attributes: dict[str, str | None]
-
-
-@dataclass
-class GeocodeSuggestion:
-    text: str
-    magic_key: str
-    is_collection: bool
-
-
-def _extract_location_xy(location: Any) -> tuple[float, float] | None:
-    """Return ``(longitude, latitude)`` from a GeocodeServer ``location``.
-
-    Returns ``None`` when the location is missing, not a mapping, or lacks a
-    usable ``x``/``y`` pair. Defaulting absent coordinates to ``0`` would
-    silently emit a valid-looking ``(0, 0)`` "null island" result that masks
-    a geocode miss — so a missing location is treated as "no result" instead.
-    """
-    if not isinstance(location, Mapping):
-        return None
-    raw_x = location.get("x")
-    raw_y = location.get("y")
-    if raw_x is None or raw_y is None:
-        return None
-    try:
-        return float(raw_x), float(raw_y)
-    except (TypeError, ValueError):
-        return None
-
-
 class HonuaGeocodingClient:
-    """Task-oriented client for Honua GeocodeServer workflows."""
+    """Synchronous task-oriented client for Honua GeocodeServer workflows."""
 
     def __init__(
         self,
@@ -113,10 +77,14 @@ class HonuaGeocodingClient:
                 auth_provider=auth_provider,
             )
 
-        effective_transport = transport
-        if max_retries > 0:
-            inner = effective_transport or httpx.HTTPTransport()
-            effective_transport = RetryTransport(inner, max_retries=max_retries)
+        # Always wrap with the retry transport — even at ``max_retries == 0`` —
+        # matching the core client so retry installation is consistent across
+        # the SDK. The transport only retries when its budget is positive, so a
+        # zero budget is a single attempt (no behaviour change).
+        inner = transport or httpx.HTTPTransport()
+        effective_transport: httpx.BaseTransport = RetryTransport(
+            inner, max_retries=max_retries
+        )
 
         self._client = httpx.Client(
             base_url=normalized_base_url,
@@ -134,8 +102,9 @@ class HonuaGeocodingClient:
     def close(self) -> None:
         """Release underlying HTTP resources if this instance owns the client.
 
-        When constructed with an externally supplied :class:`httpx.Client`,
-        ownership stays with the caller and this method is a no-op.
+        When constructed with an externally supplied
+        :class:`httpx.Client`, ownership stays with the caller and
+        this method is a no-op.
         """
         if self._owns_client:
             self._client.close()
@@ -386,7 +355,7 @@ class HonuaGeocodingClient:
         # (e.g. a locator name containing a space or "/").
         base_url = self._client.base_url
         raw_path = join_base_path(base_url, path)
-        url = base_url.copy_with(raw_path=raw_path.encode("ascii"))
+        url = base_url.copy_with(raw_path=encode_request_path(raw_path))
         request_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,

--- a/packages/honua-sdk/honua_sdk/protocols/_base.py
+++ b/packages/honua-sdk/honua_sdk/protocols/_base.py
@@ -1,6 +1,6 @@
 """Shared helpers and request/response base mixins for protocol clients."""
 
-# ruff: noqa: PLR0913, PLR2004
+# ruff: noqa: PLR0913
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from urllib.parse import parse_qsl, urlsplit
 
 import httpx
 
-from honua_sdk._http import _encode_path_segment, _to_http_error, _to_transport_error
+from honua_sdk._http import _encode_path_segment
 
 JsonObject = dict[str, Any]
 Params = Mapping[str, Any] | None
@@ -387,24 +387,18 @@ class _SyncProtocol:
         extra_headers: Mapping[str, str] | None = None,
     ) -> str:
         body = content.encode("utf-8") if isinstance(content, str) else content
-        kwargs: dict[str, Any] = {
-            "method": method,
-            "url": path,
-            "params": params,
-            "content": body,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = (
-                timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
-            )
-        if extra_headers is not None:
-            kwargs["headers"] = dict(extra_headers)
-        try:
-            response = self.client._client.request(**kwargs)
-        except httpx.HTTPError as exc:
-            raise _to_transport_error(exc) from exc
-        if response.status_code >= 400:
-            raise _to_http_error(response)
+        # Route through the client's request path (rather than the raw
+        # ``client._client``) so per-call options — ``with_options(timeout=…)``,
+        # ``with_options(max_retries=…)`` — base-URL path joining, and the
+        # shared error mapping all apply to text requests (OData ``$metadata``
+        # and every WFS operation), matching the JSON path.
+        response = self.client._request(
+            method,
+            path,
+            params=params,
+            content=body,
+            **_per_call_kwargs(timeout=timeout, extra_headers=extra_headers),
+        )
         return cast(str, response.text)
 
 
@@ -499,22 +493,16 @@ class _AsyncProtocol:
         extra_headers: Mapping[str, str] | None = None,
     ) -> str:
         body = content.encode("utf-8") if isinstance(content, str) else content
-        kwargs: dict[str, Any] = {
-            "method": method,
-            "url": path,
-            "params": params,
-            "content": body,
-        }
-        if timeout is not None:
-            kwargs["timeout"] = (
-                timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
-            )
-        if extra_headers is not None:
-            kwargs["headers"] = dict(extra_headers)
-        try:
-            response = await self.client._client.request(**kwargs)
-        except httpx.HTTPError as exc:
-            raise _to_transport_error(exc) from exc
-        if response.status_code >= 400:
-            raise _to_http_error(response)
+        # Route through the client's request path (rather than the raw
+        # ``client._client``) so per-call options — ``with_options(timeout=…)``,
+        # ``with_options(max_retries=…)`` — base-URL path joining, and the
+        # shared error mapping all apply to text requests (OData ``$metadata``
+        # and every WFS operation), matching the JSON path.
+        response = await self.client._request(
+            method,
+            path,
+            params=params,
+            content=body,
+            **_per_call_kwargs(timeout=timeout, extra_headers=extra_headers),
+        )
         return cast(str, response.text)

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -179,6 +179,15 @@ _COMMON_RULES: tuple[Rule, ...] = (
     # distinct and must be mapped explicitly.
     _rule(r"\baclose\b", "close"),
     #
+    # --- function-name seams ----------------------------------------------
+    # The async client uses the awaitable auth-application helper; its sync
+    # mirror calls the synchronous one. The ``_async`` suffix is lowercase and
+    # underscore-prefixed, so the generic ``\bAsync`` strip never fires on it.
+    _rule(
+        r"\b_apply_sensitive_auth_headers_async\b",
+        "_apply_sensitive_auth_headers",
+    ),
+    #
     # --- module-name seams -------------------------------------------------
     # Async-only sibling modules collapse onto their sync equivalents.
     _rule(r"\b_async_retry\b", "_retry"),
@@ -219,6 +228,10 @@ TARGETS: tuple[Target, ...] = (
     Target(
         source=ROOT / "packages/honua-sdk/honua_sdk/async_client.py",
         dest=ROOT / "packages/honua-sdk/honua_sdk/client.py",
+    ),
+    Target(
+        source=ROOT / "packages/honua-sdk/honua_sdk/async_geocoding.py",
+        dest=ROOT / "packages/honua-sdk/honua_sdk/geocoding.py",
     ),
     Target(
         source=ROOT / "packages/honua-admin/honua_admin/_async_client.py",

--- a/tests/test_audit_transport_dedup.py
+++ b/tests/test_audit_transport_dedup.py
@@ -1,0 +1,280 @@
+"""Regression tests for the pre-release transport/auth/de-duplication audit.
+
+Covers:
+
+* #125 — request-path encoding: a non-ASCII (server-controlled next-link) path
+  no longer crashes ``_request`` with an unwrapped ``UnicodeEncodeError``.
+* #125 — geocoding installs the retry transport consistently (always-on, even
+  at ``max_retries=0``), matching the core client.
+* #126 — the async client refreshes auth tokens without blocking the loop:
+  an :class:`AsyncRefreshableBearerTokenProvider` is awaited, and a plain
+  synchronous provider is offloaded to a worker thread.
+* #129 (AUD-162) — protocol ``_text`` requests honour per-call options
+  (``with_options(max_retries=…)``), which previously only applied to the JSON
+  path because ``_text`` bypassed the client's request path.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import httpx
+import pytest
+
+from honua_sdk import (
+    AsyncHonuaGeocodingClient,
+    AsyncRefreshableBearerTokenProvider,
+    HonuaClient,
+    HonuaGeocodingClient,
+    StaticAuthProvider,
+)
+from honua_sdk._async_retry import AsyncRetryTransport
+from honua_sdk._http import encode_request_path
+from honua_sdk._retry import RetryTransport
+from honua_sdk.async_client import AsyncHonuaClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# ---------------------------------------------------------------------------
+# #125 — request-path encoding
+# ---------------------------------------------------------------------------
+
+
+def test_encode_request_path_ascii_passthrough() -> None:
+    assert encode_request_path("/rest/services/World") == b"/rest/services/World"
+
+
+def test_encode_request_path_preserves_existing_percent_encoding() -> None:
+    # An already percent-encoded segment must not be double-encoded.
+    assert encode_request_path("/rest/services/a%20b/Query") == b"/rest/services/a%20b/Query"
+
+
+def test_encode_request_path_percent_encodes_non_ascii_only() -> None:
+    # Only the non-ASCII characters are percent-encoded (UTF-8); ASCII and the
+    # path delimiters are left intact.
+    assert encode_request_path("/rest/services/café") == b"/rest/services/caf%C3%A9"
+
+
+def test_request_with_non_ascii_path_does_not_crash() -> None:
+    seen: list[bytes] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.raw_path)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as client:
+        # Simulates following a server-controlled next-link path with non-ASCII
+        # characters — previously this raised an unwrapped UnicodeEncodeError.
+        response = client._request("GET", "/rest/services/München/FeatureServer/0/query")
+    assert response.status_code == 200
+    assert seen[0] == b"/rest/services/M%C3%BCnchen/FeatureServer/0/query"
+
+
+# ---------------------------------------------------------------------------
+# #125 — geocoding retry transport is installed consistently (always-on)
+# ---------------------------------------------------------------------------
+
+
+def test_geocoding_installs_retry_transport_even_at_zero_retries() -> None:
+    with HonuaGeocodingClient("http://example.test", max_retries=0) as geo:
+        assert isinstance(geo._client._transport, RetryTransport)
+
+
+@pytest.mark.anyio
+async def test_async_geocoding_installs_retry_transport_even_at_zero_retries() -> None:
+    async with AsyncHonuaGeocodingClient("http://example.test", max_retries=0) as geo:
+        assert isinstance(geo._client._transport, AsyncRetryTransport)
+
+
+# ---------------------------------------------------------------------------
+# #129 (AUD-162) — protocol _text honours per-call options
+# ---------------------------------------------------------------------------
+
+
+def test_text_request_honors_with_options_max_retries() -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(503)
+        return httpx.Response(200, content=b"<capabilities/>")
+
+    transport = httpx.MockTransport(handler)
+    # The base client has a zero retry budget; the WFS GetCapabilities call goes
+    # through the _text path. with_options(max_retries=1) must be honoured there
+    # too — previously _text bypassed the per-call override entirely.
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as client:
+        body = client.with_options(max_retries=1).wfs().capabilities()
+    assert body == "<capabilities/>"
+    assert attempts["count"] == 2  # one 503 retried once, then 200
+
+
+def test_text_request_joins_base_url_path_prefix() -> None:
+    seen: list[bytes] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.raw_path)
+        return httpx.Response(200, content=b"<capabilities/>")
+
+    transport = httpx.MockTransport(handler)
+    # A sub-path base URL must be preserved on the _text path (it routes through
+    # _request, which joins the base path) just like the JSON path.
+    with HonuaClient("http://example.test/honua/", transport=transport, max_retries=0) as client:
+        client.wfs().capabilities()
+    assert seen[0].split(b"?")[0] == b"/honua/wfs"
+
+
+# ---------------------------------------------------------------------------
+# #126 — async non-blocking auth refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_async_refreshable_bearer_token_provider_is_awaited() -> None:
+    refreshed: list[str] = []
+
+    async def refresh() -> str:
+        refreshed.append("called")
+        return "async-token"
+
+    provider = AsyncRefreshableBearerTokenProvider(refresh)
+
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization", ""))
+        return httpx.Response(200, json={"services": []})
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient(
+        "http://example.test", transport=transport, auth_provider=provider
+    ) as client:
+        await client.list_services()
+
+    assert refreshed == ["called"]
+    assert seen == ["Bearer async-token"]
+
+
+@pytest.mark.anyio
+async def test_async_client_offloads_sync_auth_provider_off_the_loop() -> None:
+    loop_thread = threading.get_ident()
+    call_threads: list[int] = []
+
+    class _RecordingProvider:
+        def auth_headers(self) -> dict[str, str]:
+            call_threads.append(threading.get_ident())
+            return {"Authorization": "Bearer sync-token"}
+
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization", ""))
+        return httpx.Response(200, json={"services": []})
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient(
+        "http://example.test", transport=transport, auth_provider=_RecordingProvider()
+    ) as client:
+        await client.list_services()
+
+    assert seen == ["Bearer sync-token"]
+    # The synchronous provider ran in a worker thread, not on the event loop.
+    assert call_threads and all(tid != loop_thread for tid in call_threads)
+
+
+@pytest.mark.anyio
+async def test_async_refreshable_provider_caches_and_forces_refresh() -> None:
+    counter = {"n": 0}
+
+    async def refresh() -> dict[str, object]:
+        counter["n"] += 1
+        # No expiry metadata => token never looks expired, so it is cached.
+        return {"access_token": f"tok-{counter['n']}"}
+
+    provider = AsyncRefreshableBearerTokenProvider(refresh)
+    first = await provider.get_token()
+    second = await provider.get_token()
+    assert first.access_token == "tok-1"
+    assert second.access_token == "tok-1"  # cached; refresh not called again
+    assert counter["n"] == 1
+
+    forced = await provider.refresh()
+    assert forced.access_token == "tok-2"
+    assert counter["n"] == 2
+
+
+@pytest.mark.anyio
+async def test_async_refreshable_provider_revoke_runs_hook_and_clears() -> None:
+    revoked: list[str] = []
+
+    async def refresh() -> str:
+        return "tok"
+
+    async def revoke(token: object) -> None:
+        revoked.append(getattr(token, "access_token", ""))
+
+    provider = AsyncRefreshableBearerTokenProvider(refresh, revoke=revoke)
+    await provider.get_token()
+    await provider.revoke()
+    assert revoked == ["tok"]
+    # Token cache cleared, so the next access refreshes again.
+    assert (await provider.get_token()).access_token == "tok"
+
+
+def test_async_refreshable_provider_rejects_negative_window() -> None:
+    async def refresh() -> str:
+        return "tok"
+
+    with pytest.raises(ValueError, match="refresh_window_seconds"):
+        AsyncRefreshableBearerTokenProvider(refresh, refresh_window_seconds=-1)
+
+
+@pytest.mark.anyio
+async def test_async_auth_headers_stripped_on_redirect_to_other_host() -> None:
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization", ""))
+        return httpx.Response(200, json={"services": []})
+
+    transport = httpx.MockTransport(handler)
+    provider = AsyncRefreshableBearerTokenProvider(_const_token)
+    # Build a client bound to one authority, then fire a request at a different
+    # host through the same event hook to exercise the strip branch.
+    async with AsyncHonuaClient(
+        "http://example.test", transport=transport, auth_provider=provider
+    ) as client:
+        await client._request("GET", "/rest/services")
+        # Re-target the underlying client at a foreign host: the trusted-origin
+        # gate must drop the provider-supplied Authorization header.
+        other = httpx.Request("GET", "http://evil.test/rest/services")
+        await client._client.send(other)
+    assert seen[0] == "Bearer const-token"
+    assert seen[1] == ""  # stripped on the foreign authority
+
+
+async def _const_token() -> str:
+    return "const-token"
+
+
+@pytest.mark.anyio
+async def test_async_static_auth_provider_still_attaches_headers() -> None:
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("x-api-key", ""))
+        return httpx.Response(200, json={"services": []})
+
+    transport = httpx.MockTransport(handler)
+    provider = StaticAuthProvider({"X-API-Key": "k"})
+    async with AsyncHonuaClient(
+        "http://example.test", transport=transport, auth_provider=provider
+    ) as client:
+        await client.list_services()
+    assert seen == ["k"]


### PR DESCRIPTION
## Summary

Pre-release audit follow-ups across the core client/transport, the auth layer, and the sync/async de-duplication mechanism. Fully resolves the two transport S2 issues and substantially advances the de-duplication backlog issue.

### #125 — request URL construction (fully resolved)
The remaining S3 items left open by #134:
- New `encode_request_path()` — a server-controlled pagination `next`-link path containing non-ASCII characters no longer crashes `_request` with an unwrapped `UnicodeEncodeError`. Only the non-ASCII characters are percent-encoded (UTF-8); existing percent-encoding and reserved delimiters are left intact (no double-encoding). Used on both the sync and async request paths.
- The geocoding client now installs the retry transport **consistently (always-on, even at `max_retries=0`)**, matching the core client, and routes its request path through `encode_request_path` (locator segments are already `_encode_path_segment`-encoded).

### #126 — async non-blocking auth refresh (fully resolved)
The remaining S2 item left open by #134:
- New public `AsyncAuthProvider` protocol and `AsyncRefreshableBearerTokenProvider` (awaitable refresh guarded by an `asyncio.Lock`).
- The async client resolves auth headers **without blocking the event loop**: it awaits a provider's `auth_headers_async` when present, otherwise runs a synchronous provider's `auth_headers` in a worker thread so a blocking refresh never stalls the loop.

### #129 — duplication / codegen drift / leaky internals / dead code (partial)
- **AUD-162** (the flagged user-facing item): protocol `_text` requests now route through the client's `_request` path (new `content=` parameter) instead of reaching into `client._client`. So `with_options(timeout=…)` / `with_options(max_retries=…)`, base-URL path joining, and the shared error mapping all apply to OData `$metadata` and every WFS operation — and the leaky `_client` access is gone.
- **AUD-160 / AUD-161 (meaningful slice)**: `async_geocoding` is now the gen_sync source of truth — shared geocode models moved to `_geocoding_models`, `geocoding.py` is generated, and the pair is added to `gen_sync` `TARGETS` (now enforced by CI `--check`). Geocoding already reused `_endpoints.parse_json_response_body`.
- **AUD-208**: removed the unreachable tail + unused `last_exc` accumulator in the sync and async retry transports.

#### Remaining on #129 (left open; larger restructure)
- The `source` / `ogc` / `workflow` / `geoprocessing` / `protocols` mirror pairs keep their sync **and** async classes in a single file, so adding them to file-level `gen_sync` `TARGETS` requires splitting each module into an async source + generated sync file — out of scope for one safe pass.
- Geocoding still keeps its own `_request` (full request-layer reuse not yet done).
- The typed `SupportsRequest` Protocol (AUD-207, S3) is deferred: the protocol clients also call higher-level client methods (`query_features` / `apply_edits` / `export_map`), so a faithful Protocol would be broad and brittle. The highest-value part — removing the leaky `client._client` access — is done via the `_text` change above.

## Testing
New `tests/test_audit_transport_dedup.py` covers non-ASCII path encoding, always-on geocoding retries, `_text` honoring per-call options + base-path joining, and async non-blocking auth (async provider awaited, sync provider offloaded, headers stripped on a foreign authority). `ruff check .`, `mypy`, `python scripts/gen_sync.py --check`, `python scripts/compatibility_gate.py`, and the full `pytest` suite with the `--cov-fail-under=94` gate (94.82% combined) all pass. The public-API snapshot was regenerated for the new auth exports and the geocode-model module move.

Closes #125
Closes #126
Refs #129