### PR TITLE
fix(admin): await async auth applier in async admin client

### DIFF
--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -13,7 +13,7 @@ from honua_sdk.http import (
     AsyncRetryTransport,
     AuthProvider,
     HonuaHttpError,
-    apply_sensitive_auth_headers,
+    apply_sensitive_auth_headers_async,
     build_sensitive_auth_headers,
     encode_path_segment,
     extract_trusted_authority,
@@ -201,7 +201,7 @@ class AsyncHonuaAdminClient:
         auth_headers = build_sensitive_auth_headers(api_key=api_key, bearer_token=bearer_token)
 
         async def _request_hook(request: httpx.Request) -> None:
-            apply_sensitive_auth_headers(
+            await apply_sensitive_auth_headers_async(
                 request,
                 trusted_authority=trusted_authority,
                 auth_headers=auth_headers,

--- a/packages/honua-sdk/honua_sdk/http.py
+++ b/packages/honua-sdk/honua_sdk/http.py
@@ -23,6 +23,8 @@ HTTP helpers (no leading underscore):
 * :func:`encode_path_segment`       — URL-safe path segment encoder
 * :func:`build_sensitive_auth_headers`
 * :func:`apply_sensitive_auth_headers`
+* :func:`apply_sensitive_auth_headers_async` — awaitable variant for async
+  clients; resolves dynamic/async auth providers without blocking the loop
 * :func:`extract_trusted_authority`
 * :func:`validate_auth_configuration`
 * :func:`validate_external_client_auth_configuration`
@@ -55,6 +57,7 @@ from __future__ import annotations
 from ._async_retry import AsyncNonClosingTransport, AsyncRetryTransport
 from ._http import (
     _apply_sensitive_auth_headers,
+    _apply_sensitive_auth_headers_async,
     _build_sensitive_auth_headers,
     _encode_path_segment,
     _extract_trusted_authority,
@@ -79,6 +82,7 @@ from .errors import (
 # Canonical (non-underscore) aliases. The underscore-prefixed originals
 # remain importable for back-compat with code pinned to those names.
 apply_sensitive_auth_headers = _apply_sensitive_auth_headers
+apply_sensitive_auth_headers_async = _apply_sensitive_auth_headers_async
 build_sensitive_auth_headers = _build_sensitive_auth_headers
 encode_path_segment = _encode_path_segment
 extract_trusted_authority = _extract_trusted_authority
@@ -112,6 +116,7 @@ __all__ = [
     "_validate_external_client_auth_configuration",
     "_warn_deprecated_bearer_token",
     "apply_sensitive_auth_headers",
+    "apply_sensitive_auth_headers_async",
     "build_sensitive_auth_headers",
     "encode_path_segment",
     "extract_trusted_authority",

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -187,6 +187,14 @@ _COMMON_RULES: tuple[Rule, ...] = (
         r"\b_apply_sensitive_auth_headers_async\b",
         "_apply_sensitive_auth_headers",
     ),
+    # honua-admin imports the public (non-underscore) async applier from
+    # ``honua_sdk.http`` and awaits it; its generated sync mirror calls the
+    # synchronous public applier. Matched separately from the underscore rule
+    # above (whose ``\b_`` prefix never fires on the public name).
+    _rule(
+        r"\bapply_sensitive_auth_headers_async\b",
+        "apply_sensitive_auth_headers",
+    ),
     #
     # --- module-name seams -------------------------------------------------
     # Async-only sibling modules collapse onto their sync equivalents.

--- a/tests/admin/test_async_admin_client.py
+++ b/tests/admin/test_async_admin_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 import httpx
@@ -29,7 +30,11 @@ from honua_admin import (
     TableDiscoveryResponse,
     UpdateSecureConnectionRequest,
 )
-from honua_sdk import CallableAuthProvider, HonuaHttpError
+from honua_sdk import (
+    AsyncRefreshableBearerTokenProvider,
+    CallableAuthProvider,
+    HonuaHttpError,
+)
 from honua_sdk.errors import HonuaTransportError
 
 from .conftest import make_api_response
@@ -1061,3 +1066,76 @@ async def test_async_delete_metadata_resource_with_if_match() -> None:
 
     assert seen["method"] == "DELETE"
     assert seen["if_match"] == "prev-etag"
+
+
+# ---------------------------------------------------------------------------
+# Async auth providers on the admin client.
+#
+# The admin async client must apply request-time auth headers through the
+# awaitable applier so that (1) async-only providers exposing
+# ``auth_headers_async`` work without raising ``AttributeError`` and (2) a
+# synchronous provider's blocking refresh is offloaded off the event loop.
+# This mirrors the data-plane ``AsyncHonuaClient`` behaviour.
+# ---------------------------------------------------------------------------
+
+
+async def test_async_admin_client_awaits_async_auth_provider() -> None:
+    refreshed: list[str] = []
+
+    async def refresh() -> str:
+        refreshed.append("called")
+        return "async-token"
+
+    provider = AsyncRefreshableBearerTokenProvider(refresh)
+
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization", ""))
+        return httpx.Response(200, json=make_api_response([]))
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaAdminClient(
+        "http://test.honua.io", transport=transport, auth_provider=provider
+    ) as client:
+        await client.list_services()
+
+    # An async-only provider previously raised AttributeError because the admin
+    # client called the synchronous ``auth_headers``; it must now be awaited.
+    assert refreshed == ["called"]
+    assert seen == ["Bearer async-token"]
+
+
+async def test_async_admin_client_offloads_sync_auth_provider_off_the_loop() -> None:
+    loop_thread = threading.get_ident()
+    call_threads: list[int] = []
+
+    class _RecordingProvider:
+        def auth_headers(self) -> dict[str, str]:
+            call_threads.append(threading.get_ident())
+            return {"Authorization": "Bearer sync-token"}
+
+    seen: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization", ""))
+        return httpx.Response(200, json=make_api_response([]))
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaAdminClient(
+        "http://test.honua.io", transport=transport, auth_provider=_RecordingProvider()
+    ) as client:
+        await client.list_services()
+
+    assert seen == ["Bearer sync-token"]
+    # The synchronous provider ran in a worker thread, not on the event loop.
+    assert call_threads and all(tid != loop_thread for tid in call_threads)
+
+
+# ---------------------------------------------------------------------------
+# Async auth providers on the admin client.
+#
+# The admin async client must apply request-time auth headers through the
+# awaitable applier so that (1) async-only providers exposing
+# auth_headers_async work without raising AttributeError and (2) a
+# synchronous providers

--- a/tests/admin/test_shared_sdk_boundary.py
+++ b/tests/admin/test_shared_sdk_boundary.py
@@ -74,6 +74,9 @@ def test_admin_clients_use_public_http_boundary() -> None:
     assert admin_async_client.AsyncRetryTransport is honua_http.AsyncRetryTransport
     assert admin_async_client.AuthProvider is honua_http.AuthProvider
     assert admin_async_client.HonuaHttpError is honua_http.HonuaHttpError
-    assert admin_async_client.apply_sensitive_auth_headers is honua_http.apply_sensitive_auth_headers
+    assert (
+        admin_async_client.apply_sensitive_auth_headers_async
+        is honua_http.apply_sensitive_auth_headers_async
+    )
     assert admin_async_client.encode_path_segment is honua_http.encode_path_segment
     assert admin_async_client.to_http_error is honua_http.to_http_error


### PR DESCRIPTION
## Summary

The async admin client's request hook called the **synchronous**
`apply_sensitive_auth_headers`, diverging from the data-plane
`AsyncHonuaClient`, which awaits `_apply_sensitive_auth_headers_async`
(`packages/honua-sdk/honua_sdk/async_client.py:207`). The synchronous applier
resolves a dynamic provider by calling `auth_provider.auth_headers()` inline on
the running event loop.

Finding: `packages/honua-admin/honua_admin/_async_client.py:204` (release-audit
round 4, S1, coherence).

Two consequences on the advertised public surface:

1. `AsyncAuthProvider` / `AsyncRefreshableBearerTokenProvider` (exported from
   `honua_sdk.__init__`) expose only `auth_headers_async`, so passing one to
   `AsyncHonuaAdminClient(auth_provider=...)` raised `AttributeError` on the
   first request — the async-provider feature was simply broken for the admin
   client.
2. A synchronous refreshable provider whose `auth_headers()` performs a network
   token refresh blocked the event loop.

Root cause was a missing export: `honua_sdk.http` did not surface the async
applier (`_apply_sensitive_auth_headers_async` is defined in `_http.py:216` but
was not re-exported).

## Fix (per recommendation)

- Re-export `apply_sensitive_auth_headers_async` from `honua_sdk.http`
  (added to the alias block and `__all__`, documented in the module docstring).
- Switch honua-admin's `_async_client` request hook to `await` it.
- Add a `gen_sync.py` rule mapping the public async name back to
  `apply_sensitive_auth_headers` so the generated sync mirror (`_client.py`)
  keeps calling the synchronous applier. `_client.py` regenerated (byte-equal).
- Update the public-HTTP boundary assertion for the async client.

## Tests

- New admin tests: an awaited `AsyncRefreshableBearerTokenProvider` applies the
  header without `AttributeError`; a synchronous provider runs off the event
  loop (worker thread).
- `tests/admin/` (249), `tests/test_audit_transport_dedup.py`,
  `test_shared_sdk_boundary.py`, `test_public_api_hygiene.py` pass.
- `ruff check .`, `mypy`, `scripts/gen_sync.py --check`,
  `scripts/compatibility_gate.py` all green.
