### PR TITLE
fix(grpc,retry): refresh gRPC auth per call; release pooled conn during backoff

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -5683,7 +5683,7 @@
           },
           "module": "honua_sdk.grpc._client",
           "qualname": "HonuaGrpcAsyncClient",
-          "signature": "(target: 'str', *, channel: 'grpc.aio.Channel | None' = None, credentials: 'grpc.ChannelCredentials | None' = None, insecure: 'bool' = False, metadata: 'list[tuple[str, str]] | None' = None, timeout: 'float | None' = 30.0, compression: 'grpc.Compression | None' = <Compression.Gzip: 2>) -> 'None'"
+          "signature": "(target: 'str', *, channel: 'grpc.aio.Channel | None' = None, credentials: 'grpc.ChannelCredentials | None' = None, insecure: 'bool' = False, metadata: 'list[tuple[str, str]] | None' = None, auth_provider: 'AuthProvider | None' = None, timeout: 'float | None' = 30.0, compression: 'grpc.Compression | None' = <Compression.Gzip: 2>) -> 'None'"
         },
         "HonuaGrpcClient": {
           "kind": "class",
@@ -5703,7 +5703,7 @@
           },
           "module": "honua_sdk.grpc._client",
           "qualname": "HonuaGrpcClient",
-          "signature": "(target: 'str', *, channel: 'grpc.Channel | None' = None, credentials: 'grpc.ChannelCredentials | None' = None, insecure: 'bool' = False, metadata: 'list[tuple[str, str]] | None' = None, timeout: 'float | None' = 30.0, compression: 'grpc.Compression | None' = <Compression.Gzip: 2>) -> 'None'"
+          "signature": "(target: 'str', *, channel: 'grpc.Channel | None' = None, credentials: 'grpc.ChannelCredentials | None' = None, insecure: 'bool' = False, metadata: 'list[tuple[str, str]] | None' = None, auth_provider: 'AuthProvider | None' = None, timeout: 'float | None' = 30.0, compression: 'grpc.Compression | None' = <Compression.Gzip: 2>) -> 'None'"
         },
         "HonuaGrpcError": {
           "kind": "class",

--- a/packages/honua-sdk/honua_sdk/_async_retry.py
+++ b/packages/honua-sdk/honua_sdk/_async_retry.py
@@ -161,12 +161,15 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
                 return response
 
             delay = self._compute_delay(response, attempt)
-            await asyncio.sleep(delay)
 
-            # Read and close the unsuccessful response before retrying so the
-            # underlying connection is released.
+            # Read and close the unsuccessful response BEFORE sleeping so the
+            # underlying connection is returned to the pool during the backoff
+            # window. Holding it across the sleep would tie up pooled capacity
+            # under a 429/503 storm exactly when the server is already degraded.
             await response.aread()
             await response.aclose()
+
+            await asyncio.sleep(delay)
 
             retries_remaining -= 1
             attempt += 1

--- a/packages/honua-sdk/honua_sdk/_retry.py
+++ b/packages/honua-sdk/honua_sdk/_retry.py
@@ -163,12 +163,15 @@ class RetryTransport(httpx.BaseTransport):
                 return response
 
             delay = self._compute_delay(response, attempt)
-            time.sleep(delay)
 
-            # Read and close the unsuccessful response before retrying so the
-            # underlying connection is released.
+            # Read and close the unsuccessful response BEFORE sleeping so the
+            # underlying connection is returned to the pool during the backoff
+            # window. Holding it across the sleep would tie up pooled capacity
+            # under a 429/503 storm exactly when the server is already degraded.
             response.read()
             response.close()
+
+            time.sleep(delay)
 
             retries_remaining -= 1
             attempt += 1

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -842,10 +842,14 @@ class AsyncHonuaClient:
         from .grpc import HonuaGrpcAsyncClient, build_grpc_metadata
 
         resolved_target = target or _grpc_target_from_base_url(self._base_url)
+        # Build only the static metadata (api-key / bearer / extra) here. Any
+        # auth_provider is handed to the gRPC client so it is re-consulted per
+        # RPC (awaiting ``auth_headers_async`` when available) -- otherwise a
+        # refreshable bearer token would be frozen at channel creation, and an
+        # async-only provider would raise AttributeError on the sync resolve.
         metadata = build_grpc_metadata(
             api_key=self._init_api_key,
             bearer_token=self._init_bearer_token,
-            auth_provider=self._init_auth_provider,
             extra_metadata=extra_metadata,
         )
         use_insecure = insecure if insecure is not None else (self._base_url.scheme != "https")
@@ -858,6 +862,7 @@ class AsyncHonuaClient:
             credentials=credentials,
             insecure=use_insecure,
             metadata=metadata,
+            auth_provider=self._init_auth_provider,
             timeout=timeout,
         )
 

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -843,10 +843,13 @@ class HonuaClient:
         from .grpc import HonuaGrpcClient, build_grpc_metadata
 
         resolved_target = target or _grpc_target_from_base_url(self._base_url)
