### PR TITLE
perf(sdk): fix conversion, pagination-memory, and transport-reuse lifecycle issues

### DIFF
--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import httpx
 from honua_sdk.http import (
+    AsyncNonClosingTransport,
     AsyncRetryTransport,
     AuthProvider,
     HonuaHttpError,
@@ -314,6 +315,16 @@ class AsyncHonuaAdminClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
+            # A caller-supplied transport is owned by the original client. Wrap
+            # it so the independently-owned clone reuses the transport (custom
+            # transport / smaller transport-level timeout) without closing the
+            # shared connection pool the original still depends on. When no
+            # transport was supplied, pass ``None`` so the clone builds its own.
+            clone_transport = (
+                AsyncNonClosingTransport(self._init_transport)
+                if self._init_transport is not None
+                else None
+            )
             # Suppress the re-fired bearer_token deprecation on the internal
             # clone path; the caller acknowledged it at original construction.
             with warnings.catch_warnings():
@@ -325,7 +336,7 @@ class AsyncHonuaAdminClient:
                     bearer_token=self._init_bearer_token,
                     auth_provider=self._init_auth_provider,
                     follow_redirects=self._init_follow_redirects,
-                    transport=self._init_transport,
+                    transport=clone_transport,
                     max_retries=self._init_max_retries,
                 )
             clone._options_timeout = (

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -13,6 +13,7 @@ import httpx
 from honua_sdk.http import (
     AuthProvider,
     HonuaHttpError,
+    NonClosingTransport,
     RetryTransport,
     apply_sensitive_auth_headers,
     build_sensitive_auth_headers,
@@ -315,6 +316,16 @@ class HonuaAdminClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
+            # A caller-supplied transport is owned by the original client. Wrap
+            # it so the independently-owned clone reuses the transport (custom
+            # transport / smaller transport-level timeout) without closing the
+            # shared connection pool the original still depends on. When no
+            # transport was supplied, pass ``None`` so the clone builds its own.
+            clone_transport = (
+                NonClosingTransport(self._init_transport)
+                if self._init_transport is not None
+                else None
+            )
             # Suppress the re-fired bearer_token deprecation on the internal
             # clone path; the caller acknowledged it at original construction.
             with warnings.catch_warnings():
@@ -326,7 +337,7 @@ class HonuaAdminClient:
                     bearer_token=self._init_bearer_token,
                     auth_provider=self._init_auth_provider,
                     follow_redirects=self._init_follow_redirects,
-                    transport=self._init_transport,
+                    transport=clone_transport,
                     max_retries=self._init_max_retries,
                 )
             clone._options_timeout = (

--- a/packages/honua-sdk/honua_sdk/_async_retry.py
+++ b/packages/honua-sdk/honua_sdk/_async_retry.py
@@ -35,8 +35,30 @@ from ._retry_core import (
 )
 
 __all__ = [
+    "AsyncNonClosingTransport",
     "AsyncRetryTransport",
 ]
+
+
+class AsyncNonClosingTransport(httpx.AsyncBaseTransport):
+    """Async transport wrapper whose ``aclose`` does not close the wrapped transport.
+
+    Used by ``with_options`` / ``copy`` when an independently-owned clone must
+    reuse a caller-supplied transport: the clone owns its own
+    :class:`httpx.AsyncClient`, so closing it would otherwise tear down the
+    shared transport's connection pool and break the original client that still
+    depends on it. Ownership of the wrapped transport stays with the original.
+    """
+
+    def __init__(self, wrapped: httpx.AsyncBaseTransport) -> None:
+        self._wrapped = wrapped
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return await self._wrapped.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        # Intentionally a no-op: the original client owns the wrapped transport.
+        return None
 
 
 class AsyncRetryTransport(httpx.AsyncBaseTransport):

--- a/packages/honua-sdk/honua_sdk/_retry.py
+++ b/packages/honua-sdk/honua_sdk/_retry.py
@@ -37,8 +37,30 @@ from ._retry_core import (
 # Re-export for back-compat with tests that imported the constants from
 # this module before the policy was moved into ``_retry_core``.
 __all__ = [
+    "NonClosingTransport",
     "RetryTransport",
 ]
+
+
+class NonClosingTransport(httpx.BaseTransport):
+    """Transport wrapper whose ``close`` does not close the wrapped transport.
+
+    Used by ``with_options`` / ``copy`` when an independently-owned clone must
+    reuse a caller-supplied transport: the clone owns its own
+    :class:`httpx.Client`, so closing it would otherwise tear down the shared
+    transport's connection pool and break the original client that still
+    depends on it. Ownership of the wrapped transport stays with the original.
+    """
+
+    def __init__(self, wrapped: httpx.BaseTransport) -> None:
+        self._wrapped = wrapped
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return self._wrapped.handle_request(request)
+
+    def close(self) -> None:
+        # Intentionally a no-op: the original client owns the wrapped transport.
+        return None
 
 
 class RetryTransport(httpx.BaseTransport):

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from . import _endpoints
-from ._async_retry import AsyncRetryTransport
+from ._async_retry import AsyncNonClosingTransport, AsyncRetryTransport
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -317,8 +317,19 @@ class AsyncHonuaClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            # Suppress the re-fired bearer_token deprecation on the internal
-            # clone path; the caller acknowledged it at original construction.
+            # A caller-supplied transport is owned by the original client. The
+            # clone owns its OWN httpx.AsyncClient, so if it reused the raw
+            # caller transport, closing the clone would tear down the shared
+            # connection pool the original still depends on. Wrap it so the
+            # clone reuses the transport (preserving custom transports / a
+            # smaller transport-level timeout) without closing it. When no
+            # transport was supplied, pass ``None`` so the clone builds its own
+            # independent transport.
+            clone_transport = (
+                AsyncNonClosingTransport(self._init_transport)
+                if self._init_transport is not None
+                else None
+            )
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
                 clone = self.__class__(
@@ -328,7 +339,7 @@ class AsyncHonuaClient:
                     bearer_token=self._init_bearer_token,
                     auth_provider=self._init_auth_provider,
                     follow_redirects=self._init_follow_redirects,
-                    transport=self._init_transport,
+                    transport=clone_transport,
                     max_retries=self._init_max_retries,
                 )
             clone._options_timeout = (

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -50,7 +50,7 @@ from ._query_dispatch import (
     validate_filter_routing,
     warn_if_truncated,
 )
-from ._retry import RetryTransport
+from ._retry import NonClosingTransport, RetryTransport
 from .errors import HonuaHttpError
 from .models import (
     ApplyEditsResult,
@@ -318,8 +318,19 @@ class HonuaClient:
                 if (timeout is not None and timeout < self._init_timeout)
                 else self._init_timeout
             )
-            # Suppress the re-fired bearer_token deprecation on the internal
-            # clone path; the caller acknowledged it at original construction.
+            # A caller-supplied transport is owned by the original client. The
+            # clone owns its OWN httpx.Client, so if it reused the raw
+            # caller transport, closing the clone would tear down the shared
+            # connection pool the original still depends on. Wrap it so the
+            # clone reuses the transport (preserving custom transports / a
+            # smaller transport-level timeout) without closing it. When no
+            # transport was supplied, pass ``None`` so the clone builds its own
+            # independent transport.
+            clone_transport = (
+                NonClosingTransport(self._init_transport)
+                if self._init_transport is not None
+                else None
+            )
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
                 clone = self.__class__(
@@ -329,7 +340,7 @@ class HonuaClient:
                     bearer_token=self._init_bearer_token,
                     auth_provider=self._init_auth_provider,
                     follow_redirects=self._init_follow_redirects,
-                    transport=self._init_transport,
+                    transport=clone_transport,
                     max_retries=self._init_max_retries,
                 )
             clone._options_timeout = (

--- a/packages/honua-sdk/honua_sdk/geopandas.py
+++ b/packages/honua-sdk/honua_sdk/geopandas.py
@@ -519,12 +519,18 @@ def geodataframe_to_features(
     _ensure_deps()
 
     attr_columns = [col for col in gdf.columns if col != gdf.geometry.name]
+    # Build attribute records columnar (one dict per row) instead of boxing a
+    # pandas Series per row via ``.iloc`` — the per-row Series is a perf cliff
+    # on bulk apply_edits. ``to_dict("records")`` on an empty column selection
+    # returns ``[]``, so synthesize empty dicts for the geometry-only case.
+    attr_records = (
+        gdf[attr_columns].to_dict("records") if attr_columns else [{} for _ in range(len(gdf))]
+    )
+    geometries = gdf.geometry.to_numpy()
 
     features: list[dict[str, Any]] = []
-    for idx in range(len(gdf)):
-        row = gdf.iloc[idx]
-        attrs = {col: _json_safe_value(row[col]) for col in attr_columns}
-        geom_obj = row[gdf.geometry.name]
+    for raw_attrs, geom_obj in zip(attr_records, geometries, strict=True):
+        attrs = {col: _json_safe_value(raw_attrs[col]) for col in attr_columns}
         esri_geom = _shapely_to_esri_geometry(geom_obj)
         feat: dict[str, Any] = {"attributes": attrs}
         if esri_geom is not None:
@@ -561,12 +567,16 @@ def geodataframe_to_geojson(
     from shapely.geometry import mapping as _mapping
 
     attr_columns = [col for col in gdf.columns if col != gdf.geometry.name]
+    # Columnar record extraction + a single geometry pass, avoiding a boxed
+    # pandas Series per row (see ``geodataframe_to_features``).
+    attr_records = (
+        gdf[attr_columns].to_dict("records") if attr_columns else [{} for _ in range(len(gdf))]
+    )
+    geometries = gdf.geometry.to_numpy()
 
     features: list[dict[str, Any]] = []
-    for idx in range(len(gdf)):
-        row = gdf.iloc[idx]
-        properties = {col: _json_safe_value(row[col]) for col in attr_columns}
-        geom_obj = row[gdf.geometry.name]
+    for raw_attrs, geom_obj in zip(attr_records, geometries, strict=True):
+        properties = {col: _json_safe_value(raw_attrs[col]) for col in attr_columns}
         feature: dict[str, Any] = {
             "type": "Feature",
             "properties": properties,

--- a/packages/honua-sdk/honua_sdk/http.py
+++ b/packages/honua-sdk/honua_sdk/http.py
@@ -52,7 +52,7 @@ the canonical names above.
 
 from __future__ import annotations
 
-from ._async_retry import AsyncRetryTransport
+from ._async_retry import AsyncNonClosingTransport, AsyncRetryTransport
 from ._http import (
     _apply_sensitive_auth_headers,
     _build_sensitive_auth_headers,
@@ -66,7 +66,7 @@ from ._http import (
     _validate_external_client_auth_configuration,
     _warn_deprecated_bearer_token,
 )
-from ._retry import RetryTransport
+from ._retry import NonClosingTransport, RetryTransport
 from .auth import AuthProvider
 from .errors import (
     HonuaAuthError,
@@ -91,6 +91,7 @@ validate_external_client_auth_configuration = _validate_external_client_auth_con
 warn_deprecated_bearer_token = _warn_deprecated_bearer_token
 
 __all__ = [
+    "AsyncNonClosingTransport",
     "AsyncRetryTransport",
     "AuthProvider",
     "HonuaAuthError",
@@ -98,6 +99,7 @@ __all__ = [
     "HonuaRateLimitError",
     "HonuaTimeoutError",
     "HonuaTransportError",
+    "NonClosingTransport",
     "RetryTransport",
     "_apply_sensitive_auth_headers",
     "_build_sensitive_auth_headers",

--- a/packages/honua-sdk/honua_sdk/protocols/geoservices.py
+++ b/packages/honua-sdk/honua_sdk/protocols/geoservices.py
@@ -112,7 +112,7 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
         total = 0
         base_extra = dict(extra_params or {})
         offset = int(base_extra.get("resultOffset", 0))
-        seen_object_ids: set[int] = set()
+        previous_object_ids: set[int] = set()
         for _ in _iter_page_indices(max_pages):
             remaining = None if limit is None else limit - total
             if remaining is not None and remaining <= 0:
@@ -136,11 +136,14 @@ class GeoServicesFeatureServerClient(_SyncProtocol):
             )
             # Non-advancing-cursor guard: stop before re-yielding a page a
             # server that ignores ``resultOffset`` keeps returning (it would
-            # otherwise loop to ``max_pages`` with duplicate features).
+            # otherwise loop to ``max_pages`` with duplicate features). Compare
+            # against the previous page only — not every id seen across the
+            # whole walk — so the tracking set stays bounded to a single page on
+            # the streaming path.
             new_object_ids = {oid for f in page.features if (oid := f.object_id) is not None}
-            if new_object_ids and new_object_ids.issubset(seen_object_ids):
+            if new_object_ids and new_object_ids.issubset(previous_object_ids):
                 break
-            seen_object_ids |= new_object_ids
+            previous_object_ids = new_object_ids
             yield page
             page_count = len(page.features)
             total += page_count
@@ -535,7 +538,7 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         total = 0
         base_extra = dict(extra_params or {})
         offset = int(base_extra.get("resultOffset", 0))
-        seen_object_ids: set[int] = set()
+        previous_object_ids: set[int] = set()
         for _ in _iter_page_indices(max_pages):
             remaining = None if limit is None else limit - total
             if remaining is not None and remaining <= 0:
@@ -559,11 +562,14 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
             )
             # Non-advancing-cursor guard: stop before re-yielding a page a
             # server that ignores ``resultOffset`` keeps returning (it would
-            # otherwise loop to ``max_pages`` with duplicate features).
+            # otherwise loop to ``max_pages`` with duplicate features). Compare
+            # against the previous page only — not every id seen across the
+            # whole walk — so the tracking set stays bounded to a single page on
+            # the streaming path.
             new_object_ids = {oid for f in page.features if (oid := f.object_id) is not None}
-            if new_object_ids and new_object_ids.issubset(seen_object_ids):
+            if new_object_ids and new_object_ids.issubset(previous_object_ids):
                 break
-            seen_object_ids |= new_object_ids
+            previous_object_ids = new_object_ids
             yield page
             page_count = len(page.features)
             total += page_count

--- a/tests/test_audit_resource_lifecycle.py
+++ b/tests/test_audit_resource_lifecycle.py
@@ -1,0 +1,168 @@
+"""Regression tests for the pre-release performance / resource-lifecycle audit (#131).
+
+Covers:
+
+* geopandas conversion no longer boxes a pandas Series per row (columnar
+  records + one geometry pass) and still produces identical output, including
+  the geometry-only and null-geometry edge cases.
+* the FeatureServer non-advancing-cursor guard compares against the previous
+  page only, so its tracking set stays bounded on the streaming path while
+  still stopping a server that ignores ``resultOffset``.
+* with_options/copy independent clones reuse a caller-supplied transport
+  without closing it, so closing the clone no longer tears down the original's
+  connection pool.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from honua_sdk import HonuaClient
+
+gpd = pytest.importorskip("geopandas")
+from shapely.geometry import Point
+
+from honua_sdk.geopandas import (
+    geodataframe_to_features,
+    geodataframe_to_geojson,
+)
+
+
+# ---------------------------------------------------------------------------
+# geopandas columnar conversion
+# ---------------------------------------------------------------------------
+
+
+def test_geodataframe_to_features_columnar_output() -> None:
+    gdf = gpd.GeoDataFrame(
+        {"name": ["a", "b"], "value": [1, 2]},
+        geometry=[Point(-117.1, 32.7), None],
+    )
+    features = geodataframe_to_features(gdf)
+    assert features[0]["attributes"] == {"name": "a", "value": 1}
+    assert features[0]["geometry"] == {"x": -117.1, "y": 32.7}
+    # None geometry yields an attributes-only feature (no "geometry" key).
+    assert features[1]["attributes"] == {"name": "b", "value": 2}
+    assert "geometry" not in features[1]
+
+
+def test_geodataframe_to_features_geometry_only_frame() -> None:
+    # No attribute columns: to_dict("records") would return [] — the conversion
+    # must still emit one (empty-attributes) feature per row.
+    gdf = gpd.GeoDataFrame(geometry=[Point(0, 0), Point(1, 1)])
+    features = geodataframe_to_features(gdf)
+    assert len(features) == 2
+    assert all(f["attributes"] == {} for f in features)
+    assert features[1]["geometry"] == {"x": 1.0, "y": 1.0}
+
+
+def test_geodataframe_to_geojson_columnar_output() -> None:
+    gdf = gpd.GeoDataFrame(
+        {"name": ["a"]},
+        geometry=[Point(5, 6)],
+    )
+    fc = geodataframe_to_geojson(gdf)
+    assert fc["type"] == "FeatureCollection"
+    assert fc["features"][0]["properties"] == {"name": "a"}
+    assert fc["features"][0]["geometry"] == {"type": "Point", "coordinates": (5.0, 6.0)}
+
+
+# ---------------------------------------------------------------------------
+# FeatureServer non-advancing-cursor guard (bounded tracking set)
+# ---------------------------------------------------------------------------
+
+
+def test_query_pages_stops_on_non_advancing_cursor() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        # Server ignores resultOffset and returns the SAME page forever.
+        return httpx.Response(
+            200,
+            json={
+                "features": [{"attributes": {"objectid": 1}}, {"attributes": {"objectid": 2}}],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as client:
+        pages = list(client.feature_server("parcels").query_pages(0, page_size=2, max_pages=10))
+
+    # First page yielded; the identical second page trips the guard and stops —
+    # we do NOT loop to max_pages.
+    assert [[f.object_id for f in p.features] for p in pages] == [[1, 2]]
+    assert calls["n"] == 2
+
+
+def test_query_pages_advancing_cursor_yields_all_pages() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = dict(request.url.params.multi_items())
+        offset = int(query["resultOffset"])
+        count = int(query["resultRecordCount"])
+        features = [{"attributes": {"objectid": offset + i + 1}} for i in range(count)]
+        return httpx.Response(200, json={"features": features, "exceededTransferLimit": offset == 0})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport, max_retries=0) as client:
+        pages = list(client.feature_server("parcels").query_pages(0, page_size=2, limit=3))
+    assert [[f.object_id for f in p.features] for p in pages] == [[1, 2], [3]]
+
+
+# ---------------------------------------------------------------------------
+# with_options independent clone does not close the shared transport
+# ---------------------------------------------------------------------------
+
+
+class _CloseTrackingTransport(httpx.BaseTransport):
+    def __init__(self) -> None:
+        self.closed = False
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"status": "ready"})
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_independent_clone_does_not_close_caller_transport() -> None:
+    caller_transport = _CloseTrackingTransport()
+    original = HonuaClient(
+        "http://example.test", transport=caller_transport, timeout=30.0, max_retries=0
+    )
+    try:
+        # base_url override -> independent, clone-owned httpx.Client.
+        clone = original.with_options(base_url="http://other.test")
+        assert clone._client is not original._client
+        assert clone._owns_client is True
+        clone.close()
+        # Closing the clone must NOT tear down the caller-supplied transport
+        # that the original still depends on.
+        assert caller_transport.closed is False
+        # The original is still usable after the clone was closed.
+        assert original.readiness() == {"status": "ready"}
+    finally:
+        original.close()
+    # The original owns the caller transport and closes it on its own close.
+    assert caller_transport.closed is True
+
+
+def test_smaller_timeout_clone_still_routes_through_shared_transport() -> None:
+    seen: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.extensions.get("timeout", {}))
+        return httpx.Response(200, json={"status": "ready"})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient(
+        "http://example.test", transport=transport, timeout=30.0, max_retries=0
+    ) as original:
+        # Smaller timeout -> independent clone, but it must still reuse the
+        # (mock) transport, applying the tighter transport-level timeout.
+        clone = original.with_options(timeout=1.0)
+        assert clone.readiness() == {"status": "ready"}
+        clone.close()
+    assert seen and seen[0]["connect"] == 1.0


### PR DESCRIPTION
## Summary

Pre-release audit follow-ups for efficiency and resource handling on the data plane (#131).

### AUD-157 (S2) — GeoDataFrame conversion boxed a pandas Series per row
`geodataframe_to_features` and `geodataframe_to_geojson` looped `for idx in range(len(gdf)): row = gdf.iloc[idx]`, boxing a pandas `Series` per row — a CPU/allocation cliff feeding bulk `apply_edits`. Both now build attribute records **columnar** (`gdf[attr_columns].to_dict("records")`, one dict per row) plus a single geometry pass over `gdf.geometry.to_numpy()`. The geometry-only frame case (`to_dict` on an empty column selection returns `[]`) is handled explicitly so a row per geometry is still emitted.

### AUD-204 (S3) — unbounded seen-object-id set across all pages
The non-advancing-cursor guard in FeatureServer `query_pages`/`query_items` accumulated **every** object id seen across the whole walk (`seen_object_ids |= …`), defeating streaming. It now compares the current page's id-set against the **previous page only**, keeping the tracking set bounded to a single page while still stopping a server that ignores `resultOffset`.

### AUD-205 (S3) — `with_options`/`copy` clone reused a caller transport across two owning clients
A caller-supplied transport is owned by the original client. An independently-owned clone (`base_url` change, or a smaller `timeout`) reused the raw `self._init_transport`, so closing the clone tore down the shared connection pool the original still depends on. The clone now wraps the caller transport in a new `NonClosingTransport` / `AsyncNonClosingTransport` (added to `honua_sdk.http`), so it **reuses** the transport (preserving custom transports and applying the tighter transport-level timeout) **without closing it**. When no transport was supplied the clone builds its own. Applied to both the data-plane and the admin client (same mirror code).

## Testing
New `tests/test_audit_resource_lifecycle.py` covers columnar conversion (including geometry-only and null-geometry frames), the bounded non-advancing-cursor guard (stops on a non-advancing server, still walks an advancing one), and clone close-isolation (the caller transport is not torn down by `clone.close()`, and a smaller-timeout clone still routes through the shared transport with the tighter timeout). `ruff check .`, `mypy`, `python scripts/gen_sync.py --check`, `python scripts/compatibility_gate.py`, and the full `pytest` suite with `--cov-fail-under=94` (94.70%) all pass.

Closes #131