### PR TITLE
fix(query): honour max_pages=None as unbounded; re-wind GeoJSON spatial-filter rings

### DIFF
--- a/packages/honua-sdk/honua_sdk/_geoservices_query.py
+++ b/packages/honua-sdk/honua_sdk/_geoservices_query.py
@@ -150,6 +150,43 @@ def _esri_geometry_type(geometry: Mapping[str, Any]) -> str:
     )
 
 
+def _ring_signed_area(ring: Sequence[Sequence[Any]]) -> float:
+    """Shoelace signed area in the X/Y plane (positive == counter-clockwise)."""
+    area = 0.0
+    count = len(ring)
+    for idx in range(count):
+        x1, y1 = float(ring[idx][0]), float(ring[idx][1])
+        x2, y2 = float(ring[(idx + 1) % count][0]), float(ring[(idx + 1) % count][1])
+        area += x1 * y2 - x2 * y1
+    return area / 2.0
+
+
+def _esri_ring(ring: Sequence[Sequence[Any]], *, exterior: bool) -> list[list[Any]]:
+    """Copy a GeoJSON ring with Esri winding (CW exterior, CCW holes).
+
+    GeoJSON (RFC 7946) winds exterior rings counter-clockwise and holes
+    clockwise; Esri JSON uses the OPPOSITE convention and infers a ring's role
+    (shell vs hole) from its winding. Emitting GeoJSON coordinates verbatim
+    therefore makes an Esri-conformant server read a CCW exterior as a hole,
+    yielding an inverted/empty spatial filter and silently wrong query results.
+
+    The ring's structural role is taken from its position (the first ring of a
+    polygon part is the exterior), and the vertices are reversed when the
+    current winding does not match the Esri convention. This mirrors the
+    orientation the geopandas/models export path applies via shapely
+    ``orient(geom, sign=-1.0)``.
+    """
+    coords = [list(c) for c in ring]
+    area = _ring_signed_area(coords)
+    if area == 0.0:
+        return coords
+    is_ccw = area > 0
+    want_ccw = not exterior  # Esri: exteriors clockwise, holes counter-clockwise
+    if is_ccw != want_ccw:
+        coords.reverse()
+    return coords
+
+
 def _geojson_geometry_to_esri(geometry: Mapping[str, Any]) -> dict[str, Any]:
     gtype = str(geometry.get("type"))
     coords = geometry.get("coordinates")
@@ -166,12 +203,17 @@ def _geojson_geometry_to_esri(geometry: Mapping[str, Any]) -> dict[str, Any]:
     if gtype == "MultiLineString":
         return {"paths": [[list(c) for c in line] for line in coords or []]}
     if gtype == "Polygon":
-        return {"rings": [[list(c) for c in ring] for ring in coords or []]}
+        return {
+            "rings": [
+                _esri_ring(ring, exterior=(idx == 0))
+                for idx, ring in enumerate(coords or [])
+            ]
+        }
     if gtype == "MultiPolygon":
         rings: list[list[list[float]]] = []
         for polygon in coords or []:
-            for ring in polygon:
-                rings.append([list(c) for c in ring])
+            for idx, ring in enumerate(polygon):
+                rings.append(_esri_ring(ring, exterior=(idx == 0)))
         return {"rings": rings}
     raise ValueError(f"Unsupported GeoJSON geometry type: {gtype!r}.")
 

--- a/packages/honua-sdk/honua_sdk/ogc.py
+++ b/packages/honua-sdk/honua_sdk/ogc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import itertools
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import Any, cast
 from urllib.parse import parse_qsl, urlsplit
@@ -122,10 +123,20 @@ def _normalize_page_size(page_size: int | None, limit: int | None) -> int:
     return 100
 
 
-def _normalize_max_pages(max_pages: int | None) -> int:
-    if isinstance(max_pages, int) and max_pages > 0:
-        return max_pages
-    return 100
+def _iter_page_indices(max_pages: int | None) -> Iterator[int]:
+    """Yield page indices for a pagination loop, honouring an unbounded cap.
+
+    ``max_pages=None`` means *unbounded* -- the loop walks every page the server
+    advertises (the next-link / short-page guard is what stops it), matching the
+    FeatureServer walker. Previously ``None`` was silently capped at 100 pages,
+    quietly truncating results when the server still advertised a ``rel=next``.
+    A positive ``int`` caps the walk; ``max_pages <= 0`` yields nothing.
+    """
+    if max_pages is None:
+        return itertools.count()
+    if max_pages <= 0:
+        return iter(())
+    return iter(range(max_pages))
 
 
 def _normalize_offset(offset: int | None) -> int:
@@ -610,7 +621,6 @@ class HonuaOgcFeatureCollection:
         extra_headers: Mapping[str, str] | None = None,
     ) -> Iterator[JsonObject]:
         effective_page_size = _normalize_page_size(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         start_offset = _normalize_offset(offset)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
@@ -618,7 +628,7 @@ class HonuaOgcFeatureCollection:
 
         fetched = 0
         next_href: str | None = None
-        for page in range(effective_max_pages):
+        for page in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break
@@ -1268,7 +1278,6 @@ class AsyncHonuaOgcFeatureCollection:
         extra_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[JsonObject]:
         effective_page_size = _normalize_page_size(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         start_offset = _normalize_offset(offset)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
@@ -1276,7 +1285,7 @@ class AsyncHonuaOgcFeatureCollection:
 
         fetched = 0
         next_href: str | None = None
-        for page in range(effective_max_pages):
+        for page in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break

--- a/packages/honua-sdk/honua_sdk/protocols/odata.py
+++ b/packages/honua-sdk/honua_sdk/protocols/odata.py
@@ -15,8 +15,8 @@ from ._base import (
     ODataQuery,
     Params,
     _AsyncProtocol,
+    _iter_page_indices,
     _next_link,
-    _normalize_max_pages,
     _normalize_page_limit,
     _normalize_total_limit,
     _odata_params,
@@ -367,7 +367,6 @@ class ODataClient(_SyncProtocol):
         extra_headers: Mapping[str, str] | None = None,
     ) -> Iterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -375,7 +374,7 @@ class ODataClient(_SyncProtocol):
         fetched = 0
         next_href: str | None = None
         skip = int((extra_params or {}).get("$skip", 0))
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break
@@ -748,7 +747,6 @@ class AsyncODataClient(_AsyncProtocol):
         extra_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -756,7 +754,7 @@ class AsyncODataClient(_AsyncProtocol):
         fetched = 0
         next_href: str | None = None
         skip = int((extra_params or {}).get("$skip", 0))
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break

--- a/packages/honua-sdk/honua_sdk/protocols/ogc_extras.py
+++ b/packages/honua-sdk/honua_sdk/protocols/ogc_extras.py
@@ -18,8 +18,8 @@ from ._base import (
     _AsyncProtocol,
     _bbox,
     _csv,
+    _iter_page_indices,
     _next_link,
-    _normalize_max_pages,
     _normalize_page_limit,
     _normalize_total_limit,
     _ogc_collection_path,
@@ -657,7 +657,6 @@ class OgcRecordsCollectionClient:
         type: str | None = None,
     ) -> Iterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -665,7 +664,7 @@ class OgcRecordsCollectionClient:
         fetched = 0
         next_href: str | None = None
         current_offset = 0 if offset is None else max(0, offset)
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break
@@ -939,7 +938,6 @@ class AsyncOgcRecordsCollectionClient:
         type: str | None = None,
     ) -> AsyncIterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -947,7 +945,7 @@ class AsyncOgcRecordsCollectionClient:
         fetched = 0
         next_href: str | None = None
         current_offset = 0 if offset is None else max(0, offset)
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break

--- a/packages/honua-sdk/honua_sdk/protocols/stac.py
+++ b/packages/honua-sdk/honua_sdk/protocols/stac.py
@@ -17,9 +17,9 @@ from ._base import (
     Params,
     _AsyncProtocol,
     _features_from_page,
+    _iter_page_indices,
     _next_link,
     _next_link_object,
-    _normalize_max_pages,
     _normalize_page_limit,
     _normalize_total_limit,
     _params,
@@ -99,7 +99,6 @@ class StacClient(_SyncProtocol):
         extra_headers: Mapping[str, str] | None = None,
     ) -> Iterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -107,7 +106,7 @@ class StacClient(_SyncProtocol):
         fetched = 0
         next_href: str | None = None
         offset = int((extra_params or {}).get("offset", 0))
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break
@@ -229,7 +228,6 @@ class StacClient(_SyncProtocol):
         extra_headers: Mapping[str, str] | None = None,
     ) -> Iterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -238,7 +236,7 @@ class StacClient(_SyncProtocol):
         next_link: Mapping[str, Any] | None = None
         next_href: str | None = None
         offset = int((params or json_body or {}).get("offset", 0))
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break
@@ -371,7 +369,6 @@ class AsyncStacClient(_AsyncProtocol):
         extra_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -379,7 +376,7 @@ class AsyncStacClient(_AsyncProtocol):
         fetched = 0
         next_href: str | None = None
         offset = int((extra_params or {}).get("offset", 0))
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break
@@ -502,7 +499,6 @@ class AsyncStacClient(_AsyncProtocol):
         extra_headers: Mapping[str, str] | None = None,
     ) -> AsyncIterator[JsonObject]:
         effective_page_size = _normalize_page_limit(page_size, limit)