+        # Build only the static metadata (api-key / bearer / extra) here. Any
+        # auth_provider is handed to the gRPC client so it is re-consulted per
+        # RPC -- otherwise a refreshable bearer token would be frozen at channel
+        # creation and every call would fail once it expired.
         metadata = build_grpc_metadata(
             api_key=self._init_api_key,
             bearer_token=self._init_bearer_token,
-            auth_provider=self._init_auth_provider,
             extra_metadata=extra_metadata,
         )
         use_insecure = insecure if insecure is not None else (self._base_url.scheme != "https")
@@ -859,6 +862,7 @@ class HonuaClient:
             credentials=credentials,
             insecure=use_insecure,
             metadata=metadata,
+            auth_provider=self._init_auth_provider,
             timeout=timeout,
         )
 

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -845,8 +845,9 @@ class HonuaClient:
         resolved_target = target or _grpc_target_from_base_url(self._base_url)
         # Build only the static metadata (api-key / bearer / extra) here. Any
         # auth_provider is handed to the gRPC client so it is re-consulted per
-        # RPC -- otherwise a refreshable bearer token would be frozen at channel
-        # creation and every call would fail once it expired.
+        # RPC (awaiting ``auth_headers_async`` when available) -- otherwise a
+        # refreshable bearer token would be frozen at channel creation, and an
+        # async-only provider would raise AttributeError on the sync resolve.
         metadata = build_grpc_metadata(
             api_key=self._init_api_key,
             bearer_token=self._init_bearer_token,

--- a/packages/honua-sdk/honua_sdk/grpc/_client.py
+++ b/packages/honua-sdk/honua_sdk/grpc/_client.py
@@ -5,7 +5,11 @@ from collections.abc import Iterator, Mapping
 
 import grpc
 
-from honua_sdk._http import _build_sensitive_auth_headers, _validate_auth_configuration
+from honua_sdk._http import (
+    _build_sensitive_auth_headers,
+    _resolve_dynamic_auth_headers_async,
+    _validate_auth_configuration,
+)
 from honua_sdk.auth import AuthProvider, normalize_auth_headers
 from honua_sdk.errors import HonuaGrpcError
 
@@ -20,15 +24,58 @@ def build_grpc_metadata(
     auth_provider: AuthProvider | None = None,
     extra_metadata: Mapping[str, str] | None = None,
 ) -> list[tuple[str, str]]:
-    """Build gRPC metadata entries from SDK auth options."""
+    """Build gRPC metadata entries from SDK auth options.
+
+    When ``auth_provider`` is supplied its headers are resolved synchronously
+    *once*, so the returned list is a static snapshot. Refreshable providers
+    are renewed per call only when the provider is passed to the gRPC client
+    (see :meth:`HonuaGrpcClient` / :meth:`HonuaGrpcAsyncClient`), which consult
+    it on every RPC. An async-only provider (one exposing ``auth_headers_async``
+    but no synchronous ``auth_headers``) cannot be resolved here and raises a
+    clear ``ValueError`` rather than an opaque ``AttributeError``.
+    """
     _validate_auth_configuration(bearer_token=bearer_token, auth_provider=auth_provider)
     headers = _build_sensitive_auth_headers(api_key=api_key, bearer_token=bearer_token)
     if auth_provider is not None:
-        for name, value in normalize_auth_headers(auth_provider.auth_headers()).items():
+        for name, value in _provider_auth_headers_sync(auth_provider).items():
             headers.setdefault(name, value)
     if extra_metadata:
         headers.update(extra_metadata)
     return [(name.lower(), value) for name, value in headers.items()]
+
+
+def _provider_auth_headers_sync(auth_provider: AuthProvider) -> dict[str, str]:
+    """Resolve an auth provider's headers synchronously, rejecting async-only ones."""
+    sync_getter = getattr(auth_provider, "auth_headers", None)
+    if sync_getter is None:
+        raise ValueError(
+            "auth_provider exposes only `auth_headers_async`; it cannot be resolved "
+            "on the synchronous gRPC path. Use a synchronous AuthProvider here, or "
+            "construct the client via the AsyncHonuaClient.grpc() surface, which "
+            "resolves async providers per call without blocking the event loop."
+        )
+    return normalize_auth_headers(sync_getter())
+
+
+def _merge_provider_metadata(
+    static_metadata: list[tuple[str, str]],
+    provider_headers: Mapping[str, str],
+) -> list[tuple[str, str]]:
+    """Merge per-call provider headers under static metadata (static wins on dupes).
+
+    Mirrors the ``setdefault`` precedence of :func:`build_grpc_metadata`: the
+    static api-key/bearer/``extra_metadata`` entries take precedence, and the
+    refreshable provider only fills metadata keys not already present.
+    """
+    if not provider_headers:
+        return static_metadata
+    present = {name for name, _ in static_metadata}
+    merged = list(static_metadata)
+    for name, value in provider_headers.items():
+        lowered = name.lower()
+        if lowered not in present:
+            merged.append((lowered, value))
+    return merged
 
 
 class HonuaGrpcClient:
@@ -42,10 +89,12 @@ class HonuaGrpcClient:
         credentials: grpc.ChannelCredentials | None = None,
         insecure: bool = False,
         metadata: list[tuple[str, str]] | None = None,
+        auth_provider: AuthProvider | None = None,
         timeout: float | None = 30.0,
         compression: grpc.Compression | None = grpc.Compression.Gzip,
     ) -> None:
         self._metadata = metadata or []
