### PR TITLE
docs(honua-gp): correct README coverage to match the compatibility matrix

### DIFF
--- a/packages/honua-gp/README.md
+++ b/packages/honua-gp/README.md
@@ -73,15 +73,22 @@ with arcpy.da.UpdateCursor("roads_lyr", ["OID@", "STATUS"]) as cursor:
             cursor.deleteRow()
 ```
 
-Process-backed shims (``analysis.Buffer`` / ``Clip`` / ``Intersect`` /
-``Union`` / ``Erase`` / ``SpatialJoin`` and ``management.CalculateField``
-/ ``Dissolve`` / ``Copy`` / ``Delete`` / ``Project``) currently raise
-``HonuaGpUnsupportedError`` -- audit pass 8 downgraded them because
-their payloads did not match honua-server's ``BuiltInProcessCatalog``
-inputs (see [`CHANGELOG.md`](CHANGELOG.md) and the Status section
-below). The migration tool surfaces each one as a ``stub`` with a
-``honua-server#...`` tracking ticket so customers know what work
-remains. The end-to-end runnable example lives at
+Process-backed shims run a supported subset against honua-server's
+``BuiltInProcessCatalog`` as asynchronous OGC API Processes jobs:
+``analysis.Buffer`` and ``management.Copy`` / ``CopyFeatures`` / ``Project``
+are **Supported**, and ``analysis.SpatialJoin`` plus
+``management.CalculateField`` / ``Dissolve`` are **Partial** (documented
+deviations -- see the matrix). The remaining process-shaped operations
+(``analysis.Clip`` / ``Intersect`` / ``Union`` / ``Erase`` and
+``management.Delete``) still raise ``HonuaGpUnsupportedError`` because
+honua-server only exposes the single-WKB ``geometry.*`` family (one geometry
+per call, not feature classes) and ``data-management.delete-features`` deletes
+filtered features inside a layer rather than dropping the dataset arcpy.Delete
+targets. The migration tool surfaces each unmapped op as a ``stub`` with a
+``honua-server#...`` tracking ticket so customers know what work remains. See
+[`docs/compatibility-matrix.md`](docs/compatibility-matrix.md) for the
+authoritative per-function status and [`CHANGELOG.md`](CHANGELOG.md) for the
+projection-adapter promotion. The end-to-end runnable example lives at
 [`examples/buffer_clip_roundtrip.py`](examples/buffer_clip_roundtrip.py).
 
 The shim writes one JSONL line per call to
@@ -94,15 +101,18 @@ inventory to get a per-call TODO list against the compatibility matrix.
 - **Closed source:** distributed via private PyPI index; do not redistribute.
 - **MVP scope:** 45 functions (15 analysis + 20 management + 10 da); see
   [`docs/compatibility-matrix.md`](docs/compatibility-matrix.md).
-- **Coverage today:** 4 supported entries and 3 partial entries
-  (session-backed ``MakeFeatureLayer`` / ``MakeTableView``, source-backed
-  ``SelectLayerByAttribute`` / ``GetCount``, and the three ``da`` cursors)
-  + 38 stubs. The 11 previously process-backed entries (``Buffer``,
-  ``Clip``, ``Intersect``, ``Union``, ``Erase``, ``SpatialJoin``,
-  ``CalculateField``, ``Dissolve``, ``Copy``, ``Delete``, ``Project``)
-  were downgraded in audit pass 8 because their payloads did not match
-  honua-server's ``BuiltInProcessCatalog`` contract. Each carries a
-  ``honua-server#...`` tracking ticket pointing at the projection
-  adapter that needs to land before they can be re-promoted.
+- **Coverage today:** 7 supported entries and 6 partial entries
+  (13 supported/partial) + 32 stubs. Supported: session-backed
+  ``MakeFeatureLayer`` / ``MakeTableView``, the two buffered ``da`` write
+  cursors (``InsertCursor`` / ``UpdateCursor``), and process-backed
+  ``analysis.Buffer`` / ``management.Copy`` / ``management.Project``. Partial:
+  source-backed ``SelectLayerByAttribute`` / ``GetCount`` / ``da.SearchCursor``,
+  and process-backed ``analysis.SpatialJoin`` / ``management.CalculateField`` /
+  ``management.Dissolve`` (documented deviations). The layer-aware projection
+  adapter (see [`CHANGELOG.md`](CHANGELOG.md)) re-promoted the six high-frequency
+  process tools from stub to working. The remaining process-shaped stubs
+  (``analysis.Clip`` / ``Intersect`` / ``Union`` / ``Erase`` and
+  ``management.Delete``) each carry a ``honua-server#...`` tracking ticket
+  because no single ``BuiltInProcessCatalog`` op maps onto them.
 - **Audit:** every invocation produces a redacted JSONL record (paths and
   secrets are stripped per the `honua_admin._arcpy_scanner` heuristics).

--- a/packages/honua-gp/tests/test_compat_manifest.py
+++ b/packages/honua-gp/tests/test_compat_manifest.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import honua_gp
 from honua_gp._compat import COMPAT
+
+_README_PATH = Path(honua_gp.__file__).resolve().parent.parent / "README.md"
 
 
 def test_manifest_covers_45_functions_across_three_families() -> None:
@@ -223,3 +227,53 @@ def test_stub_hints_do_not_recommend_stubbed_sibling_shims() -> None:
                 "acknowledge the shared blocker without inviting another "
                 "HonuaGpUnsupportedError."
             )
+
+
+def test_readme_coverage_counts_match_manifest() -> None:
+    """The README Status section quotes supported/partial/stub counts. Pin them
+    to the COMPAT manifest so the doc cannot drift back to a stale (and badly
+    understated) claim the way audit pass 8 left it."""
+    supported = sum(1 for e in COMPAT.values() if e.status == "supported")
+    partial = sum(1 for e in COMPAT.values() if e.status == "partial")
+    stubs = sum(1 for e in COMPAT.values() if e.status == "stub")
+    supported_or_partial = supported + partial
+
+    readme = _README_PATH.read_text(encoding="utf-8")
+    assert f"{supported} supported entries and {partial} partial entries" in readme, (
+        "README Status coverage line is stale; regenerate from the COMPAT manifest "
+        f"({supported} supported, {partial} partial, {stubs} stubs)."
+    )
+    assert f"({supported_or_partial} supported/partial) + {stubs} stubs" in readme
+
+
+def test_readme_only_lists_true_stubs_as_raising() -> None:
+    """The README must not claim a working tool raises HonuaGpUnsupportedError.
+    Every process op named as still raising must actually be a stub, and the
+    re-promoted tools must NOT be named in that raising list."""
+    readme = _README_PATH.read_text(encoding="utf-8")
+    promoted = [
+        "analysis.Buffer",
+        "analysis.SpatialJoin",
+        "management.CalculateField",
+        "management.Dissolve",
+        "management.Copy",
+        "management.Project",
+    ]
+    for name in promoted:
+        assert COMPAT[name].is_supported, f"{name} should be supported/partial in COMPAT"
+        # A re-promoted tool's bare function name must not be presented in the
+        # README's "still raise HonuaGpUnsupportedError" sentence.
+        func = name.split(".", 1)[1]
+        assert f"``{func}`` / ``Clip``" not in readme, (
+            f"README still lists {name} among the ops that raise"
+        )
+    # The raising list in the Quickstart enumerates the genuine process stubs.
+    raising_stubs = (
+        "analysis.Clip",
+        "analysis.Intersect",
+        "analysis.Union",
+        "analysis.Erase",
+        "management.Delete",
+    )
+    for name in raising_stubs:
+        assert COMPAT[name].status == "stub", f"{name} should be a stub in COMPAT"


### PR DESCRIPTION
## Summary

The honua-gp README Quickstart and Status sections still described the
audit-pass-8 state: they claimed `Buffer` / `SpatialJoin` / `CalculateField` /
`Dissolve` / `Copy` / `Project` raise `HonuaGpUnsupportedError` and reported
coverage as 4 supported + 3 partial + 38 stubs. In the code those six tools call
`run_layer_process` (functional), and the authoritative
`docs/compatibility-matrix.md` + the `COMPAT` manifest record
7 supported + 6 partial (13 supported/partial) + 32 stubs. The CHANGELOG's
"layer-aware projection adapter" entry re-promoted them, superseding pass 8; the
README alone was never updated. Six common-path, currently-working operations
were documented as throwing, and coverage was understated.

Finding: `packages/honua-gp/README.md:78` and `:97` vs
`packages/honua-gp/honua_gp/analysis/__init__.py:31`,
`management/__init__.py:335-356`, and `docs/compatibility-matrix.md`
(release-audit round 4, S2, docs-claims-accuracy).

## Fix (per recommendation)

- Rewrite the Quickstart process-shim paragraph and the Status coverage bullet
  from the matrix. Only `analysis.Clip` / `Intersect` / `Union` / `Erase` and
  `management.Delete` are described as still raising.
- Add README-pinning tests in `test_compat_manifest.py` that assert the stated
  supported/partial/stub counts and the raising list stay in sync with the
  `COMPAT` manifest, so the doc cannot drift back.

## Tests

- `tests/test_compat_manifest.py` (11) and the full honua-gp suite (151) pass.
- `honua_gp._cli matrix --check` (committed matrix unchanged) green.
