### PR TITLE
fix(grpc): emit envelope spatial filter ring clockwise (Esri exterior winding)

### DIFF
--- a/packages/honua-sdk/honua_sdk/grpc/_proto_adapter.py
+++ b/packages/honua-sdk/honua_sdk/grpc/_proto_adapter.py
@@ -282,11 +282,18 @@ def _to_proto_geometry(geom: dict[str, Any]) -> tuple[Any, pb2.SpatialReference 
             point.m = geom["m"]
         msg.point.CopyFrom(point)
     elif "xmin" in geom and "ymin" in geom and "xmax" in geom and "ymax" in geom:
+        # Emit the envelope ring clockwise so an Esri-winding-aware engine
+        # reads it as an exterior, not a hole. Per the Esri convention used
+        # elsewhere in the SDK (see ``geopandas`` ring decoding), an exterior
+        # ring is clockwise (negative shoelace area) and a CCW ring is a hole.
+        # Walking the corners (xmin,ymin)->(xmin,ymax)->(xmax,ymax)->(xmax,ymin)
+        # yields a clockwise ring; the reverse order is CCW and would be read
+        # as a hole, producing an inverted/empty bbox spatial filter over gRPC.
         ring = pb2.CoordinateSequence(coords=[
             pb2.Coordinate(x=geom["xmin"], y=geom["ymin"]),
-            pb2.Coordinate(x=geom["xmax"], y=geom["ymin"]),
-            pb2.Coordinate(x=geom["xmax"], y=geom["ymax"]),
             pb2.Coordinate(x=geom["xmin"], y=geom["ymax"]),
+            pb2.Coordinate(x=geom["xmax"], y=geom["ymax"]),
+            pb2.Coordinate(x=geom["xmax"], y=geom["ymin"]),
             pb2.Coordinate(x=geom["xmin"], y=geom["ymin"]),
         ])
         msg.polygon.CopyFrom(pb2.PolygonGeometry(rings=[ring]))

--- a/tests/grpc_sdk/test_proto_adapter.py
+++ b/tests/grpc_sdk/test_proto_adapter.py
@@ -1,6 +1,8 @@
 """Unit tests for the proto adapter conversion functions."""
 from __future__ import annotations
 
+from itertools import pairwise
+
 import pytest
 
 from honua_sdk.grpc._generated.honua.v1 import feature_service_pb2 as pb2
@@ -190,6 +192,29 @@ class TestToProtoRequest:
         assert point.HasField("z") is False
         assert point.HasField("m") is True
         assert point.m == pytest.approx(99.0)
+
+    def test_envelope_spatial_filter_emits_clockwise_ring(self) -> None:
+        """An Esri envelope must convert to a clockwise (exterior) ring.
+
+        Per the Esri winding convention used elsewhere in the SDK an exterior
+        ring is clockwise (negative shoelace area); a CCW ring is read as a
+        hole, which would make a bbox spatial filter inverted/empty over gRPC.
+        """
+        msg, _ = adapter._to_proto_geometry(
+            {"xmin": 0.0, "ymin": 0.0, "xmax": 10.0, "ymax": 10.0}
+        )
+
+        ring = msg.polygon.rings[0]
+        coords = [(c.x, c.y) for c in ring.coords]
+        # Closed ring of five points.
+        assert len(coords) == 5
+        assert coords[0] == coords[-1]
+        # Signed area (shoelace); negative => clockwise => exterior.
+        signed_area = sum(
+            x1 * y2 - x2 * y1
+            for (x1, y1), (x2, y2) in pairwise(coords)
+        )
+        assert signed_area < 0, "envelope ring must be clockwise (Esri exterior)"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`_to_proto_geometry` in `packages/honua-sdk/honua_sdk/grpc/_proto_adapter.py:271` converts an Esri envelope spatial filter (`{xmin,ymin,xmax,ymax}`) into a polygon ring by walking the corners:

```
(xmin,ymin) -> (xmax,ymin) -> (xmax,ymax) -> (xmin,ymax) -> close
```

That ordering is **counter-clockwise** (positive shoelace area). The SDK follows the Esri winding convention elsewhere — e.g. the GeoPandas ring decoder in `honua_sdk/geopandas.py` treats a clockwise ring as an exterior and a CCW ring as a hole. An Esri-winding-aware engine therefore reads this CCW envelope ring as a **hole**, producing an inverted/empty spatial filter and silently wrong (empty) bbox query results over gRPC.

The REST envelope path is unaffected: it sends `geometryType=esriGeometryEnvelope` (a non-ring shape) rather than emitting a ring.

Verification (signed area * 2):
- current ring: `+200` (CCW => read as hole)
- fixed ring: `-200` (CW => exterior)

## Fix

Emit the envelope ring clockwise:

```
(xmin,ymin) -> (xmin,ymax) -> (xmax,ymax) -> (xmax,ymin) -> close
```

so it is read as an exterior. Adds a proto-adapter test asserting clockwise (negative signed-area) envelope winding.

## Finding addressed

Round-5 release-audit finding (S2, cross-repo-contract-integrity), referenced by `file:line` (no GH issue):
- `packages/honua-sdk/honua_sdk/grpc/_proto_adapter.py:284` — gRPC envelope→polygon spatial filter emits CCW ring (Esri-hole winding), inconsistent with the REST path. Recommendation: emit the ring clockwise (or route through the same exterior-ring helper) and add a winding test.

## Validation

- `pytest tests/grpc_sdk/` — 74 passed
- `ruff check` (changed files) — clean
- `mypy` (changed module) — clean