+        self._auth_provider = auth_provider
         self._timeout = timeout
         self._owns_channel = channel is None
 
@@ -75,6 +124,19 @@ class HonuaGrpcClient:
         if self._owns_channel:
             self._channel.close()
 
+    def _request_metadata(self) -> list[tuple[str, str]]:
+        """Resolve per-call metadata, re-consulting any auth provider each RPC.
+
+        Resolving the provider on every call means a refreshable bearer token is
+        renewed when it nears expiry instead of being frozen at channel-creation
+        time (the static-snapshot behaviour of a bare ``metadata=`` list).
+        """
+        if self._auth_provider is None:
+            return self._metadata
+        return _merge_provider_metadata(
+            self._metadata, _provider_auth_headers_sync(self._auth_provider)
+        )
+
     def query_features(
         self, request: models.QueryFeaturesRequest
     ) -> models.QueryFeaturesResponse:
@@ -83,7 +145,7 @@ class HonuaGrpcClient:
         try:
             proto_response = self._stub.QueryFeatures(
                 proto_request,
-                metadata=self._metadata,
+                metadata=self._request_metadata(),
                 timeout=self._timeout,
             )
         except grpc.RpcError as e:
@@ -98,7 +160,7 @@ class HonuaGrpcClient:
         try:
             stream = self._stub.QueryFeaturesStream(
                 proto_request,
-                metadata=self._metadata,
+                metadata=self._request_metadata(),
                 timeout=self._timeout,
             )
             for page in stream:
@@ -120,10 +182,12 @@ class HonuaGrpcAsyncClient:
         credentials: grpc.ChannelCredentials | None = None,
         insecure: bool = False,
         metadata: list[tuple[str, str]] | None = None,
