### PR TITLE
feat(sdk): raster result interop + typed transport protocol + retry codegen

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,12 @@ omit =
     # extra-less ``grpc`` matrix where the module is intentionally unimportable.
     packages/honua-sdk/honua_sdk/geopandas.py
     */honua_sdk/geopandas.py
+    # raster interop lives behind the optional ``raster`` extra and is exercised
+    # (via importorskip) only when rasterio/rioxarray/xarray are installed.
+    # Omitting it keeps the combined coverage gate stable across matrices where
+    # the module is intentionally unimportable.
+    packages/honua-sdk/honua_sdk/raster.py
+    */honua_sdk/raster.py
 
 [report]
 exclude_lines =

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,14 +21,17 @@ pip install honua-sdk
 # With gRPC support
 pip install honua-sdk[grpc]
 
-# With GeoPandas integration
+# With GeoPandas integration (vector result interop)
 pip install honua-sdk[geopandas]
+
+# With raster result interop (rasterio / rioxarray / xarray)
+pip install honua-sdk[raster]
 
 # Admin / control-plane client
 pip install honua-admin
 
 # Everything
-pip install honua-sdk[grpc,geopandas] honua-admin
+pip install honua-sdk[grpc,geopandas,raster] honua-admin
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -44,14 +44,17 @@ pip install honua-sdk honua-admin
 # With gRPC support
 pip install honua-sdk[grpc]
 
-# With GeoPandas integration
+# With GeoPandas integration (vector result interop)
 pip install honua-sdk[geopandas]
+
+# With raster result interop (rasterio / rioxarray / xarray)
+pip install honua-sdk[raster]
 
 # Admin / control-plane client (depends on honua-sdk)
 pip install honua-admin
 
 # Everything
-pip install honua-sdk[grpc,geopandas] honua-admin
+pip install honua-sdk[grpc,geopandas,raster] honua-admin
 ```
 
 Requires Python 3.11+. See [INSTALL.md](INSTALL.md) for full details.

--- a/docs/protocol-examples.md
+++ b/docs/protocol-examples.md
@@ -171,6 +171,48 @@ with HonuaClient(SERVER) as client:
     processes.dismiss_job("job-id")                 # None
 ```
 
+### Geoprocessing result interop (Honua computes, your ecosystem consumes)
+
+There is **one canonical geoprocessing engine: the server** (OGC API
+Processes). The SDK does not reimplement any analysis (no client-side
+buffer/overlay/interpolation/raster math); it is an OGC Processes *client* plus
+*last-mile interop* that drops server output straight into the tools you
+already use. Reach for native libraries (`geopandas`, `shapely`, `rasterio`,
+`pysal`, `scikit-learn`) for ad-hoc local work, and for server geoprocessing
+when you need canonical, repeatable analysis.
+
+The richer `client.geoprocessing()` client (submit / poll-to-terminal /
+fetch-results, plus multi-step plans) exposes interop helpers behind optional
+extras:
+
+```python
+from honua_sdk import HonuaClient
+from honua_sdk.geoprocessing import LayerReference
+
+with HonuaClient(SERVER) as client:
+    gp = client.geoprocessing()
+
+    # Vector: GeoDataFrame in -> server process -> GeoDataFrame out.
+    #   (requires: pip install honua-sdk[geopandas])
+    out_gdf = gp.execute_dataframe("geometry.buffer", gdf, parameters={"distance": 100})
+
+    # Raster: server raster output -> xarray / rasterio.
+    #   (requires: pip install honua-sdk[raster])
+    layer = LayerReference.from_query_result("layer-123")
+    data_array = gp.execute_raster("analytics.kernel-density", layer)   # xarray.DataArray
+
+    # Or convert an already-fetched results document:
+    results = gp.results("job-id")
+    data_array = gp.result_to_xarray(results)        # xarray.DataArray (via rioxarray)
+    with gp.result_to_rasterio(results) as dataset:  # rasterio dataset
+        band = dataset.read(1)
+```
+
+Heavy geo dependencies stay **optional**: the base SDK only needs `httpx`, the
+helpers import `geopandas` / `rasterio` / `rioxarray` / `xarray` lazily, and a
+clear `ImportError` (pointing at the right extra) is raised when they are
+absent. The `AsyncHonuaClient` exposes the same helpers as awaitables.
+
 ## STAC
 
 STAC helpers return STAC JSON dictionaries. Item collection and search responses

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -21,6 +21,13 @@ Optional GeoPandas integration is available via ``honua_sdk.geopandas``::
     from honua_sdk.geopandas import features_to_geodataframe, geodataframe_to_features
 
 Install with:  ``pip install honua-sdk[geopandas]``
+
+Optional raster interop (for server geoprocessing output) is available via
+``honua_sdk.raster``::
+
+    from honua_sdk.raster import geotiff_to_xarray, open_geotiff
+
+Install with:  ``pip install honua-sdk[raster]``
 """
 
 from __future__ import annotations

--- a/packages/honua-sdk/honua_sdk/_async_retry.py
+++ b/packages/honua-sdk/honua_sdk/_async_retry.py
@@ -1,17 +1,10 @@
-"""Async retry transport wrapper for httpx.
+"""Asynchronous retry transport wrapper for httpx.
 
-This module owns only the **async I/O dispatch** for retries: it awaits
-``self._wrapped.handle_async_request`` and ``asyncio.sleep`` between
-attempts. Every pure policy decision (transient-exception set,
-should-retry-on status/method, exponential backoff math,
-``Retry-After`` parsing) lives in :mod:`honua_sdk._retry_core` and is
-shared verbatim with the sync counterpart in :mod:`honua_sdk._retry`.
-
-Boundary recap::
-
-    _retry_core   -> pure functions, no I/O
-    _retry        -> sync I/O dispatch + ``time.sleep``
-    _async_retry  -> async I/O dispatch + ``asyncio.sleep``   (this module)
+This module owns only the **asynchronous I/O dispatch** for retries: it drives
+``self._wrapped.handle_async_request`` and ``asyncio.sleep`` between attempts.
+Every pure policy decision (transient-exception set, should-retry-on
+status/method, exponential backoff math, ``Retry-After`` parsing) lives in the
+shared, I/O-free :mod:`honua_sdk._retry_core`.
 """
 
 from __future__ import annotations