-        effective_max_pages = _normalize_max_pages(max_pages)
         total_limit = _normalize_total_limit(limit)
         if total_limit == 0:
             return
@@ -511,7 +507,7 @@ class AsyncStacClient(_AsyncProtocol):
         next_link: Mapping[str, Any] | None = None
         next_href: str | None = None
         offset = int((params or json_body or {}).get("offset", 0))
-        for _ in range(effective_max_pages):
+        for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
                 break

--- a/tests/test_gp_query_parity.py
+++ b/tests/test_gp_query_parity.py
@@ -75,6 +75,34 @@ def test_coerce_geometry_geojson_polygon() -> None:
     assert geometry == {"rings": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
 
 
+def test_geojson_polygon_spatial_filter_orients_rings_to_esri_winding() -> None:
+    """An RFC 7946 GeoJSON polygon (CCW exterior, CW hole) must be re-wound to
+    the Esri convention (CW exterior, CCW hole). Emitting it verbatim would make
+    an Esri-conformant server read the exterior as a hole -> inverted/empty
+    filter and silently wrong results."""
+    geojson = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]],  # CCW exterior
+            [[1, 1], [1, 2], [2, 2], [2, 1], [1, 1]],  # CW hole
+        ],
+    }
+    geometry, gtype = coerce_geometry(geojson)
+    assert gtype == "esriGeometryPolygon"
+    # Exterior re-wound clockwise, hole re-wound counter-clockwise.
+    assert geometry["rings"][0] == [[0, 0], [0, 3], [3, 3], [3, 0], [0, 0]]
+    assert geometry["rings"][1] == [[1, 1], [2, 1], [2, 2], [1, 2], [1, 1]]
+
+
+def test_geojson_multipolygon_spatial_filter_orients_each_part() -> None:
+    geojson = {
+        "type": "MultiPolygon",
+        "coordinates": [[[[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]]]],  # CCW exterior
+    }
+    geometry, _ = coerce_geometry(geojson)
+    assert geometry["rings"] == [[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]]
+
+
 def test_coerce_geometry_geojson_point_with_z() -> None:
     geometry, gtype = coerce_geometry({"type": "Point", "coordinates": [1, 2, 3]})
     assert gtype == "esriGeometryPoint"

