### PR TITLE
docs: fix GeoDataFrame query path (result.raw is empty) and Retry-After clamp claims (round-3 S2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Convert query results to GeoDataFrames in one call:
 
 ```python
 from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
-from honua_sdk.geopandas import features_to_geodataframe, geodataframe_to_features
+from honua_sdk.geopandas import geodataframe_to_features
 
 with HonuaClient("https://your-honua-server.com") as client:
     source = client.source(
@@ -227,7 +227,7 @@ with HonuaClient("https://your-honua-server.com") as client:
         )
     )
     result = source.query(Query(where="1=1"))
-    gdf = features_to_geodataframe(result.raw)
+    gdf = result.to_geodataframe()
 
     # gdf is a GeoDataFrame with geometry column + CRS set
     print(gdf.head())

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -130,7 +130,6 @@ request shapes; supplying them for a non-FeatureServer source raises
 
 ```python
 from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
-from honua_sdk.geopandas import features_to_geodataframe
 
 with HonuaClient("https://example.com") as client:
     parcels = client.source(
@@ -141,7 +140,7 @@ with HonuaClient("https://example.com") as client:
         )
     )
     result = parcels.query(Query(where="status='active'", page_size=2000))
-    gdf = features_to_geodataframe(result.raw_legacy)
+    gdf = result.to_geodataframe()
     print(gdf.crs, len(gdf))
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,10 +48,10 @@ for feature in result.features[:3]:
 `client.source(...)` returns a source-bound facade; `source.query(...)`
 returns a canonical `Result` whose `features` are normalized
 `QueryFeature` entries (`id`, `properties`, `geometry`, `protocol`,
-`source`, `raw`). The `raw` attribute on each feature -- and
-`result.raw` on the result -- still expose the underlying protocol
-payload (for FeatureServer that is the GeoServices JSON shape with
-`"attributes"` and `"geometry"` sub-keys) when you need it.
+`source`, `raw`). The `raw` attribute on each feature still exposes that
+feature's underlying protocol payload (for FeatureServer that is the
+GeoServices JSON shape with `"attributes"` and `"geometry"` sub-keys), and
+`result.raw_legacy` holds the underlying query envelope, when you need it.
 
 > **Legacy / compact form.** `client.query_features("test_service",
 > layer_id=0, where="1=1", return_geometry=True, out_fields=["*"])`
