### PR TITLE
fix(ogc): guard OGC Features paging against a non-advancing next link

### DIFF
--- a/packages/honua-sdk/honua_sdk/ogc.py
+++ b/packages/honua-sdk/honua_sdk/ogc.py
@@ -628,6 +628,7 @@ class HonuaOgcFeatureCollection:
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         for page in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
@@ -665,6 +666,12 @@ class HonuaOgcFeatureCollection:
             next_href = _next_link(response)
             if next_href is None and len(page_features) < page_limit:
                 break
+            # Guard against a non-advancing cursor: a server that echoes a
+            # constant ``rel=next`` would otherwise loop forever (max_pages=None
+            # is unbounded) re-fetching the same page. Mirrors the STAC walker.
+            if next_href is not None and next_href == previous_next_href:
+                break
+            previous_next_href = next_href
 
     def iter_items(
         self,
@@ -1285,6 +1292,7 @@ class AsyncHonuaOgcFeatureCollection:
 
         fetched = 0
         next_href: str | None = None
+        previous_next_href: str | None = None
         for page in _iter_page_indices(max_pages):
             remaining = effective_page_size if total_limit is None else max(0, total_limit - fetched)
             if remaining < 1:
@@ -1322,6 +1330,12 @@ class AsyncHonuaOgcFeatureCollection:
             next_href = _next_link(response)
             if next_href is None and len(page_features) < page_limit:
                 break
+            # Guard against a non-advancing cursor: a server that echoes a
+            # constant ``rel=next`` would otherwise loop forever (max_pages=None
+            # is unbounded) re-fetching the same page. Mirrors the STAC walker.
+            if next_href is not None and next_href == previous_next_href:
+                break
+            previous_next_href = next_href
 
     async def iter_items(
         self,

--- a/tests/test_ogc_coverage_uplift.py
+++ b/tests/test_ogc_coverage_uplift.py
@@ -306,6 +306,10 @@ def test_sync_items_pages_unbounded_walks_past_legacy_cap() -> None:
     cap and silently truncated, diverging from the FeatureServer walker (which
     treats ``None`` as unbounded). Walking 150 advertised pages proves the cap
     is gone.
+
+    The cursor must *advance* between pages (a distinct ``rel=next`` href each
+    time); a real paginating server does this, and the non-advancing-cursor
+    guard intentionally stops a server that echoes a constant next link.
     """
     total = 150
     counter = {"n": 0}
@@ -314,7 +318,12 @@ def test_sync_items_pages_unbounded_walks_past_legacy_cap() -> None:
         counter["n"] += 1
         if counter["n"] < total:
             features = [{"id": counter["n"]}, {"id": counter["n"] + 1000}]
-            links = [{"rel": "next", "href": "/ogc/features/collections/parcels/items?cont"}]
+            links = [
+                {
+                    "rel": "next",
+                    "href": f"/ogc/features/collections/parcels/items?cont={counter['n']}",
+                }
+            ]
         else:
             features = [{"id": counter["n"]}]  # short final page terminates the walk
             links = []
@@ -334,6 +343,41 @@ def test_sync_items_pages_unbounded_walks_past_legacy_cap() -> None:
 
     assert len(pages) == total
     assert counter["n"] == total
+
+
+def test_sync_items_pages_breaks_on_non_advancing_next_link() -> None:
+    """A server echoing a constant ``rel=next`` plus a full page must not loop
+    forever. ``max_pages=None`` is unbounded, so the only thing that can stop
+    the walk is the non-advancing-cursor guard."""
+
+    counter = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        counter["n"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "type": "FeatureCollection",
+                # Full page (== page_size) so the short-page break never fires.
+                "features": [{"id": counter["n"]}, {"id": counter["n"] + 100}],
+                # Constant, non-null next link -> the cursor never advances.
+                "links": [{"rel": "next", "href": "/ogc/features/collections/parcels/items?cont"}],
+            },
+        )
+
+    with HonuaClient(
+        "http://example.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        pages = list(
+            client.ogc_features()
+            .collection("parcels")
+            .items_pages(page_size=2, max_pages=None)
+        )
+
+    # First page is fetched and yielded; the second response repeats the same
+    # next href, so the walk stops instead of re-fetching indefinitely.
+    assert len(pages) == 2
+    assert counter["n"] == 2
 
 
 def test_sync_item_get_uses_crs_parameter() -> None:
@@ -426,6 +470,37 @@ async def test_async_items_pages_follows_next_link() -> None:
     assert "limit=2" in seen_paths[0]
     assert "page=2" in seen_paths[1]
     assert len(seen_paths) == 2
+
+
+async def test_async_items_pages_breaks_on_non_advancing_next_link() -> None:
+    """Async mirror of the non-advancing-cursor guard: a constant ``rel=next``
+    plus a full page must stop the unbounded walk instead of looping."""
+
+    counter = {"n": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        counter["n"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "type": "FeatureCollection",
+                "features": [{"id": counter["n"]}, {"id": counter["n"] + 100}],
+                "links": [{"rel": "next", "href": "/ogc/features/collections/parcels/items?cont"}],
+            },
+        )
+
+    async with AsyncHonuaClient(
+        "http://example.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        pages = [
+            page
+            async for page in client.ogc_features()
+            .collection("parcels")
+            .items_pages(page_size=2, max_pages=None)
+        ]
+
+    assert len(pages) == 2
+    assert counter["n"] == 2
 
 
 async def test_async_iter_items_stops_at_user_limit() -> None:


### PR DESCRIPTION
## Summary

OGC API Features `items_pages` (sync and async) followed the server's `rel=next`
link each iteration and terminated only when the link was absent **and** the
page was short. `_iter_page_indices(max_pages)` drives the loop and the public
`items_all`/`items_pages`/`iter_items` default `max_pages=None` -> unbounded
(`itertools.count()`). A server returning a constant non-null `rel=next` plus a
full page caused an infinite request loop (and unbounded memory in `items_all`).

Finding: `packages/honua-sdk/honua_sdk/ogc.py:665` (sync) and `:1313` (async)
(release-audit round 4, S2, correctness).

The sibling protocols already guard this: STAC `item_pages` compares against the
previous next href, and GeoServices `query_pages` uses an object-id-subset
guard. OGC was left without the equivalent.

## Fix (per recommendation)

Track `previous_next_href` and stop when a non-null `next_href` repeats, in both
the sync and async loops — mirroring the STAC walker.

## Tests

- New sync + async regression tests: a constant `rel=next` plus full pages stops
  after the cursor first repeats instead of looping.
- Updated `test_sync_items_pages_unbounded_walks_past_legacy_cap` to use an
  **advancing** cursor (a distinct `rel=next` per page), which is what a real
  paginating server emits and what the unbounded-walk behaviour actually needs.
- Full SDK suite (1321 passed, 5 skipped), `ruff check .`, `mypy`,
  `scripts/gen_sync.py --check` all green.