--- a/tests/test_ogc_coverage_uplift.py
+++ b/tests/test_ogc_coverage_uplift.py
@@ -20,8 +20,8 @@ from honua_sdk import HonuaClient
 from honua_sdk.async_client import AsyncHonuaClient
 from honua_sdk.ogc import (
     _features_from_collection,
+    _iter_page_indices,
     _next_link,
-    _normalize_max_pages,
     _normalize_offset,
     _normalize_page_size,
     _normalize_total_limit,
@@ -82,10 +82,15 @@ class TestPrivateHelpers:
         assert _normalize_page_size(0, None) == 100
         assert _normalize_page_size(-5, None) == 100
 
-    def test_normalize_max_pages(self) -> None:
-        assert _normalize_max_pages(7) == 7
-        assert _normalize_max_pages(None) == 100
-        assert _normalize_max_pages(0) == 100
+    def test_iter_page_indices(self) -> None:
+        # A positive cap yields exactly that many 0-based indices.
+        assert list(_iter_page_indices(3)) == [0, 1, 2]
+        # Non-positive caps yield nothing.
+        assert list(_iter_page_indices(0)) == []
+        assert list(_iter_page_indices(-5)) == []
+        # ``None`` is unbounded (no silent 100-page cap); sample the prefix.
+        unbounded = _iter_page_indices(None)
+        assert [next(unbounded) for _ in range(150)] == list(range(150))
 
     def test_normalize_offset(self) -> None:
         assert _normalize_offset(None) == 0
@@ -292,6 +297,43 @@ def test_sync_items_pages_max_pages_cutoff() -> None:
 
     assert len(pages) == 2
     assert counter["n"] == 2
+
+
+def test_sync_items_pages_unbounded_walks_past_legacy_cap() -> None:
+    """``max_pages=None`` must walk every advertised page, not stop at 100.
+
+    The cursor-based walkers previously normalized ``None`` to a hard 100-page
+    cap and silently truncated, diverging from the FeatureServer walker (which
+    treats ``None`` as unbounded). Walking 150 advertised pages proves the cap
+    is gone.
+    """
+    total = 150
+    counter = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        counter["n"] += 1
+        if counter["n"] < total:
+            features = [{"id": counter["n"]}, {"id": counter["n"] + 1000}]
+            links = [{"rel": "next", "href": "/ogc/features/collections/parcels/items?cont"}]
+        else:
+            features = [{"id": counter["n"]}]  # short final page terminates the walk
+            links = []
+        return httpx.Response(
+            200,
+            json={"type": "FeatureCollection", "features": features, "links": links},
+        )
+
+    with HonuaClient(
+        "http://example.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        pages = list(
+            client.ogc_features()
+            .collection("parcels")
+            .items_pages(page_size=2, max_pages=None)
+        )
+
+    assert len(pages) == total
+    assert counter["n"] == total
 
 
 def test_sync_item_get_uses_crs_parameter() -> None:


### PR DESCRIPTION
Round-2 audit fixes (S2) for protocol query correctness. New findings — referenced by file:line.

## OGC Features / STAC / OData honour `max_pages=None` as unbounded

`ogc.py` `items_pages`, `protocols/stac.py` `item_pages`/`search_pages`, and `protocols/odata.py` walkers normalized `max_pages=None` to a hard **100-page cap** (`_normalize_max_pages`) and iterated `range(cap)`. A caller passing `max_pages=None` for an unbounded walk on these cursor-based protocols instead silently got at most 100 pages — even though the server still advertised `rel=next` / `@odata.nextLink`. The truncation was silent: the FeatureServer dispatch's `warn_if_truncated` returns early when `max_pages is None`, so no `ResourceWarning` fired.

This diverged from the FeatureServer walker, which treats `None` as unbounded via `_iter_page_indices` (`protocols/_base.py:264`). 

**Fix:** every cursor walker now uses `_iter_page_indices(max_pages)` — `None` is unbounded (the loop's own next-link / short-page guard terminates it), a positive `int` still caps, `<= 0` yields nothing. `ogc.py` (which carries its own copy of the paging helpers) gains a matching local `_iter_page_indices`, replacing its local `_normalize_max_pages`. The wrapper `query()`/`iter_query()` default (`max_pages=100`) is unchanged; only an explicit `None` is affected.

- `ogc.py:613/621`, `ogc.py:1271/1279`
- `protocols/stac.py` (4 walkers), `protocols/odata.py` (2 walkers), `protocols/ogc_extras.py` OGC Records (2 walkers)

## GeoJSON → Esri spatial-filter ring winding (`_geoservices_query.py:168`)

`_geojson_geometry_to_esri` copied GeoJSON Polygon/MultiPolygon coordinates verbatim into Esri JSON `rings`. GeoJSON (RFC 7946) winds exterior rings **CCW** and holes **CW**; Esri JSON uses the **opposite** convention and infers a ring's role (shell vs hole) from its winding. A GeoJSON/shapely polygon passed as `spatial_filter=` to `client.query`/`query_features` was thus emitted with a CCW exterior — read by an Esri-conformant server as a *hole*, producing an inverted/empty filter and silently wrong (often empty) results on a documented code path.

**Fix:** re-wind each ring to the Esri convention (CW exterior, CCW holes) by structural role — the same orientation the geopandas/models export path applies via shapely `orient(geom, sign=-1.0)`. Implemented as a pure-Python shoelace helper so the module stays dependency-free.

## Tests
- `tests/test_ogc_coverage_uplift.py`: `_iter_page_indices` unit test (incl. unbounded prefix) and an end-to-end `items_pages(max_pages=None)` walk past the legacy 100-page cap (150 pages).
- `tests/test_gp_query_parity.py`: GeoJSON Polygon (CCW exterior / CW hole) and MultiPolygon re-wound to Esri winding.

Full suite (`pytest tests/ -q`, 1313 passed), ruff, mypy, and the compatibility gate pass locally.