@@ -41,7 +34,7 @@ __all__ = [
 
 
 class AsyncNonClosingTransport(httpx.AsyncBaseTransport):
-    """Async transport wrapper whose ``aclose`` does not close the wrapped transport.
+    """Asynchronous transport wrapper whose ``aclose`` does not close the wrapped transport.
 
     Used by ``with_options`` / ``copy`` when an independently-owned clone must
     reuse a caller-supplied transport: the clone owns its own

--- a/packages/honua-sdk/honua_sdk/_client_protocol.py
+++ b/packages/honua-sdk/honua_sdk/_client_protocol.py
@@ -1,0 +1,89 @@
+"""Typed structural protocols for the host-client transport surface.
+
+Facade clients (for example :mod:`honua_sdk.geoprocessing`) need only a thin
+slice of the bound :class:`~honua_sdk.client.HonuaClient` /
+:class:`~honua_sdk.async_client.AsyncHonuaClient`: the low-level request
+methods. Depending on these :class:`typing.Protocol` contracts instead of
+``Any`` documents exactly what a facade requires from its host client and lets
+the type checker verify it -- without leaking the full concrete client surface
+or its private internals into the facade.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+import httpx
+
+Params = Mapping[str, Any] | None
+
+
+class SupportsSyncRequest(Protocol):
+    """The synchronous request surface a facade client depends on."""
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Params = None,
+        json_body: Mapping[str, Any] | None = None,
+        files: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Params = None,
+        json_body: Mapping[str, Any] | None = None,
+        files: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        content: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
+    ) -> httpx.Response: ...
+
+
+class SupportsAsyncRequest(Protocol):
+    """The asynchronous request surface a facade client depends on."""
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Params = None,
+        json_body: Mapping[str, Any] | None = None,
+        files: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Params = None,
+        json_body: Mapping[str, Any] | None = None,
+        files: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        content: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | httpx.Timeout | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
+    ) -> httpx.Response: ...

--- a/packages/honua-sdk/honua_sdk/_retry.py
+++ b/packages/honua-sdk/honua_sdk/_retry.py
@@ -1,18 +1,13 @@
-"""Sync retry transport wrapper for httpx.
+"""Synchronous retry transport wrapper for httpx.
 
-This module owns only the **sync I/O dispatch** for retries: it calls
+This module owns only the **synchronous I/O dispatch** for retries: it drives
 ``self._wrapped.handle_request`` and ``time.sleep`` between attempts.
 Every pure policy decision (transient-exception set, should-retry-on
-status/method, exponential backoff math, ``Retry-After`` parsing) lives
-in :mod:`honua_sdk._retry_core` and is shared verbatim with the async
-counterpart in :mod:`honua_sdk._async_retry`.
-
-Boundary recap::
-
-    _retry_core   -> pure functions, no I/O
-    _retry        -> sync I/O dispatch + ``time.sleep``   (this module)
-    _async_retry  -> async I/O dispatch + ``asyncio.sleep``
+status/method, exponential backoff math, ``Retry-After`` parsing) lives in the
+shared, I/O-free :mod:`honua_sdk._retry_core`.
 """
+# AUTO-GENERATED from packages/honua-sdk/honua_sdk/_async_retry.py by scripts/gen_sync.py — do not edit by hand.
+# Edit the async source-of-truth and run `python scripts/gen_sync.py`.
 
 from __future__ import annotations
 
@@ -34,8 +29,6 @@ from ._retry_core import (
     should_retry_status,
 )
 
-# Re-export for back-compat with tests that imported the constants from
-# this module before the policy was moved into ``_retry_core``.
 __all__ = [
     "NonClosingTransport",
     "RetryTransport",
@@ -43,12 +36,12 @@ __all__ = [
 
 
 class NonClosingTransport(httpx.BaseTransport):
-    """Transport wrapper whose ``close`` does not close the wrapped transport.
+    """Synchronous transport wrapper whose ``close`` does not close the wrapped transport.
 
     Used by ``with_options`` / ``copy`` when an independently-owned clone must
     reuse a caller-supplied transport: the clone owns its own
-    :class:`httpx.Client`, so closing it would otherwise tear down the shared
-    transport's connection pool and break the original client that still
+    :class:`httpx.Client`, so closing it would otherwise tear down the
+    shared transport's connection pool and break the original client that still
     depends on it. Ownership of the wrapped transport stays with the original.
     """
 
@@ -64,7 +57,7 @@ class NonClosingTransport(httpx.BaseTransport):
 
 
 class RetryTransport(httpx.BaseTransport):
-    """An httpx transport wrapper that retries on transient HTTP errors.
+    """A httpx transport wrapper that retries on transient HTTP errors.
 
     Retries are triggered for responses whose status codes are listed in
     ``retry_statuses`` (default: ``429``, ``502``, ``503``, ``504``).

--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -46,13 +46,16 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard, cast
-from urllib.parse import unquote, urlsplit
+from urllib.parse import parse_qsl, unquote, urlsplit
 
+from ._client_protocol import SupportsAsyncRequest, SupportsSyncRequest
 from ._http import _encode_path_segment
 from .errors import HonuaError
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import geopandas as gpd
+    import rasterio
+    import xarray
 
 JsonObject = dict[str, Any]
 LayerReferenceKind = Literal["inlineGeoJson", "queryResult"]
@@ -334,23 +337,35 @@ def _job_results_path(root: str, job_id: str) -> str:
     return f"{_job_path(root, job_id)}/results"
 
 
+def _href_path_and_params(href: str) -> tuple[str, dict[str, str]]:
+    """Split a (possibly absolute) ``href`` into a request path and query params.
+
+    By-reference raster outputs point at a result on the same Honua host; only
+    the path + query are forwarded so the bound client's base URL, auth, and
+    retry policy apply (the host/scheme are taken from the client).
+    """
+    parsed = urlsplit(href)
+    path = parsed.path or href
+    return path, dict(parse_qsl(parsed.query, keep_blank_values=True))
+
+
 class HonuaGeoprocessing:
     """Synchronous geoprocessing client built on OGC API Processes."""
 
     root = "/ogc/processes"
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: SupportsSyncRequest) -> None:
         self.client = client
 
     # -- discovery ---------------------------------------------------------
 
     def processes(self) -> JsonObject:
         """List the available processes."""
-        return cast(JsonObject, self.client._request_json("GET", _processes_path(self.root)))
+        return self.client._request_json("GET", _processes_path(self.root))
 
     def describe(self, process_id: str) -> JsonObject:
         """Describe one process (inputs, outputs, job-control options)."""
-        return cast(JsonObject, self.client._request_json("GET", _process_path(self.root, process_id)))
+        return self.client._request_json("GET", _process_path(self.root, process_id))
 
     # -- raw execution -----------------------------------------------------
 
@@ -508,6 +523,71 @@ class HonuaGeoprocessing:
             out = out.to_crs(source_crs)
         return out
 
+    # -- raster result interop --------------------------------------------
+
+    def result_raster_bytes(self, results: Mapping[str, Any]) -> bytes:
+        """Return the GeoTIFF bytes of a results document's raster output.
+
+        Selects the raster output (see
+        :func:`honua_sdk.raster.find_raster_output`), decoding an inline base64
+        ``value`` or fetching a by-reference ``href`` through the bound client
+        (so base URL, auth, and retry policy apply). Raises
+        :class:`~honua_sdk.errors.HonuaError` when no usable raster output is
+        present.
+        """
+        from .raster import find_raster_output, inline_raster_bytes, raster_href
+
+        member = find_raster_output(results)
+        inline = inline_raster_bytes(member)
+        if inline is not None:
+            return inline
+        href = raster_href(member)
+        if href:
+            path, params = _href_path_and_params(href)
+            return self.client._request("GET", path, params=params).content
+        raise HonuaError("Raster output has neither an inline value nor an href to fetch.")
+
+    def result_to_rasterio(self, results: Mapping[str, Any]) -> "rasterio.io.DatasetReader":
+        """Open a results document's raster output as a :mod:`rasterio` dataset.
+
+        Requires the ``raster`` extra (``pip install honua-sdk[raster]``).
+        """
+        from .raster import open_geotiff
+
+        return open_geotiff(self.result_raster_bytes(results))
+
+    def result_to_xarray(self, results: Mapping[str, Any]) -> "xarray.DataArray":
+        """Convert a results document's raster output to an :class:`xarray.DataArray`.
+
+        Requires the ``raster`` extra (``pip install honua-sdk[raster]``).
+        """
+        from .raster import geotiff_to_xarray
+
+        return geotiff_to_xarray(self.result_raster_bytes(results))
+
+    def execute_raster(
+        self,
+        process_id: str,
+        layer: LayerReference,
+        *,
+        parameters: Mapping[str, Any] | None = None,
+        poll_interval: float = 0.5,
+        timeout: float | None = 120.0,
+    ) -> "xarray.DataArray":
+        """Run a raster-producing process and return the output as an xarray array.
+
+        Convenience wrapper that runs :meth:`execute` and converts the raster
+        output via :meth:`result_to_xarray`. Requires the ``raster`` extra.
+        """
+        result = self.execute(
+            process_id,
+            layer,
+            parameters=parameters,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+        return self.result_to_xarray(result)
+
     # -- canonical multi-step plan ----------------------------------------
 
     def submit_plan(self, plan: Mapping[str, Any], *, respond_async: bool = True) -> GeoprocessingJob:
@@ -544,11 +624,11 @@ class HonuaGeoprocessing:
 
     def results(self, job_id: str) -> JsonObject:
         """Fetch the results document for a (successful) job."""
-        return cast(JsonObject, self.client._request_json("GET", _job_results_path(self.root, job_id)))
+        return self.client._request_json("GET", _job_results_path(self.root, job_id))
 
     def jobs(self) -> JsonObject:
         """List submitted jobs."""
-        return cast(JsonObject, self.client._request_json("GET", f"{self.root}/jobs"))
+        return self.client._request_json("GET", f"{self.root}/jobs")
 
     def dismiss(self, job_id: str) -> None:
         """Dismiss (cancel/forget) a job."""
@@ -593,20 +673,18 @@ class AsyncHonuaGeoprocessing:
 
     root = "/ogc/processes"
 
-    def __init__(self, client: Any) -> None:
+    def __init__(self, client: SupportsAsyncRequest) -> None:
         self.client = client
 
     # -- discovery ---------------------------------------------------------
 
     async def processes(self) -> JsonObject:
         """List the available processes."""
-        return cast(JsonObject, await self.client._request_json("GET", _processes_path(self.root)))
+        return await self.client._request_json("GET", _processes_path(self.root))
 
     async def describe(self, process_id: str) -> JsonObject:
         """Describe one process (inputs, outputs, job-control options)."""
-        return cast(
-            JsonObject, await self.client._request_json("GET", _process_path(self.root, process_id))
-        )
+        return await self.client._request_json("GET", _process_path(self.root, process_id))
 
     # -- raw execution -----------------------------------------------------
 
@@ -731,6 +809,64 @@ class AsyncHonuaGeoprocessing:
             out = out.to_crs(source_crs)
         return out
 
+    # -- raster result interop --------------------------------------------
+
+    async def result_raster_bytes(self, results: Mapping[str, Any]) -> bytes:
+        """Return the GeoTIFF bytes of a results document's raster output."""
+        from .raster import find_raster_output, inline_raster_bytes, raster_href
+
+        member = find_raster_output(results)
+        inline = inline_raster_bytes(member)
+        if inline is not None:
+            return inline
+        href = raster_href(member)
+        if href:
+            path, params = _href_path_and_params(href)
+            response = await self.client._request("GET", path, params=params)
+            return response.content
+        raise HonuaError("Raster output has neither an inline value nor an href to fetch.")
+
+    async def result_to_rasterio(self, results: Mapping[str, Any]) -> "rasterio.io.DatasetReader":
+        """Open a results document's raster output as a :mod:`rasterio` dataset.
+
+        Requires the ``raster`` extra (``pip install honua-sdk[raster]``).
+        """
+        from .raster import open_geotiff
+
+        return open_geotiff(await self.result_raster_bytes(results))
+
+    async def result_to_xarray(self, results: Mapping[str, Any]) -> "xarray.DataArray":
+        """Convert a results document's raster output to an :class:`xarray.DataArray`.
+
+        Requires the ``raster`` extra (``pip install honua-sdk[raster]``).
+        """
+        from .raster import geotiff_to_xarray
+
+        return geotiff_to_xarray(await self.result_raster_bytes(results))
+
+    async def execute_raster(
+        self,
+        process_id: str,
+        layer: LayerReference,
+        *,
+        parameters: Mapping[str, Any] | None = None,
+        poll_interval: float = 0.5,
+        timeout: float | None = 120.0,
+    ) -> "xarray.DataArray":
+        """Run a raster-producing process and return the output as an xarray array.
+
+        Convenience wrapper that runs :meth:`execute` and converts the raster
+        output via :meth:`result_to_xarray`. Requires the ``raster`` extra.
+        """
+        result = await self.execute(
+            process_id,
+            layer,
+            parameters=parameters,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+        return await self.result_to_xarray(result)
+
     # -- canonical multi-step plan ----------------------------------------
 
     async def submit_plan(self, plan: Mapping[str, Any], *, respond_async: bool = True) -> GeoprocessingJob:
@@ -763,13 +899,11 @@ class AsyncHonuaGeoprocessing:
 
     async def results(self, job_id: str) -> JsonObject:
         """Fetch the results document for a (successful) job."""
-        return cast(
-            JsonObject, await self.client._request_json("GET", _job_results_path(self.root, job_id))
-        )
+        return await self.client._request_json("GET", _job_results_path(self.root, job_id))
 
     async def jobs(self) -> JsonObject:
         """List submitted jobs."""
-        return cast(JsonObject, await self.client._request_json("GET", f"{self.root}/jobs"))
+        return await self.client._request_json("GET", f"{self.root}/jobs")
 
     async def dismiss(self, job_id: str) -> None:
         """Dismiss (cancel/forget) a job."""

--- a/packages/honua-sdk/honua_sdk/raster.py
+++ b/packages/honua-sdk/honua_sdk/raster.py
@@ -1,0 +1,172 @@
+"""Raster interop for converting server geoprocessing output to/from rasters.
+
+Honua computes; your ecosystem consumes. This module is a *last-mile*
+consumption layer: it turns the GeoTIFF a server-side OGC API Processes job
+produces into the raster objects you already work with -- a :mod:`rasterio`
+dataset, an :class:`xarray.DataArray` (via :mod:`rioxarray`) -- and back. It
+contains **no** client-side raster analysis; the canonical engine is the
+server.
+
+The heavy geo stack is optional. Install it with::
+
+    pip install honua-sdk[raster]
+
+The output-selection helpers (:func:`find_raster_output`,
+:func:`inline_raster_bytes`, :func:`raster_href`) are pure and dependency-free;
+only the conversion helpers require ``rasterio``/``rioxarray``/``xarray`` and
+raise a clear :class:`ImportError` when the extra is absent.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Mapping
+from typing import Any
+
+from .errors import HonuaError
+
+try:
+    import rasterio
+    import rioxarray
+    import xarray
+
+    _HAS_DEPS = True
+except ImportError:
+    _HAS_DEPS = False
+
+
+def _ensure_deps() -> None:
+    if not _HAS_DEPS:
+        raise ImportError(
+            "rasterio, rioxarray and xarray are required for raster interop. "
+            "Install them with:  pip install honua-sdk[raster]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Output selection (pure -- no optional deps required).
+# ---------------------------------------------------------------------------
+#: Substrings that mark a media/content type as a (Cloud-Optimized) GeoTIFF.
+_RASTER_MEDIA_HINTS = ("tiff", "geotiff", "cog")
+_RASTER_SUFFIXES = (".tif", ".tiff")
+
+
+def _looks_raster_media(media: Any) -> bool:
+    return isinstance(media, str) and any(hint in media.lower() for hint in _RASTER_MEDIA_HINTS)
+
+
+def _looks_raster_href(href: Any) -> bool:
+    if not isinstance(href, str):
+        return False
+    path = href.split("?", 1)[0].split("#", 1)[0]
+    return path.lower().endswith(_RASTER_SUFFIXES)
+
+
+def _is_raster_member(member: Any) -> bool:
+    if not isinstance(member, Mapping):
+        return False
+    media = member.get("mediaType") or member.get("type")
+    href = member.get("href")
+    if isinstance(href, str) and (_looks_raster_media(media) or _looks_raster_href(href)):
+        return True
+    return isinstance(member.get("value"), str) and _looks_raster_media(media)
+
+
+def find_raster_output(results: Mapping[str, Any]) -> dict[str, Any]:
+    """Select the raster output member from an OGC Processes results document.
+
+    The results document returned by ``GET /ogc/processes/jobs/{id}/results``
+    is an outputs map keyed by output id. A raster member is identified by a
+    GeoTIFF ``mediaType``/``type`` or a ``.tif``/``.tiff`` ``href``. The first
+    match (the document itself, a top-level member, or a member nested under an
+    OGC ``value`` wrapper) is returned.
+
+    Raises :class:`~honua_sdk.errors.HonuaError` when no raster output is
+    present so the failure is explicit rather than silent.
+    """
+    if _is_raster_member(results):
+        return dict(results)
+
+    for member in results.values():
+        if _is_raster_member(member):
+            return dict(member)
+        if isinstance(member, Mapping) and _is_raster_member(member.get("value")):
+            return dict(member["value"])
+
+    raise HonuaError(
+        "Geoprocessing results document does not contain a raster (GeoTIFF) output; "
+        f"got output keys {sorted(results)!r}. "
+        "Raster interop requires a raster-out process."
+    )
+
+
+def inline_raster_bytes(member: Mapping[str, Any]) -> bytes | None:
+    """Decode an inline base64 raster ``value`` from an output member.
+
+    Returns ``None`` when the member carries no inline ``value`` (for example a
+    by-reference ``href`` output, which the caller fetches over HTTP instead).
+    A ``data:`` URI prefix is tolerated. Raises
+    :class:`~honua_sdk.errors.HonuaError` when a ``value`` is present but is not
+    valid base64.
+    """
+    value = member.get("value")
+    if not isinstance(value, str):
+        return None
+    payload = value.split(",", 1)[1] if value.startswith("data:") else value
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HonuaError(f"Raster output value is not valid base64: {exc}") from exc
+
+
+def raster_href(member: Mapping[str, Any]) -> str | None:
+    """Return the by-reference ``href`` of an output member, when present."""
+    href = member.get("href")
+    return href if isinstance(href, str) else None
+
+
+# ---------------------------------------------------------------------------
+# Conversions (require the ``raster`` extra).
+# ---------------------------------------------------------------------------
+def open_geotiff(data: bytes) -> rasterio.io.DatasetReader:
+    """Open in-memory GeoTIFF ``data`` as a :mod:`rasterio` dataset.
+
+    The returned dataset reads from an in-memory ``MemoryFile``; the backing
+    file is kept alive for the dataset's lifetime, so close the dataset (or use
+    it as a context manager) when done. Requires the ``raster`` extra.
+    """
+    _ensure_deps()
+    memfile = rasterio.io.MemoryFile(data)
+    dataset = memfile.open()
+    # Pin the MemoryFile to the dataset so it is not garbage-collected (which
+    # would drop the underlying VSIMEM file) before the caller is finished.
+    dataset._honua_memfile = memfile
+    return dataset
+
+
+def geotiff_to_xarray(data: bytes) -> xarray.DataArray:
+    """Convert in-memory GeoTIFF ``data`` to an :class:`xarray.DataArray`.
+
+    The array (with CRS/affine transform attached by :mod:`rioxarray`) is read
+    fully into memory and is self-contained -- no open file handle is retained.
+    Requires the ``raster`` extra.
+    """
+    _ensure_deps()
+    with rasterio.io.MemoryFile(data) as memfile, memfile.open() as dataset:
+        array = rioxarray.open_rasterio(dataset)
+        return array.load()
+
+
+def xarray_to_geotiff(data_array: xarray.DataArray) -> bytes:
+    """Serialize a (rioxarray-backed) :class:`xarray.DataArray` to GeoTIFF bytes.
+
+    Useful for preparing a raster to send to the server. The array must carry
+    rioxarray spatial metadata (CRS + transform), e.g. one produced by
+    :func:`geotiff_to_xarray` or ``rioxarray.open_rasterio``. Requires the
+    ``raster`` extra.
+    """
+    _ensure_deps()
+    with rasterio.io.MemoryFile() as memfile:
+        data_array.rio.to_raster(memfile.name, driver="GTiff")
+        return bytes(memfile.read())

--- a/packages/honua-sdk/pyproject.toml
+++ b/packages/honua-sdk/pyproject.toml
@@ -40,6 +40,7 @@ Issues = "https://github.com/honua-io/honua-sdk-python/issues"
 [project.optional-dependencies]
 grpc = ["grpcio>=1.70.0", "protobuf>=5.27"]
 geopandas = ["geopandas>=0.14.0", "shapely>=2.0.0"]
+raster = ["rasterio>=1.3.0", "rioxarray>=0.15.0", "xarray>=2024.1.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ ignore = []
 "packages/honua-sdk/honua_sdk/client.py" = ["PLC0415", "PLR0913", "PLR2004"]
 "packages/honua-sdk/honua_sdk/async_client.py" = ["PLC0415", "PLR0913", "PLR2004"]
 "packages/honua-sdk/honua_sdk/ogc.py" = ["PLR0913"]
+# _client_protocol.py mirrors the client's wide request signatures in a typed
+# Protocol, so it forwards the same many optional knobs (PLR0913).
+"packages/honua-sdk/honua_sdk/_client_protocol.py" = ["PLR0913"]
 "packages/honua-sdk/honua_sdk/migration/arcpy.py" = ["E501", "PLR2004"]
 # _cli.py imports HonuaClient lazily inside the `run` subcommand so the
 # offline scan/translate/pyt commands work without httpx wired up.
@@ -128,3 +131,14 @@ disallow_untyped_defs = false
 disallow_untyped_calls = false
 disallow_any_generics = false
 disallow_subclassing_any = false
+
+# Optional raster-interop extra (``honua-sdk[raster]``): rasterio/rioxarray/
+# xarray and their transitive numpy stack are heavy third-party deps used only
+# behind the optional ``honua_sdk.raster`` module. Treat them as untyped (Any)
+# rather than following their published stubs — numpy's stubs use 3.12-only
+# ``type`` statements that mypy's pinned 3.11 target cannot parse, and the
+# raster module already degrades gracefully when the extra is absent.
+[[tool.mypy.overrides]]
+module = ["rasterio.*", "rioxarray.*", "xarray.*"]
+follow_imports = "skip"
+ignore_missing_imports = true

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -155,6 +155,10 @@ _COMMON_RULES: tuple[Rule, ...] = (
     _rule(r"__anext__", "__next__"),
     #
     # --- async stdlib / builtins ------------------------------------------
+    # The retry-transport mirror imports ``asyncio`` for ``asyncio.sleep``; its
+    # sync sibling imports ``time`` for ``time.sleep``. Rewrite the top-level
+    # import before the ``asyncio.sleep`` → ``time.sleep`` call rewrite below.
+    _rule(r"\bimport asyncio\b", "import time"),
     _rule(r"\basyncio\.sleep\b", "time.sleep"),
     # Any other ``asyncio.<attr>`` is unexpected in these facades; map the
     # module defensively so a stray reference becomes a clear sync error
@@ -178,6 +182,12 @@ _COMMON_RULES: tuple[Rule, ...] = (
     # AsyncHTTPTransport → HTTPTransport), but the resource-close method is
     # distinct and must be mapped explicitly.
     _rule(r"\baclose\b", "close"),
+    # The async response/transport read + dispatch entry points have distinct
+    # names from their sync counterparts (``aread`` → ``read``,
+    # ``handle_async_request`` → ``handle_request``); the generic ``Async``
+    # strip never fires on these all-lowercase identifiers.
+    _rule(r"\baread\b", "read"),
+    _rule(r"\bhandle_async_request\b", "handle_request"),
     #
     # --- function-name seams ----------------------------------------------
     # The async client uses the awaitable auth-application helper; its sync
@@ -240,6 +250,10 @@ TARGETS: tuple[Target, ...] = (
     Target(
         source=ROOT / "packages/honua-sdk/honua_sdk/async_geocoding.py",
         dest=ROOT / "packages/honua-sdk/honua_sdk/geocoding.py",
+    ),
+    Target(
+        source=ROOT / "packages/honua-sdk/honua_sdk/_async_retry.py",
+        dest=ROOT / "packages/honua-sdk/honua_sdk/_retry.py",
     ),
     Target(
         source=ROOT / "packages/honua-admin/honua_admin/_async_client.py",

--- a/tests/test_geoprocessing_raster.py
+++ b/tests/test_geoprocessing_raster.py
@@ -1,0 +1,277 @@
+"""Tests for raster result interop on the geoprocessing clients.
+
+The pure output-selection helpers (``find_raster_output`` / ``inline_raster_bytes``
+/ ``raster_href``) carry no optional dependency and are tested directly. The
+conversion helpers and the client integration paths require the optional
+``raster`` extra (rasterio/rioxarray/xarray) and are skipped via
+:func:`pytest.importorskip` when it is absent.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import httpx
+import pytest
+
+from honua_sdk import AsyncHonuaClient, HonuaClient
+from honua_sdk.errors import HonuaError
+from honua_sdk.geoprocessing import LayerReference
+from honua_sdk.raster import (
+    find_raster_output,
+    inline_raster_bytes,
+    raster_href,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _status(job_id: str, status: str) -> dict[str, Any]:
+    return {"jobID": job_id, "status": status, "processID": "raster.kernel-density", "type": "process"}
+
+
+# ---------------------------------------------------------------------------
+# Pure output selection (no optional deps)
+# ---------------------------------------------------------------------------
+
+
+def test_find_raster_output_by_href_suffix() -> None:
+    results = {"out": {"href": "https://api.honua.test/artifacts/r.tif", "type": "image/tiff"}}
+    member = find_raster_output(results)
+    assert member["href"].endswith("r.tif")
+
+
+def test_find_raster_output_by_media_type() -> None:
+    results = {"out": {"href": "https://api.honua.test/d/123", "type": "image/tiff; application=geotiff"}}
+    assert find_raster_output(results)["href"].endswith("/123")
+
+
+def test_find_raster_output_inline_value() -> None:
+    results = {"coverage": {"value": "Zm9v", "mediaType": "image/tiff; application=geotiff"}}
+    assert find_raster_output(results)["value"] == "Zm9v"
+
+
+def test_find_raster_output_value_wrapped() -> None:
+    results = {"out": {"value": {"href": "x.tiff", "mediaType": "image/geotiff"}}}
+    assert find_raster_output(results)["href"] == "x.tiff"
+
+
+def test_find_raster_output_document_is_member() -> None:
+    results = {"href": "cog.tif", "type": "image/tiff"}
+    assert find_raster_output(results)["href"] == "cog.tif"
+
+
+def test_find_raster_output_missing_raises() -> None:
+    results = {"out": {"value": {"type": "FeatureCollection", "features": []}}}
+    with pytest.raises(HonuaError, match="does not contain a raster"):
+        find_raster_output(results)
+
+
+def test_inline_raster_bytes_plain_and_data_uri() -> None:
+    raw = b"\x49\x49\x2a\x00fake-tiff"
+    encoded = base64.b64encode(raw).decode("ascii")
+    assert inline_raster_bytes({"value": encoded}) == raw
+    assert inline_raster_bytes({"value": f"data:image/tiff;base64,{encoded}"}) == raw
+
+
+def test_inline_raster_bytes_none_for_href_only() -> None:
+    assert inline_raster_bytes({"href": "x.tif"}) is None
+
+
+def test_inline_raster_bytes_invalid_base64_raises() -> None:
+    with pytest.raises(HonuaError, match="not valid base64"):
+        inline_raster_bytes({"value": "not!base64!!"})
+
+
+def test_raster_href() -> None:
+    assert raster_href({"href": "x.tif"}) == "x.tif"
+    assert raster_href({"value": "Zm9v"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Conversions + client integration (require the ``raster`` extra)
+# ---------------------------------------------------------------------------
+
+
+def _tiny_geotiff() -> bytes:
+    pytest.importorskip("rasterio")
+    import numpy as np
+    from rasterio.io import MemoryFile
+    from rasterio.transform import from_origin
+
+    array = np.arange(12, dtype="float32").reshape(1, 3, 4)
+    profile = {
+        "driver": "GTiff",
+        "height": 3,
+        "width": 4,
+        "count": 1,
+        "dtype": "float32",
+        "crs": "EPSG:4326",
+        "transform": from_origin(0, 3, 1, 1),
+    }
+    with MemoryFile() as memfile:
+        with memfile.open(**profile) as dataset:
+            dataset.write(array)
+        return bytes(memfile.read())
+
+
+def test_geotiff_to_xarray_roundtrip() -> None:
+    pytest.importorskip("rioxarray")
+    from honua_sdk.raster import geotiff_to_xarray
+
+    data = _tiny_geotiff()
+    array = geotiff_to_xarray(data)
+    assert array.shape == (1, 3, 4)
+    assert float(array.sum()) == pytest.approx(66.0)
+    assert array.rio.crs is not None
+
+
+def test_open_geotiff_dataset() -> None:
+    pytest.importorskip("rasterio")
+    from honua_sdk.raster import open_geotiff
+
+    with open_geotiff(_tiny_geotiff()) as dataset:
+        assert dataset.count == 1
+        assert dataset.width == 4
+        assert dataset.height == 3
+
+
+def test_xarray_to_geotiff_roundtrip() -> None:
+    pytest.importorskip("rioxarray")
+    from honua_sdk.raster import geotiff_to_xarray, xarray_to_geotiff
+
+    array = geotiff_to_xarray(_tiny_geotiff())
+    data = xarray_to_geotiff(array)
+    reloaded = geotiff_to_xarray(data)
+    assert float(reloaded.sum()) == pytest.approx(66.0)
+
+
+def test_ensure_deps_raises_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    import honua_sdk.raster as raster_mod
+
+    monkeypatch.setattr(raster_mod, "_HAS_DEPS", False)
+    with pytest.raises(ImportError, match=r"honua-sdk\[raster\]"):
+        raster_mod.open_geotiff(b"")
+
+
+def test_result_to_xarray_inline_value() -> None:
+    pytest.importorskip("rioxarray")
+    encoded = base64.b64encode(_tiny_geotiff()).decode("ascii")
+    results = {"coverage": {"value": encoded, "mediaType": "image/tiff; application=geotiff"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - inline needs no fetch
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        array = client.geoprocessing().result_to_xarray(results)
+
+    assert float(array.sum()) == pytest.approx(66.0)
+
+
+def test_result_raster_bytes_fetches_href() -> None:
+    pytest.importorskip("rasterio")
+    data = _tiny_geotiff()
+    results = {"out": {"href": "https://example.test/artifacts/r.tif", "type": "image/tiff"}}
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.url.path)
+        return httpx.Response(200, content=data, headers={"content-type": "image/tiff"})
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        fetched = client.geoprocessing().result_raster_bytes(results)
+
+    assert fetched == data
+    assert seen == ["/artifacts/r.tif"]
+
+
+def test_result_raster_bytes_without_value_or_href_raises() -> None:
+    # A raster member identified by mediaType whose ``href`` is empty, so there
+    # is neither a usable inline ``value`` nor a fetchable ``href``.
+    results = {"out": {"href": "", "mediaType": "image/tiff; application=geotiff"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError("no fetch expected")
+
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(HonuaError, match="neither an inline value nor an href"):
+            client.geoprocessing().result_raster_bytes(results)
+
+
+def test_execute_raster_end_to_end() -> None:
+    pytest.importorskip("rioxarray")
+    encoded = base64.b64encode(_tiny_geotiff()).decode("ascii")
+    results_outputs_map = {"coverage": {"value": encoded, "mediaType": "image/tiff; application=geotiff"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST":
+            return httpx.Response(201, json=_status("job-r", "accepted"))
+        if path == "/ogc/processes/jobs/job-r":
+            return httpx.Response(200, json=_status("job-r", "successful"))
+        if path == "/ogc/processes/jobs/job-r/results":
+            return httpx.Response(200, json=results_outputs_map)
+        raise AssertionError(f"unexpected {path}")
+
+    layer = LayerReference.from_geojson({"type": "FeatureCollection", "features": []})
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        array = client.geoprocessing().execute_raster("raster.kernel-density", layer, poll_interval=0.0)
+
+    assert float(array.sum()) == pytest.approx(66.0)
+
+
+@pytest.mark.anyio
+async def test_async_result_to_xarray_and_href() -> None:
+    pytest.importorskip("rioxarray")
+    data = _tiny_geotiff()
+    results = {"out": {"href": "https://example.test/artifacts/r.tif", "type": "image/tiff"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=data, headers={"content-type": "image/tiff"})
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        array = await client.geoprocessing().result_to_xarray(results)
+
+    assert float(array.sum()) == pytest.approx(66.0)
+
+
+@pytest.mark.anyio
+async def test_async_result_to_rasterio_inline() -> None:
+    pytest.importorskip("rasterio")
+    encoded = base64.b64encode(_tiny_geotiff()).decode("ascii")
+    results = {"coverage": {"value": encoded, "mediaType": "image/tiff; application=geotiff"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - inline needs no fetch
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        with await client.geoprocessing().result_to_rasterio(results) as dataset:
+            assert dataset.count == 1
+            assert dataset.width == 4
+
+
+@pytest.mark.anyio
+async def test_async_execute_raster_end_to_end() -> None:
+    pytest.importorskip("rioxarray")
+    encoded = base64.b64encode(_tiny_geotiff()).decode("ascii")
+    results_outputs_map = {"coverage": {"value": encoded, "mediaType": "image/tiff; application=geotiff"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST":
+            return httpx.Response(201, json=_status("job-ar", "accepted"))
+        if path == "/ogc/processes/jobs/job-ar":
+            return httpx.Response(200, json=_status("job-ar", "successful"))
+        if path == "/ogc/processes/jobs/job-ar/results":
+            return httpx.Response(200, json=results_outputs_map)
+        raise AssertionError(f"unexpected {path}")
+
+    layer = LayerReference.from_geojson({"type": "FeatureCollection", "features": []})
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        array = await client.geoprocessing().execute_raster("raster.kernel-density", layer, poll_interval=0.0)
+
+    assert float(array.sum()) == pytest.approx(66.0)


### PR DESCRIPTION
Clears the tractable SDK backlog: #124 (GP interop) and a safe slice of #129 (audit S2 maintainability).

## #124 — GP interop + process client (`Closes #124`)

Most of #124 already landed on `trunk` (compat surface un-stubbed via the layer-aware projection adapter in #120; `honua-gp` rename in #123; vector GeoDataFrame interop). The genuine remaining gap was **raster result interop**, delivered here:

- **New `honua_sdk.raster` module.** Pure, dependency-free output selection (`find_raster_output` / `inline_raster_bytes` / `raster_href`) plus conversions (`open_geotiff`, `geotiff_to_xarray`, `xarray_to_geotiff`).
- **New optional `raster` extra** (`rasterio` / `rioxarray` / `xarray`). The base SDK stays `httpx`-only; the helpers import the heavy geo stack **lazily** and raise a clear `ImportError` pointing at the extra when it is absent.
- **Geoprocessing client helpers** (sync + async): `result_raster_bytes`, `result_to_rasterio`, `result_to_xarray`, and `execute_raster` — mirroring the existing vector `execute_dataframe`. By-reference `href` outputs are fetched through the bound client so base URL / auth / retry policy apply.
- **Docs:** the "Honua computes, your ecosystem consumes" boundary + no-local-engine policy in `docs/protocol-examples.md`; raster extra wired into README / INSTALL / package docstring.

New interop is covered by `tests/test_geoprocessing_raster.py` (pure helpers run always; conversions/integration `importorskip` the extra and skip cleanly when absent).

## Related to #129 — maintainability (safe slice)

AUD-162 (`_text` per-call options) and AUD-208 (retry dead code) were already fixed on `trunk`; geocoding is already gen_sync-driven. This PR adds:

- **AUD-207 slice:** typed `SupportsSyncRequest` / `SupportsAsyncRequest` transport protocols; the geoprocessing facades now depend on them instead of `Any`, removing the leaky private-internals coupling (and the now-redundant `cast`s).
- **AUD-160 slice:** the `_async_retry.py` → `_retry.py` mirror pair is now under the `gen_sync` codegen + CI `--check` (new `import asyncio`→`import time`, `aread`→`read`, `handle_async_request`→`handle_request` transforms). `_retry.py` is generated from the async source-of-truth; behaviour is unchanged (docstring/comment-only diff).

### Deferred (still `#129`)
- Extending `gen_sync` to the `source`/`ogc`/`workflow`/`geoprocessing`/protocol facades requires splitting each single-file dual sync+async class into an async-source + generated-sync file (a larger restructure).
- Applying the typed host protocol across `protocols/_base.py` needs a richer contract that also covers the public methods (`query_features`/`apply_edits`/`export_map`) the geoservices subclasses call.
- Full geocoding request-layer reuse (it still keeps its own `_request`).

## Gates
ruff + mypy clean; `gen_sync --check` and the compatibility gate pass; full suite green (**1344 passed, 5 skipped**) at **94.5%** combined coverage; `honua-sdk` wheel builds with `raster.py` / `_client_protocol.py` included and the `raster` extra in metadata.