+        auth_provider: AuthProvider | None = None,
         timeout: float | None = 30.0,
         compression: grpc.Compression | None = grpc.Compression.Gzip,
     ) -> None:
         self._metadata = metadata or []
+        self._auth_provider = auth_provider
         self._timeout = timeout
         self._owns_channel = channel is None
 
@@ -153,6 +217,19 @@ class HonuaGrpcAsyncClient:
         if self._owns_channel:
             await self._channel.close()
 
+    async def _request_metadata(self) -> list[tuple[str, str]]:
+        """Resolve per-call metadata without blocking the event loop.
+
+        Prefers an awaitable ``auth_headers_async`` (an async-only provider
+        works here) and re-consults the provider each RPC, so a refreshable
+        bearer token is renewed near expiry rather than frozen at channel
+        creation.
+        """
+        if self._auth_provider is None:
+            return self._metadata
+        provider_headers = await _resolve_dynamic_auth_headers_async(self._auth_provider)
+        return _merge_provider_metadata(self._metadata, provider_headers)
+
     async def query_features(
         self, request: models.QueryFeaturesRequest
     ) -> models.QueryFeaturesResponse:
@@ -161,7 +238,7 @@ class HonuaGrpcAsyncClient:
         try:
             proto_response = await self._stub.QueryFeatures(
                 proto_request,
-                metadata=self._metadata,
+                metadata=await self._request_metadata(),
                 timeout=self._timeout,
             )
         except grpc.aio.AioRpcError as e:
@@ -173,10 +250,11 @@ class HonuaGrpcAsyncClient:
     ):  # -> AsyncIterator[models.FeaturePage]
         """Execute a streaming feature query, yielding one page at a time."""
         proto_request = adapter.to_proto_request(request)
+        metadata = await self._request_metadata()
         try:
             stream = self._stub.QueryFeaturesStream(
                 proto_request,
-                metadata=self._metadata,
+                metadata=metadata,
                 timeout=self._timeout,
             )
             async for page in stream:

--- a/tests/grpc_sdk/test_grpc_client.py
+++ b/tests/grpc_sdk/test_grpc_client.py
@@ -474,6 +474,118 @@ class TestAsyncClient:
 
 
 # ---------------------------------------------------------------------------