@@ -61,22 +61,30 @@ payload (for FeatureServer that is the GeoServices JSON shape with
 
 ## Step 3: Convert to GeoDataFrame (10 seconds)
 
-The SDK ships `features_to_geodataframe`, which converts a FeatureServer
-response (including Esri JSON geometries and the layer's `spatialReference`)
-directly into a GeoDataFrame -- no Shapely glue code required.
+A `Result` from the `Source` API converts directly with one call -- no
+Shapely glue code required:
 
 ```python
-from honua_sdk.geopandas import features_to_geodataframe
-
-gdf = features_to_geodataframe(result.raw)
+gdf = result.to_geodataframe()
 print(gdf.head())
 print(gdf.crs)
 ```
 
-`features_to_geodataframe` accepts the raw FeatureServer payload (as
-exposed via `result.raw` from the Source API or returned directly by
-`query_features`), the typed `FeatureSet` returned by
-`query_feature_set`, or a list of feature dicts.
+`Result.to_geodataframe()` reads attributes and geometry from the result's
+normalized features and resolves the CRS from the query's spatial reference.
+
+For raw FeatureServer payloads (the GeoServices dict returned directly by
+`query_features`), the typed `FeatureSet` returned by `query_feature_set`, or
+a list of feature dicts, use `features_to_geodataframe`, which also accepts
+Esri JSON geometries and the layer's `spatialReference`:
+
+```python
+from honua_sdk.geopandas import features_to_geodataframe
+
+raw = client.query_features("test_service", layer_id=0, where="1=1")
+gdf = features_to_geodataframe(raw)
+```
+
 The reverse helper, `geodataframe_to_features`, turns an edited GeoDataFrame
 back into payloads ready for `apply_edits`.
 
@@ -198,7 +206,6 @@ from honua_sdk import (
     SourceDescriptor,
     SourceLocator,
 )
-from honua_sdk.geopandas import features_to_geodataframe
 
 SERVER = "https://your-honua-server.com"
 
@@ -216,7 +223,7 @@ with HonuaClient(SERVER) as client:
 print(f"Found {len(result.features)} features")
 
 # --- Build GeoDataFrame ----------------------------------------------------
-gdf = features_to_geodataframe(result.raw)
+gdf = result.to_geodataframe()
 
 # --- Plot ------------------------------------------------------------------
 ax = gdf.plot(figsize=(12, 8), color="lightgrey", edgecolor="black")
@@ -252,13 +259,15 @@ plt.show()
 If you cannot install the `geopandas` extra and need to handle the FeatureServer
 response yourself, the JSON shape is straightforward. Each feature has
 `"attributes"` and `"geometry"` keys; the geometry uses Esri JSON
-(`rings`, `paths`, or `x`/`y`) rather than GeoJSON.
+(`rings`, `paths`, or `x`/`y`) rather than GeoJSON. Use the legacy
+`query_features` call, which returns that raw GeoServices dict directly:
 
 ```python
 import geopandas as gpd
 from shapely.geometry import shape
 
-features = result.raw.get("features", [])
+raw = client.query_features("test_service", layer_id=0, where="1=1")
+features = raw.get("features", [])
 
 rows = []
 for f in features:

--- a/docs/retries-and-timeouts.md
+++ b/docs/retries-and-timeouts.md
@@ -86,13 +86,17 @@ resets on each new request.
 
 ## `Retry-After`
 
-When the server responds with `Retry-After`, the parsed value is used
-verbatim and is **never** jittered. Both forms from RFC 7231 are
-supported (see `parse_retry_after` re-exported via `honua_sdk.http`):
+When the server responds with `Retry-After`, the parsed value is honoured
+(and is **never** jittered) but is **clamped to `backoff_max`** (default
+`5.0s`) so a large server-sent header cannot block far longer than the
+configured ceiling. Both forms from RFC 7231 are supported (see
+`parse_retry_after` re-exported via `honua_sdk.http`):
 
-- delta-seconds: `Retry-After: 120` → 120.0 seconds
+- delta-seconds: `Retry-After: 3` → 3.0 seconds; `Retry-After: 120` is
+  clamped to `backoff_max` (→ 5.0 seconds with the defaults).
 - HTTP-date: `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT` →
-  `max(0, target - now)` in seconds. A date in the past becomes `0.0`.
+  `min(max(0, target - now), backoff_max)` in seconds. A date in the past
+  becomes `0.0`.
 
 Unparseable values fall back to the exponential backoff above.
 


### PR DESCRIPTION
Round-3 release-audit fixes for confirmed S2 docs-accuracy findings. New findings (no GH issue numbers); referenced by file:line + recommendation.

## Findings addressed

### 6. GeoPandas quickstart uses `result.raw`, which is always empty (`docs/quickstart.md:71`, `README.md:230`)
A `Source` query `Result.raw` defaults to an empty dict and is never populated (`source.py:_result_from_legacy` only sets `raw_legacy`), so `features_to_geodataframe(result.raw)` produced a **0-row** GeoDataFrame — the central advertised query-to-GeoDataFrame path, silently empty. Switched the examples to the first-class `Result.to_geodataframe()` (already covered by `tests/test_cursors_and_geodataframe.py::test_result_to_geodataframe`). `features_to_geodataframe` is now shown only with the raw GeoServices dict returned by `query_features`, which it actually accepts. Corrected the prose at `quickstart.md` that claimed `result.raw` exposes the payload, and the manual-appendix snippet that read `result.raw.get("features", ...)`.

### 7. pagination.md passes a dataclass to `features_to_geodataframe` (`docs/pagination.md:144`)
The recipe did `features_to_geodataframe(result.raw_legacy)`, but `raw_legacy` is a `FeatureQueryResult` dataclass with no `.get` method, so `features_to_geodataframe` (which calls `response.get("features")`) raises `AttributeError`. Changed to `result.to_geodataframe()`, consistent with `models.md:49`.

### 8. retries doc says `Retry-After` is used verbatim, but code clamps it (`docs/retries-and-timeouts.md:89`)
The doc stated `Retry-After` is used verbatim and gave a `Retry-After: 120 → 120.0 seconds` example, but `compute_delay` returns `min(retry_after, backoff_max)` (default `backoff_max=5.0s`), so 120 yields 5.0s. Updated the prose to say the value is honoured but clamped to `backoff_max`, and changed the example to a sub-ceiling value.

## Verification
- `mkdocs build --strict` — builds clean (only pre-existing unrelated nav/relative-link warnings)
- Edited code snippets parse as valid Python
- `Result.to_geodataframe()` (the path now documented) is exercised by existing tests