### PR TITLE
fix(sdk): cursor OID merge, async attachment I/O, link pagination, WFS-T, GeoServices error mapping (round-3 S2)

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -4612,7 +4612,7 @@
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaAuthError",
-          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None) -> 'None'"
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None) -> 'None'"
         },
         "HonuaCapabilityNotSupportedError": {
           "kind": "class",
@@ -4819,13 +4819,13 @@
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaHttpError",
-          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None) -> 'None'"
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None) -> 'None'"
         },
         "HonuaRateLimitError": {
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaRateLimitError",
-          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, retry_after: 'float | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None) -> 'None'"
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, retry_after: 'float | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None) -> 'None'"
         },
         "HonuaTimeoutError": {
           "kind": "class",

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -397,11 +397,85 @@ def raise_for_geoservices_error(response: httpx.Response, payload: Mapping[str, 
         except ValueError:
             body = payload
 
-    raise _build_http_error(
-        status_code=code,
+    raise _build_geoservices_error(
+        error_code=code,
         message=message,
         body=body,
         response=response,
+    )
+
+
+# Esri GeoServices auth/token error codes. These are an application code space,
+# NOT HTTP statuses: 498 = Invalid Token, 499 = Token Required, 403 = permission
+# denied. They must map to HonuaAuthError so ``except HonuaAuthError`` catches a
+# token-required rejection (which previously surfaced as a generic HonuaHttpError).
+_GEOSERVICES_AUTH_CODES = frozenset({401, 403, 498, 499})
+
+
+def _normalize_geoservices_status(error_code: int) -> int:
+    """Map a GeoServices envelope ``code`` onto a sane ``status_code`` surface.
+
+    GeoServices codes are an application code space, so an arbitrary code (e.g. a
+    large negative HRESULT-style value such as ``-2147217395``) must not be
+    surfaced verbatim as an HTTP ``status_code``. Codes that already fall in the
+    valid HTTP range are passed through; auth/token codes collapse to ``403``;
+    everything else normalizes to ``500`` (server-side failure). The original
+    code is always preserved on ``error_code``.
+    """
+    if error_code in _GEOSERVICES_AUTH_CODES:
+        return error_code if error_code in (401, 403) else 403
+    if 100 <= error_code <= 599:
+        return error_code
+    return 500
+
+
+def _build_geoservices_error(
+    *,
+    error_code: int,
+    message: str,
+    body: Any | None,
+    response: httpx.Response,
+) -> HonuaHttpError:
+    """Construct a Honua exception from an Esri GeoServices error envelope.
+
+    Chooses the exception subtype from a GeoServices-aware mapping (auth/token
+    codes -> :class:`HonuaAuthError`) rather than reinterpreting the envelope
+    code as an HTTP status, and records the original Esri code on ``error_code``.
+    """
+    request_id = (
+        response.headers.get("x-request-id")
+        or response.headers.get("honua-request-id")
+        or response.headers.get("x-correlation-id")
+    )
+    headers = dict(response.headers)
+    status_code = _normalize_geoservices_status(error_code)
+    if error_code in _GEOSERVICES_AUTH_CODES:
+        return HonuaAuthError(
+            status_code,
+            message,
+            body=body,
+            request_id=request_id,
+            headers=headers,
+            error_code=error_code,
+        )
+    if error_code == 429:
+        retry_after = _parse_retry_after(response.headers.get("retry-after"))
+        return HonuaRateLimitError(
+            status_code,
+            message,
+            body=body,
+            retry_after=retry_after,
+            request_id=request_id,
+            headers=headers,
+            error_code=error_code,
+        )
+    return HonuaHttpError(
+        status_code,
+        message,
+        body=body,
+        request_id=request_id,
+        headers=headers,
+        error_code=error_code,
     )
 
 

--- a/packages/honua-sdk/honua_sdk/cursors.py
+++ b/packages/honua-sdk/honua_sdk/cursors.py
@@ -273,7 +273,12 @@ class UpdateCursor(_BaseWriteCursor):
         merged = dict(row.feature.properties)
         if attributes:
             merged.update(attributes)
-        merged.setdefault("OBJECTID", object_id)
+        # Reuse whatever OID key the row already carries (server casing may be
+        # 'objectid' or 'objectId'); only add the canonical 'OBJECTID' when none
+        # of the recognized variants is present, so the applyEdits payload never
+        # ends up with two object-id-like keys for the same row.
+        if not any(key in merged for key in ("objectid", "objectId", "OBJECTID")):
+            merged["OBJECTID"] = object_id
         geom = geometry if geometry is not None else row.feature.geometry
         self._buffer.updates.append(_esri_feature_from(merged, geom))
         if self._buffer.pending >= self._buffer.batch_size:
@@ -438,7 +443,12 @@ class AsyncUpdateCursor(_BaseWriteCursor):
         merged = dict(row.feature.properties)
         if attributes:
             merged.update(attributes)
-        merged.setdefault("OBJECTID", object_id)
+        # Reuse whatever OID key the row already carries (server casing may be
+        # 'objectid' or 'objectId'); only add the canonical 'OBJECTID' when none
+        # of the recognized variants is present, so the applyEdits payload never
+        # ends up with two object-id-like keys for the same row.
+        if not any(key in merged for key in ("objectid", "objectId", "OBJECTID")):
+            merged["OBJECTID"] = object_id
         geom = geometry if geometry is not None else row.feature.geometry
         self._buffer.updates.append(_esri_feature_from(merged, geom))
 

--- a/packages/honua-sdk/honua_sdk/errors.py
+++ b/packages/honua-sdk/honua_sdk/errors.py
@@ -100,9 +100,14 @@ class HonuaHttpError(HonuaError):
             headers (``x-request-id`` / ``Honua-Request-Id`` /
             ``X-Correlation-ID``), or ``None`` when not present.
         headers: Full response headers as a plain ``dict[str, str]``.
+        error_code: The application-level error code reported by an Esri
+            GeoServices error envelope (e.g. ``498``/``499`` token errors), when
+            the failure originated from such an envelope. ``None`` for ordinary
+            transport-level HTTP failures. Distinct from ``status_code`` because
+            GeoServices codes are an application code space, not HTTP statuses.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 — kwarg-only fields surface server diagnostics
         self,
         status_code: int,
         message: str,
@@ -110,6 +115,7 @@ class HonuaHttpError(HonuaError):
         body: Any | None = None,
         request_id: str | None = None,
         headers: Mapping[str, str] | None = None,
+        error_code: int | None = None,
     ) -> None:
         super().__init__(f"HTTP {status_code}: {message}")
         self.status_code = status_code
@@ -117,6 +123,7 @@ class HonuaHttpError(HonuaError):
         self.body = body
         self.request_id = request_id
         self.headers: Mapping[str, str] = dict(headers) if headers is not None else {}
+        self.error_code = error_code
 
 
 class HonuaAuthError(HonuaHttpError):
@@ -163,6 +170,7 @@ class HonuaRateLimitError(HonuaHttpError):
         retry_after: float | None = None,
         request_id: str | None = None,
         headers: Mapping[str, str] | None = None,
+        error_code: int | None = None,
     ) -> None:
         super().__init__(
             status_code,
@@ -170,6 +178,7 @@ class HonuaRateLimitError(HonuaHttpError):
             body=body,
             request_id=request_id,
             headers=headers,
+            error_code=error_code,
         )
         self.retry_after = retry_after
 

--- a/packages/honua-sdk/honua_sdk/protocols/_base.py
+++ b/packages/honua-sdk/honua_sdk/protocols/_base.py
@@ -235,6 +235,28 @@ def _next_link_object(response: Mapping[str, Any]) -> Mapping[str, Any] | None:
     return None
 
 
+def _next_link_signature(next_link: Mapping[str, Any] | None, next_href: str | None) -> str | None:
+    """A stable signature for a STAC ``next`` link used to detect non-advancing cursors.
+
+    For STAC POST ``/search`` the continuation token lives in the link ``body``,
+    so two consecutive pages can share the same ``href`` while still advancing.
+    Fold the method/href/body into one comparable string so the pagination loop
+    only treats a page as non-advancing when the *entire* next link repeats.
+    Falls back to the bare ``href`` when no link object is available.
+    """
+    if next_link is None:
+        return next_href
+    method = str(next_link.get("method", "GET")).upper()
+    href = next_link.get("href")
+    href_str = href if isinstance(href, str) else (next_href or "")
+    body = next_link.get("body")
+    try:
+        body_sig = json.dumps(body, sort_keys=True, default=str) if body is not None else ""
+    except (TypeError, ValueError):
+        body_sig = repr(body)
+    return f"{method} {href_str} {body_sig}"
+
+
 def _path_and_params_from_href(href: str) -> tuple[str, dict[str, str]]:
     parsed = urlsplit(href)
     path = parsed.path or href

--- a/packages/honua-sdk/honua_sdk/protocols/geoservices.py
+++ b/packages/honua-sdk/honua_sdk/protocols/geoservices.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
+from functools import partial
 from typing import IO, Any, cast
 
 import httpx
+from anyio import to_thread
 
 from honua_sdk._http import _encode_path_segment
 from honua_sdk.models import Feature, FeatureSet, LayerSchema
@@ -1165,7 +1167,11 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         object, or raw ``bytes``. The returned ``object_id`` is the id of the
         newly created attachment.
         """
-        files = {"attachment": _attachment_multipart_file(file, content_type=content_type)}
+        # Offload the (blocking, whole-file) read to a worker thread so the
+        # event loop is not stalled for the duration of the disk read, mirroring
+        # _resolve_dynamic_auth_headers_async in _http.py.
+        part = await to_thread.run_sync(partial(_attachment_multipart_file, file, content_type=content_type))
+        files = {"attachment": part}
         data = {"f": "json"}
         if keywords is not None:
             data["keywords"] = keywords
@@ -1200,9 +1206,11 @@ class AsyncGeoServicesFeatureServerClient(_AsyncProtocol):
         data: dict[str, Any] = {"f": "json", "attachmentId": attachment_id}
         if keywords is not None:
             data["keywords"] = keywords
-        files = (
-            {"attachment": _attachment_multipart_file(file, content_type=content_type)} if file is not None else None
-        )
+        files = None
+        if file is not None:
+            # Offload the blocking read off the event loop (see add_attachment).
+            part = await to_thread.run_sync(partial(_attachment_multipart_file, file, content_type=content_type))
+            files = {"attachment": part}
         payload = await self._json(
             "POST",
             f"{self.path}/{layer_id}/{object_id}/updateAttachment",

--- a/packages/honua-sdk/honua_sdk/protocols/odata.py
+++ b/packages/honua-sdk/honua_sdk/protocols/odata.py
@@ -373,6 +373,7 @@ class ODataClient(_SyncProtocol):
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         skip = int((extra_params or {}).get("$skip", 0))
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -402,6 +403,13 @@ class ODataClient(_SyncProtocol):
             page_values = _values_from_page(page)
             fetched += len(page_values)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor: if the
+            # server keeps returning the same non-null next link, stop instead
+            # of fetching the same page forever (matches the FeatureServer
+            # query_pages id-subset guard).
+            if next_href is not None and next_href == previous_next_href:
+                return
+            previous_next_href = next_href
             if next_href is None:
                 if len(page_values) < page_limit:
                     break
@@ -753,6 +761,7 @@ class AsyncODataClient(_AsyncProtocol):
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         skip = int((extra_params or {}).get("$skip", 0))
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -782,6 +791,13 @@ class AsyncODataClient(_AsyncProtocol):
             page_values = _values_from_page(page)
             fetched += len(page_values)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor: if the
+            # server keeps returning the same non-null next link, stop instead
+            # of fetching the same page forever (matches the FeatureServer
+            # query_pages id-subset guard).
+            if next_href is not None and next_href == previous_next_href:
+                return
+            previous_next_href = next_href
             if next_href is None:
                 if len(page_values) < page_limit:
                     break

--- a/packages/honua-sdk/honua_sdk/protocols/ogc_extras.py
+++ b/packages/honua-sdk/honua_sdk/protocols/ogc_extras.py
@@ -663,6 +663,7 @@ class OgcRecordsCollectionClient:
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         current_offset = 0 if offset is None else max(0, offset)
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -691,6 +692,13 @@ class OgcRecordsCollectionClient:
             page_records = _records_from_page(page)
             fetched += len(page_records)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor: if the
+            # server keeps returning the same non-null next link, stop instead
+            # of fetching the same page forever (matches the FeatureServer
+            # query_pages id-subset guard).
+            if next_href is not None and next_href == previous_next_href:
+                return
+            previous_next_href = next_href
             if next_href is None:
                 if len(page_records) < page_limit:
                     break
@@ -944,6 +952,7 @@ class AsyncOgcRecordsCollectionClient:
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         current_offset = 0 if offset is None else max(0, offset)
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -972,6 +981,13 @@ class AsyncOgcRecordsCollectionClient:
             page_records = _records_from_page(page)
             fetched += len(page_records)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor: if the
+            # server keeps returning the same non-null next link, stop instead
+            # of fetching the same page forever (matches the FeatureServer
+            # query_pages id-subset guard).
+            if next_href is not None and next_href == previous_next_href:
+                return
+            previous_next_href = next_href
             if next_href is None:
                 if len(page_records) < page_limit:
                     break

--- a/packages/honua-sdk/honua_sdk/protocols/stac.py
+++ b/packages/honua-sdk/honua_sdk/protocols/stac.py
@@ -20,6 +20,7 @@ from ._base import (
     _iter_page_indices,
     _next_link,
     _next_link_object,
+    _next_link_signature,
     _normalize_page_limit,
     _normalize_total_limit,
     _params,
@@ -105,6 +106,7 @@ class StacClient(_SyncProtocol):
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         offset = int((extra_params or {}).get("offset", 0))
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -126,6 +128,13 @@ class StacClient(_SyncProtocol):
             page_items = _features_from_page(page)
             fetched += len(page_items)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor: if the
+            # server keeps returning the same non-null next link, stop instead
+            # of fetching the same page forever (matches the FeatureServer
+            # query_pages id-subset guard).
+            if next_href is not None and next_href == previous_next_href:
+                return
+            previous_next_href = next_href
             if next_href is None:
                 if len(page_items) < page_limit:
                     break
@@ -235,6 +244,7 @@ class StacClient(_SyncProtocol):
         fetched = 0
         next_link: Mapping[str, Any] | None = None
         next_href: str | None = None
+        previous_next_href: str | None = None
         offset = int((params or json_body or {}).get("offset", 0))
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -271,6 +281,15 @@ class StacClient(_SyncProtocol):
             fetched += len(page_items)
             next_link = _next_link_object(page)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor. For STAC
+            # POST /search the continuation lives in the link body, so compare a
+            # signature of the whole next link (method/href/body) rather than the
+            # href alone; stop if the server repeats it (matches the FeatureServer
+            # query_pages id-subset guard).
+            next_signature = _next_link_signature(next_link, next_href)
+            if next_signature is not None and next_signature == previous_next_href:
+                return
+            previous_next_href = next_signature
             if next_href is None:
                 if len(page_items) < page_limit:
                     break
@@ -375,6 +394,7 @@ class AsyncStacClient(_AsyncProtocol):
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         offset = int((extra_params or {}).get("offset", 0))
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -396,6 +416,13 @@ class AsyncStacClient(_AsyncProtocol):
             page_items = _features_from_page(page)
             fetched += len(page_items)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor: if the
+            # server keeps returning the same non-null next link, stop instead
+            # of fetching the same page forever (matches the FeatureServer
+            # query_pages id-subset guard).
+            if next_href is not None and next_href == previous_next_href:
+                return
+            previous_next_href = next_href
             if next_href is None:
                 if len(page_items) < page_limit:
                     break
@@ -506,6 +533,7 @@ class AsyncStacClient(_AsyncProtocol):
         fetched = 0
         next_link: Mapping[str, Any] | None = None
         next_href: str | None = None
+        previous_next_href: str | None = None
         offset = int((params or json_body or {}).get("offset", 0))
         for _ in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
@@ -542,6 +570,15 @@ class AsyncStacClient(_AsyncProtocol):
             fetched += len(page_items)
             next_link = _next_link_object(page)
             next_href = _next_link(page)
+            # Guard against a self-referential / non-advancing cursor. For STAC
+            # POST /search the continuation lives in the link body, so compare a
+            # signature of the whole next link (method/href/body) rather than the
+            # href alone; stop if the server repeats it (matches the FeatureServer
+            # query_pages id-subset guard).
+            next_signature = _next_link_signature(next_link, next_href)
+            if next_signature is not None and next_signature == previous_next_href:
+                return
+            previous_next_href = next_signature
             if next_href is None:
                 if len(page_items) < page_limit:
                     break

--- a/packages/honua-sdk/honua_sdk/protocols/wfs.py
+++ b/packages/honua-sdk/honua_sdk/protocols/wfs.py
@@ -33,8 +33,11 @@ class WfsClient(_SyncProtocol):
         params = _params({"typeNames": _csv(type_names)} if type_names is not None else None, extra_params)
         return self.request("GetFeature", params=params)
 
-    def transaction(self, xml: str | bytes) -> str:
-        return self._text("POST", self.path, content=xml)
+    def transaction(self, xml: str | bytes, *, content_type: str = "application/xml") -> str:
+        # WFS-T request bodies are XML; declare the content type explicitly so a
+        # conformant WFS endpoint (or a strict proxy/WAF) does not 415/400 the
+        # transaction or mis-route it as form data. Override with text/xml if needed.
+        return self._text("POST", self.path, content=xml, extra_headers={"Content-Type": content_type})
 
 
 class AsyncWfsClient(_AsyncProtocol):
@@ -56,5 +59,6 @@ class AsyncWfsClient(_AsyncProtocol):
         params = _params({"typeNames": _csv(type_names)} if type_names is not None else None, extra_params)
         return await self.request("GetFeature", params=params)
 
-    async def transaction(self, xml: str | bytes) -> str:
-        return await self._text("POST", self.path, content=xml)
+    async def transaction(self, xml: str | bytes, *, content_type: str = "application/xml") -> str:
+        # See WfsClient.transaction: declare the XML content type explicitly.
+        return await self._text("POST", self.path, content=xml, extra_headers={"Content-Type": content_type})

--- a/tests/test_cursors_and_geodataframe.py
+++ b/tests/test_cursors_and_geodataframe.py
@@ -193,7 +193,13 @@ def test_update_cursor_iterates_and_writes_back() -> None:
 
     assert len(edits) == 1  # single batch flushed on exit
     updates = edits[0]["updates"]
-    assert {u["attributes"]["OBJECTID"] for u in updates} == {1, 2}
+    # The source carries its OID under the lowercase ``objectid`` key; update_row
+    # must reuse that exact key and NOT also inject a canonical ``OBJECTID`` (which
+    # would leave two object-id-like keys for the same row and corrupt the edit).
+    for update in updates:
+        oid_keys = [k for k in update["attributes"] if k in ("objectid", "objectId", "OBJECTID")]
+        assert oid_keys == ["objectid"], oid_keys
+    assert {u["attributes"]["objectid"] for u in updates} == {1, 2}
     assert {u["attributes"]["name"] for u in updates} == {"a", "b"}
 
 
@@ -218,6 +224,22 @@ def test_update_row_without_object_id_raises() -> None:
         row = Row(feature=QueryFeature(id=None, properties={"name": "no-oid"}))
         with pytest.raises(ValueError, match="object id"):
             cursor.update_row(row)
+
+
+def test_update_row_adds_canonical_objectid_only_when_absent() -> None:
+    from honua_sdk.models import QueryFeature
+
+    edits: list[dict[str, Any]] = []
+    with HonuaClient("http://example.test", transport=_edit_transport(edits)) as client:
+        source = client.source(_descriptor())
+        cursor = source.update_cursor(batch_size=1)
+        # OID present only via the feature id, not in properties -> canonical
+        # ``OBJECTID`` is injected.
+        cursor.update_row(Row(feature=QueryFeature(id=7, properties={"name": "x"})))
+    attrs = edits[0]["updates"][0]["attributes"]
+    oid_keys = [k for k in attrs if k in ("objectid", "objectId", "OBJECTID")]
+    assert oid_keys == ["OBJECTID"]
+    assert attrs["OBJECTID"] == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_geoservices_error_envelope.py
+++ b/tests/test_geoservices_error_envelope.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from honua_sdk import HonuaClient, HonuaGeocodingClient, HonuaHttpError
+from honua_sdk import HonuaAuthError, HonuaClient, HonuaGeocodingClient, HonuaHttpError
 from honua_sdk._endpoints import parse_json_response_body
 
 
@@ -30,13 +30,41 @@ def test_query_features_raises_on_error_envelope() -> None:
     assert "Unable to complete" in str(excinfo.value)
 
 
-def test_apply_edits_raises_on_error_envelope() -> None:
+def test_apply_edits_raises_auth_on_token_required_envelope() -> None:
+    # Esri code 499 (Token Required) is an application code, not an HTTP status:
+    # it must surface as HonuaAuthError (catchable via ``except HonuaAuthError``)
+    # while preserving the original Esri code on ``error_code`` and normalizing
+    # the HTTP ``status_code`` surface to 403.
     with HonuaClient(
         "http://example.test", transport=_envelope_handler(code=499, message="Token Required")
     ) as client:
-        with pytest.raises(HonuaHttpError) as excinfo:
+        with pytest.raises(HonuaAuthError) as excinfo:
             client.apply_edits("Parcels", 0, adds=[{"attributes": {"NAME": "x"}}])
-    assert excinfo.value.status_code == 499
+    assert excinfo.value.error_code == 499
+    assert excinfo.value.status_code == 403
+
+
+def test_invalid_token_envelope_maps_to_auth_error() -> None:
+    # Esri code 498 (Invalid Token) likewise maps to HonuaAuthError.
+    with HonuaClient(
+        "http://example.test", transport=_envelope_handler(code=498, message="Invalid Token")
+    ) as client:
+        with pytest.raises(HonuaAuthError) as excinfo:
+            client.query_features("Parcels", 0, where="1=1")
+    assert excinfo.value.error_code == 498
+    assert excinfo.value.status_code == 403
+
+
+def test_exotic_negative_code_normalizes_status_but_preserves_error_code() -> None:
+    # A large negative HRESULT-style code must not be surfaced verbatim as an HTTP
+    # status; it normalizes to 500 while the original code is kept on error_code.
+    with HonuaClient(
+        "http://example.test", transport=_envelope_handler(code=-2147217395, message="Workspace error")
+    ) as client:
+        with pytest.raises(HonuaHttpError) as excinfo:
+            client.query_features("Parcels", 0, where="1=1")
+    assert excinfo.value.error_code == -2147217395
+    assert excinfo.value.status_code == 500
 
 
 def test_list_services_raises_on_error_envelope() -> None:

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -179,6 +179,30 @@ def test_stac_item_iterators_follow_next_links_and_clip_limit() -> None:
     assert seen == [{"limit": "2", "offset": "0"}, {"offset": "2", "limit": "2"}]
 
 
+def test_stac_iter_items_breaks_on_non_advancing_next_link() -> None:
+    # A buggy/hostile server returns a constant, self-referential ``next`` link
+    # pointing at a full page. With an unbounded walk (max_pages=None) the loop
+    # must terminate via the non-advancing-cursor guard rather than fetch forever.
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] > 50:  # safety net so a regression fails fast instead of hanging
+            raise AssertionError("pagination did not stop on a non-advancing next link")
+        page = [{"type": "Feature", "id": "scene-1"}, {"type": "Feature", "id": "scene-2"}]
+        links = [{"rel": "next", "href": "http://example.test/stac/collections/imagery/items?cursor=stuck"}]
+        return httpx.Response(200, json={"type": "FeatureCollection", "features": page, "links": links})
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        pages = list(client.stac().item_pages("imagery", page_size=2, max_pages=None))
+
+    # First page is fetched/yielded; the second fetch returns the identical next
+    # link, which trips the non-advancing guard and stops the unbounded walk.
+    assert calls["n"] == 2
+    assert len(pages) == 2
+
+
 def test_odata_query_helpers_and_iterators() -> None:
     seen: list[dict[str, str]] = []
 


### PR DESCRIPTION
Round-3 release-audit fixes for confirmed S2 correctness/reliability findings in `honua-sdk`. These are new findings (no GH issue numbers); each is referenced below by file:line + recommendation.

## Findings addressed

### 1. UpdateCursor.update_row could emit duplicate OBJECTID keys (`packages/honua-sdk/honua_sdk/cursors.py:276`)
`Row.object_id` resolves the OID from any of `('objectid','objectId','OBJECTID')`, but `update_row` did `merged.setdefault('OBJECTID', object_id)`. When the source feature carried the OID under a non-canonical key (e.g. lowercase `objectid`), this added a **second** upper-case `OBJECTID`, so the `applyEdits` payload contained two object-id-like keys for the same row — which a strict FeatureServer may reject or use to update the wrong field. Now the existing OID key is reused; canonical `OBJECTID` is only added when none of the recognized variants is present. Fixed in both the sync and async cursors.

### 2. Async attachment upload blocked the event loop (`packages/honua-sdk/honua_sdk/protocols/geoservices.py:1168,1204`)
`AsyncGeoServicesFeatureServerClient.add_attachment`/`update_attachment` called the synchronous `_attachment_multipart_file` (blocking `open().read()` / `file.read()`) directly on the event loop, stalling all concurrent async work for the duration of the disk read. The read is now offloaded with `anyio.to_thread.run_sync`, mirroring `_resolve_dynamic_auth_headers_async` in `_http.py`.

### 3. Link-following pagination lacked a non-advancing-page guard (`packages/honua-sdk/honua_sdk/protocols/stac.py:109` and twins in `ogc_extras.py`, `odata.py`)
STAC/OGC-records/OData next-link loops default `max_pages=None`, so a server returning a constant/self-referential `next` link pointing at a full page could loop forever. Added the same guard the FeatureServer `query_pages` path has: track the previous next link and stop when the server repeats it. For STAC POST `/search`, the comparison uses a full link signature (method/href/body) so a body-based continuation token is not mistaken for a stuck cursor.

### 4. WFS-T transaction sent XML with no Content-Type (`packages/honua-sdk/honua_sdk/protocols/wfs.py:37,60`)
`transaction()` POSTed the WFS-T XML document with no declared content type; a conformant WFS endpoint or strict proxy/WAF can `415`/`400` it or mis-route it as form data. Now sends `Content-Type: application/xml` (overridable via a new `content_type` argument), consistent with every other body-bearing method in the SDK.

### 5. GeoServices envelope error codes mis-typed as HTTP statuses (`packages/honua-sdk/honua_sdk/_http.py:400`)
`raise_for_geoservices_error` fed the Esri envelope `error.code` straight into HTTP-status subclass logic, so token errors `498`/`499` surfaced as a plain `HonuaHttpError` (not catchable via `except HonuaAuthError`) and exotic codes (e.g. a negative HRESULT) became bogus out-of-range `status_code`s. Now a GeoServices-aware mapping routes auth/token codes (`401/403/498/499`) to `HonuaAuthError`, preserves the original Esri code on a new `HonuaHttpError.error_code` attribute, and normalizes the surfaced `status_code` for non-HTTP codes.

## Verification
- `ruff check` — clean
- `mypy packages/honua-sdk/honua_sdk packages/honua-admin/honua_admin` — clean
- `pytest tests/ --cov --cov-fail-under=94` — 1323 passed, 1 skipped, **94.50%** coverage
- Public-API snapshot refreshed (additive optional `error_code` kwarg only; backward compatible)

New/updated regression tests cover each fix.