+# Per-call auth metadata resolution
+# ---------------------------------------------------------------------------
+
+
+class _RotatingAuthProvider:
+    """Sync provider whose token changes on every resolve (refresh stand-in)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def auth_headers(self) -> dict[str, str]:
+        self.calls += 1
+        return {"Authorization": f"Bearer token-{self.calls}"}
+
+
+class _AsyncOnlyAuthProvider:
+    """Provider that exposes only ``auth_headers_async`` (no sync surface)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def auth_headers_async(self) -> dict[str, str]:
+        self.calls += 1
+        return {"Authorization": f"Bearer async-{self.calls}"}
+
+
+class TestPerCallAuthMetadata:
+    """The gRPC clients must re-consult an auth provider on every RPC.
+
+    Baking the metadata once at channel creation froze a refreshable bearer
+    token, so every call failed once it expired, and an async-only provider
+    raised ``AttributeError`` on the sync resolve.
+    """
+
+    def test_build_grpc_metadata_rejects_async_only_provider(self) -> None:
+        with pytest.raises(ValueError, match="auth_headers_async"):
+            build_grpc_metadata(auth_provider=_AsyncOnlyAuthProvider())
+
+    def test_sync_client_resolves_provider_per_call(self) -> None:
+        provider = _RotatingAuthProvider()
+        channel = MagicMock()
+        with patch(
+            "honua_sdk.grpc._generated.honua.v1.feature_service_pb2_grpc.FeatureServiceStub"
+        ) as stub_cls:
+            mock_stub = MagicMock()
+            mock_stub.QueryFeatures.return_value = pb2.QueryFeaturesResponse()
+            stub_cls.return_value = mock_stub
+            client = HonuaGrpcClient(
+                "localhost:50051", channel=channel, auth_provider=provider
+            )
+
+        request = QueryFeaturesRequest(service_id="svc", layer_id=0)
+        client.query_features(request)
+        client.query_features(request)
+
+        first = mock_stub.QueryFeatures.call_args_list[0][1]["metadata"]
+        second = mock_stub.QueryFeatures.call_args_list[1][1]["metadata"]
+        assert ("authorization", "Bearer token-1") in first
+        assert ("authorization", "Bearer token-2") in second
+        assert provider.calls == 2
+        client.close()
+
+    def test_static_metadata_takes_precedence_over_provider(self) -> None:
+        provider = _RotatingAuthProvider()
+        channel = MagicMock()
+        with patch(
+            "honua_sdk.grpc._generated.honua.v1.feature_service_pb2_grpc.FeatureServiceStub"
+        ) as stub_cls:
+            mock_stub = MagicMock()
+            mock_stub.QueryFeatures.return_value = pb2.QueryFeaturesResponse()
+            stub_cls.return_value = mock_stub
+            client = HonuaGrpcClient(
+                "localhost:50051",
+                channel=channel,
+                metadata=[("authorization", "Bearer static")],
+                auth_provider=provider,
+            )
+
+        client.query_features(QueryFeaturesRequest(service_id="svc", layer_id=0))
+
+        metadata = mock_stub.QueryFeatures.call_args[1]["metadata"]
+        assert metadata == [("authorization", "Bearer static")]
+        client.close()
+
+    def test_async_client_resolves_async_only_provider_per_call(self) -> None:
+        provider = _AsyncOnlyAuthProvider()
+        channel = MagicMock()
+        with patch(
+            "honua_sdk.grpc._generated.honua.v1.feature_service_pb2_grpc.FeatureServiceStub"
+        ) as stub_cls:
+            mock_stub = MagicMock()
+            mock_stub.QueryFeatures = AsyncMock(return_value=pb2.QueryFeaturesResponse())
+            stub_cls.return_value = mock_stub
+            client = HonuaGrpcAsyncClient(
+                "localhost:50051", channel=channel, auth_provider=provider
+            )
+
+        async def _run() -> None:
+            request = QueryFeaturesRequest(service_id="svc", layer_id=0)
+            await client.query_features(request)
+            await client.query_features(request)
+
+        asyncio.run(_run())
+
+        first = mock_stub.QueryFeatures.call_args_list[0][1]["metadata"]
+        second = mock_stub.QueryFeatures.call_args_list[1][1]["metadata"]
+        assert ("authorization", "Bearer async-1") in first
+        assert ("authorization", "Bearer async-2") in second
+        assert provider.calls == 2
+
+
+# ---------------------------------------------------------------------------
 # HonuaGrpcError
 # ---------------------------------------------------------------------------
 

--- a/tests/test_retry_hardening.py
+++ b/tests/test_retry_hardening.py
@@ -161,6 +161,41 @@ def test_transport_exception_exhausts_and_reraises() -> None:
     assert transport._call_count["n"] == 4  # type: ignore[attr-defined]
 
 
+def _instrument_response(response: httpx.Response, events: list[str]) -> httpx.Response:
+    """Record ``read``/``close`` calls on *response* into *events* (sync)."""
+    orig_read, orig_close = response.read, response.close
+
+    def _read() -> bytes:
+        events.append("read")
+        return orig_read()
+
+    def _close() -> None:
+        events.append("close")
+        orig_close()
+
+    response.read = _read  # type: ignore[method-assign]
+    response.close = _close  # type: ignore[method-assign]
+    return response
+
+
+def test_failed_response_released_before_backoff_sleep() -> None:
+    """A retriable response must be read+closed before the backoff sleep.
+
+    Sleeping while still holding the unread failed response keeps its pooled
+    connection checked out for the whole backoff window, starving the pool
+    during a 429/503 storm.
+    """
+    events: list[str] = []
+    failed = _instrument_response(httpx.Response(503), events)
+    transport = _build_exception_transport([failed, httpx.Response(200, json={"ok": True})])
+
+    with patch("honua_sdk._retry.time.sleep", side_effect=lambda _d: events.append("sleep")):
+        response = transport.handle_request(httpx.Request("GET", "http://example.test/"))
+
+    assert response.status_code == 200
+    assert events == ["read", "close", "sleep"]
+
+
 # ---------------------------------------------------------------------------
 # Transport-exception retry coverage (async)
 # ---------------------------------------------------------------------------
@@ -227,6 +262,41 @@ def test_async_retries_on_read_error() -> None:
 
 async def _noop_async_sleep(_delay: float) -> None:
     return None
+
+
+def test_async_failed_response_released_before_backoff_sleep() -> None:
+    """Async variant of the read/close-before-sleep ordering guarantee."""
+    events: list[str] = []
+    failed = httpx.Response(503)
+    orig_aread, orig_aclose = failed.aread, failed.aclose
+
+    async def _aread() -> bytes:
+        events.append("read")
+        return await orig_aread()
+
+    async def _aclose() -> None:
+        events.append("close")
+        await orig_aclose()
+
+    failed.aread = _aread  # type: ignore[method-assign]
+    failed.aclose = _aclose  # type: ignore[method-assign]
+
+    async def _sleep(_delay: float) -> None:
+        events.append("sleep")
+
+    transport = _build_async_exception_transport(
+        [failed, httpx.Response(200, json={"ok": True})]
+    )
+
+    async def _run() -> httpx.Response:
+        with patch("honua_sdk._async_retry.asyncio.sleep", new=_sleep):
+            return await transport.handle_async_request(
+                httpx.Request("GET", "http://example.test/")
+            )
+
+    response = asyncio.run(_run())
+    assert response.status_code == 200
+    assert events == ["read", "close", "sleep"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Round-2 audit fixes (S2) for the gRPC client auth path and the retry transports. No issue numbers — new findings, referenced below by file:line.

## gRPC auth metadata resolved per RPC (`grpc/_client.py`, `client.py`/`async_client.py` `grpc()`)

Two related S2 correctness findings:

- **Static token snapshot — refreshable tokens never refresh** (`grpc/_client.py:48`; metadata built once at `client.py:846` / `async_client.py:845`). `build_grpc_metadata()` was called once and the resolved auth headers baked into a static list reused on every `QueryFeatures`/`QueryFeaturesStream` call. A `RefreshableBearerTokenProvider` was frozen at `.grpc()` time, so once its token expired every gRPC call failed and the provider was never re-consulted — a silent divergence from the per-request resolution on the REST surface.
- **`AsyncHonuaClient.grpc()` crashes with an async-only provider** (`grpc/_client.py:27`). The sync `build_grpc_metadata()` called `auth_provider.auth_headers()`, which an `AsyncRefreshableBearerTokenProvider` (only `auth_headers_async`) does not define → `AttributeError`.

**Fix:** the gRPC clients now take the `auth_provider` and resolve it **per RPC**. The sync client calls `auth_headers()` each call; the async client awaits `_resolve_dynamic_auth_headers_async` (preferring `auth_headers_async`, so an async-only provider works and a blocking refresh runs off the event loop). Static api-key/bearer/`extra_metadata` keep precedence over provider headers (same `setdefault` semantics as before). `build_grpc_metadata` now raises a clear `ValueError` instead of `AttributeError` when handed an async-only provider directly.

## Retry transports release the failed connection before backoff (`_retry.py:166`, `_async_retry.py:164`)

On a retriable status (429/502/503/504) the transports computed the delay, slept the backoff, and only then `read()`/`close()`d the failed response — contradicting the inline comment and keeping the pooled connection checked out for the whole backoff window. Under a 429/503 storm every in-flight retry held its connection during its sleep, sharply reducing pool capacity exactly when the server is already degraded. **Fix:** read+close the failed response *before* sleeping; same reorder on the async transport.

## Tests
- `tests/grpc_sdk/test_grpc_client.py`: provider re-consulted per call (sync + async-only), static metadata precedence, `build_grpc_metadata` rejects async-only provider.
- `tests/test_retry_hardening.py`: read/close-before-sleep ordering (sync + async).
- Refreshed `compatibility/public-api.json` for the additive `auth_provider=` kwarg.

Full suite (`pytest tests/ -q`), ruff, mypy, and the compatibility gate pass locally.