### PR TITLE
Guard intra-file sync/async twins under gen_sync --check (#129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ packages/honua-gp/eval/.audit/
 
 # Generated MkDocs static site output
 /site/
+.serena/

--- a/packages/honua-sdk/honua_sdk/protocols/ogc_extras.py
+++ b/packages/honua-sdk/honua_sdk/protocols/ogc_extras.py
@@ -721,6 +721,9 @@ class OgcRecordsCollectionClient:
     def items_all(self, **kwargs: Any) -> list[JsonObject]:
         return self.records_all(**kwargs)
 
+    def iter_items(self, **kwargs: Any) -> Iterator[JsonObject]:
+        yield from self.iter_records(**kwargs)
+
 
 class AsyncOgcRecordsClient(_AsyncProtocol):
     """Async OGC API Records wrapper."""
@@ -836,8 +839,41 @@ class AsyncOgcRecordsClient(_AsyncProtocol):
             return await self._json("POST", path, params=params, json_body=json_body)
         return await self._json("GET", path, params=params)
 
-    async def record_pages(self, collection_id: FeatureId, **kwargs: Any) -> AsyncIterator[JsonObject]:
-        async for page in self.collection(collection_id).record_pages(**kwargs):
+    async def record_pages(
+        self,
+        collection_id: FeatureId,
+        *,
+        response_format: str = "json",
+        extra_params: Params = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        page_size: int | None = None,
+        max_pages: int | None = None,
+        bbox: BboxValue | None = None,
+        datetime: str | None = None,
+        filter: str | None = None,
+        q: str | None = None,
+        ids: CsvValue | None = None,
+        properties: CsvValue | None = None,
+        sortby: str | None = None,
+        type: str | None = None,
+    ) -> AsyncIterator[JsonObject]:
+        async for page in self.collection(collection_id).record_pages(
+            response_format=response_format,
+            extra_params=extra_params,
+            limit=limit,
+            offset=offset,
+            page_size=page_size,
+            max_pages=max_pages,
+            bbox=bbox,
+            datetime=datetime,
+            filter=filter,
+            q=q,
+            ids=ids,
+            properties=properties,
+            sortby=sortby,
+            type=type,
+        ):
             yield page
 
     async def records_all(self, collection_id: FeatureId, **kwargs: Any) -> list[JsonObject]:

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -29,11 +29,21 @@ the build.
 Whenever a sync/async pair drifts in a way this transform cannot express,
 *reconcile the divergence in the async source* and extend the replacement table
 below — never hand-edit a generated sync file (its header says as much).
+
+In addition to the fully-generated file-pairs (``TARGETS``), the ``--check``
+mode also guards the hand-maintained **intra-file sync/async twins**
+(``TWIN_TARGETS``: the protocol / source / ogc / workflow / geoprocessing
+facades, where a sync class lives next to its ``Async`` twin in one module).
+Those twins are not whole-file generated — a few methods legitimately diverge in
+their bodies beyond the mechanical transform — so :func:`check_twins` instead
+verifies that both classes expose the *same method surface* (names + signatures,
+modulo the async→sync transform), failing the build on any silent drift.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
 import difflib
 import re
 import subprocess
@@ -262,6 +272,180 @@ TARGETS: tuple[Target, ...] = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Intra-file sync/async twin guard (AUD-160/161, issue #129)
+# ---------------------------------------------------------------------------
+#
+# The ``TARGETS`` above cover the async→sync *file-pair* mirrors, which are
+# fully generated. A second family of sync/async duplication lives *inside a
+# single module*: the protocol / source / ogc / workflow / geoprocessing
+# facades each ship a hand-written sync class next to its ``Async`` twin
+# (``Source``/``AsyncSource``, ``WfsClient``/``AsyncWfsClient``, …). These are
+# NOT whole-file generated because a handful of methods legitimately diverge in
+# their *bodies* beyond the mechanical transform (e.g. ``anyio.to_thread`` for
+# blocking file I/O in ``geoservices``; ``asyncio.CancelledError`` handling in
+# ``geoprocessing``). They can therefore still silently drift in their *public
+# surface* — a method or parameter added to one twin but not the other.
+#
+# The guard below closes that gap: for every registered twin pair it verifies
+# that the two classes expose the **same set of methods with the same
+# signatures** (modulo the mechanical async→sync transform). Signatures are
+# normalized via :func:`ast.unparse` so formatting/whitespace never matters —
+# only the actual method surface. This runs as part of ``gen_sync.py --check``
+# (CI), so a divergent twin fails the build exactly like a stale file-pair.
+#
+# Twin classes are *not* rewritten by ``gen_sync.py`` (unlike ``TARGETS``);
+# they remain hand-maintained. The guard only *verifies* parity.
+
+# Extra replacements needed for the intra-file twins whose sync/async seam is
+# an *infix* ``Sync``/``Async`` (not the leading ``Async`` prefix handled by
+# ``_COMMON_RULES``): the typed request protocols and the shared protocol base.
+_TWIN_EXTRA_RULES: tuple[Rule, ...] = (
+    _rule(r"\bSupportsAsync", "SupportsSync"),
+    _rule(r"\b_AsyncProtocol\b", "_SyncProtocol"),
+)
+_TWIN_RULES: tuple[Rule, ...] = _COMMON_RULES + _TWIN_EXTRA_RULES
+
+_SDK_ROOT = ROOT / "packages/honua-sdk/honua_sdk"
+
+
+@dataclass(frozen=True)
+class Twin:
+    """A module holding hand-maintained sync/async twin classes to keep in lockstep.
+
+    ``pairs`` maps each ``async_class`` name to its ``sync_class`` name within
+    ``source``. The guard checks that the two classes expose an identical
+    method surface once the async names/signatures are mechanically transformed.
+    """
+
+    source: Path
+    pairs: tuple[tuple[str, str], ...]
+
+    @property
+    def source_rel(self) -> str:
+        return self.source.relative_to(ROOT).as_posix()
+
+
+TWIN_TARGETS: tuple[Twin, ...] = (
+    Twin(
+        _SDK_ROOT / "source.py",
+        (("AsyncSourceClientProtocol", "SourceClientProtocol"), ("AsyncSource", "Source")),
+    ),
+    Twin(
+        _SDK_ROOT / "ogc.py",
+        (
+            ("AsyncHonuaOgcFeatures", "HonuaOgcFeatures"),
+            ("AsyncHonuaOgcFeatureCollection", "HonuaOgcFeatureCollection"),
+        ),
+    ),
+    Twin(_SDK_ROOT / "workflow.py", (("AsyncHonuaWorkflow", "HonuaWorkflow"),)),
+    Twin(_SDK_ROOT / "geoprocessing.py", (("AsyncHonuaGeoprocessing", "HonuaGeoprocessing"),)),
+    Twin(_SDK_ROOT / "protocols/_base.py", (("_AsyncProtocol", "_SyncProtocol"),)),
+    Twin(
+        _SDK_ROOT / "protocols/geoservices.py",
+        (
+            ("AsyncGeoServicesFeatureServerClient", "GeoServicesFeatureServerClient"),
+            ("AsyncGeoServicesMapServerClient", "GeoServicesMapServerClient"),
+            ("AsyncGeoServicesImageServerClient", "GeoServicesImageServerClient"),
+            ("AsyncGeoServicesGeometryServerClient", "GeoServicesGeometryServerClient"),
+        ),
+    ),
+    Twin(_SDK_ROOT / "protocols/odata.py", (("AsyncODataClient", "ODataClient"),)),
+    Twin(
+        _SDK_ROOT / "protocols/ogc_extras.py",
+        (
+            ("AsyncOgcMapsClient", "OgcMapsClient"),
+            ("AsyncOgcTilesClient", "OgcTilesClient"),
+            ("AsyncOgcCoveragesClient", "OgcCoveragesClient"),
+            ("AsyncOgcProcessesClient", "OgcProcessesClient"),
+            ("AsyncOgcRecordsClient", "OgcRecordsClient"),
+            ("AsyncOgcRecordsCollectionClient", "OgcRecordsCollectionClient"),
+        ),
+    ),
+    Twin(
+        _SDK_ROOT / "protocols/scenes.py",
+        (("AsyncSceneClient", "SceneClient"), ("AsyncElevationClient", "ElevationClient")),
+    ),
+    Twin(_SDK_ROOT / "protocols/stac.py", (("AsyncStacClient", "StacClient"),)),
+    Twin(_SDK_ROOT / "protocols/wfs.py", (("AsyncWfsClient", "WfsClient"),)),
+    Twin(_SDK_ROOT / "protocols/wms.py", (("AsyncWmsClient", "WmsClient"),)),
+    Twin(_SDK_ROOT / "protocols/wmts.py", (("AsyncWmtsClient", "WmtsClient"),)),
+)
+
+
+def _transform_twin(text: str) -> str:
+    for rule in _TWIN_RULES:
+        text = rule.apply(text)
+    return text
+
+
+def _class_def(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise KeyError(name)
+
+
+def _twin_method_surface(node: ast.ClassDef) -> dict[str, str]:
+    """Map each method name to a normalized ``name(args) -> return`` signature."""
+    surface: dict[str, str] = {}
+    for child in node.body:
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            args = ast.unparse(child.args)
+            returns = ast.unparse(child.returns) if child.returns is not None else ""
+            surface[child.name] = f"{child.name}({args}) -> {returns}"
+    return surface
+
+
+def check_twins() -> list[str]:
+    """Return a list of drift messages for the intra-file sync/async twins.
+
+    Each pair passes when the async class, once mechanically transformed to its
+    sync form, exposes exactly the sync class's method surface.
+    """
+    problems: list[str] = []
+    for twin in TWIN_TARGETS:
+        tree = ast.parse(twin.source.read_text(encoding="utf-8"))
+        for async_name, sync_name in twin.pairs:
+            try:
+                async_node = _class_def(tree, async_name)
+                sync_node = _class_def(tree, sync_name)
+            except KeyError as exc:
+                problems.append(f"{twin.source_rel}: missing twin class {exc}")
+                continue
+            sync_surface = _twin_method_surface(sync_node)
+            async_surface = {
+                # Transform the whole ``name(args) -> ret`` signature so that
+                # async-only dunder names (``__aenter__`` → ``__enter__``) and
+                # async return types (``AsyncIterator`` → ``Iterator``) line up.
+                sig.split("(", 1)[0]: sig
+                for sig in (
+                    _transform_twin(raw)
+                    for raw in _twin_method_surface(async_node).values()
+                )
+            }
+            only_async = sorted(set(async_surface) - set(sync_surface))
+            only_sync = sorted(set(sync_surface) - set(async_surface))
+            if only_async:
+                problems.append(
+                    f"{twin.source_rel}: {async_name} has method(s) missing from "
+                    f"{sync_name}: {only_async}"
+                )
+            if only_sync:
+                problems.append(
+                    f"{twin.source_rel}: {sync_name} has method(s) missing from "
+                    f"{async_name}: {only_sync}"
+                )
+            for name in sorted(set(async_surface) & set(sync_surface)):
+                if async_surface[name] != sync_surface[name]:
+                    problems.append(
+                        f"{twin.source_rel}: signature drift in {name}()\n"
+                        f"    {sync_name}: {sync_surface[name]}\n"
+                        f"    {async_name}: {async_surface[name]}"
+                    )
+    return problems
+
+
 def _ruff_fix_imports(text: str, dest: Path) -> str:
     """Re-sort imports in the generated source via ``ruff``.
 
@@ -368,14 +552,25 @@ def check_all() -> int:
                 tofile=f"{target.dest_rel} (regenerated)",
             )
             sys.stderr.writelines(diff)
+
+    twin_problems = check_twins()
+
     if stale:
         sys.stderr.write(
             "\nStale generated sync file(s): "
             + ", ".join(stale)
             + "\nRun `python scripts/gen_sync.py` and commit the result.\n"
         )
+    if twin_problems:
+        sys.stderr.write(
+            "\nSync/async twin drift (intra-file mirrors, issue #129):\n"
+            + "\n".join(f"  - {problem}" for problem in twin_problems)
+            + "\nReconcile the divergent twin so both classes expose the same "
+            "method surface.\n"
+        )
+    if stale or twin_problems:
         return 1
-    print("Generated sync files are up to date.")
+    print("Generated sync files are up to date; sync/async twins are in lockstep.")
     return 0
 
 

--- a/tests/test_gen_sync_twins.py
+++ b/tests/test_gen_sync_twins.py
@@ -1,0 +1,84 @@
+"""Guard that the intra-file sync/async twins stay in lockstep.
+
+AUD-160/161 (issue #129): ``scripts/gen_sync.py`` fully generates the async→sync
+*file-pair* mirrors, but the protocol / source / ogc / workflow / geoprocessing
+facades keep a hand-written sync class next to its ``Async`` twin *inside a
+single module*. Those twins are not whole-file generated (a few methods diverge
+in their bodies beyond the mechanical transform), so they can silently drift in
+their public surface — a method or parameter added to one twin but not the
+other.
+
+``gen_sync.check_twins()`` verifies the twin pairs expose the same method
+surface; these tests wire it into the pytest gate and additionally fail CI if a
+new ``Async*`` twin class is added to a covered module without being registered
+in ``gen_sync.TWIN_TARGETS`` (so it cannot escape the parity guard).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GEN_SYNC_PATH = ROOT / "scripts" / "gen_sync.py"
+
+SPEC = importlib.util.spec_from_file_location("gen_sync", GEN_SYNC_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+gen_sync = importlib.util.module_from_spec(SPEC)
+sys.modules["gen_sync"] = gen_sync
+SPEC.loader.exec_module(gen_sync)
+
+SDK_ROOT = ROOT / "packages" / "honua-sdk" / "honua_sdk"
+
+# Modules where every ``Async*`` twin class must be registered in TWIN_TARGETS.
+# The protocol package is the main extension point for new protocol clients;
+# the four facades below each host a sync/async twin pair as well.
+_SCANNED_FILES = [
+    *sorted((SDK_ROOT / "protocols").glob("*.py")),
+    SDK_ROOT / "source.py",
+    SDK_ROOT / "ogc.py",
+    SDK_ROOT / "workflow.py",
+    SDK_ROOT / "geoprocessing.py",
+]
+
+
+def _async_twin_classes(path: Path) -> set[str]:
+    """Top-level classes whose name starts with ``Async`` / ``_Async``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+        and (node.name.startswith("Async") or node.name.startswith("_Async"))
+    }
+
+
+def test_twins_are_in_lockstep() -> None:
+    problems = gen_sync.check_twins()
+    assert not problems, "sync/async twin drift:\n" + "\n".join(problems)
+
+
+def test_every_async_twin_is_registered() -> None:
+    registered: set[str] = {
+        async_name for twin in gen_sync.TWIN_TARGETS for async_name, _ in twin.pairs
+    }
+    missing: dict[str, set[str]] = {}
+    for path in _SCANNED_FILES:
+        if not path.exists():
+            continue
+        unregistered = _async_twin_classes(path) - registered
+        if unregistered:
+            missing[str(path.relative_to(ROOT))] = unregistered
+    assert not missing, (
+        "async twin class(es) not registered in scripts/gen_sync.py TWIN_TARGETS "
+        "(they would escape the twin parity guard): "
+        f"{ {k: sorted(v) for k, v in missing.items()} }"
+    )
+
+
+def test_all_twin_targets_point_at_existing_files() -> None:
+    for twin in gen_sync.TWIN_TARGETS:
+        assert twin.source.exists(), f"missing twin source: {twin.source_rel}"


### PR DESCRIPTION
## Summary

Finishes the remaining sync/async anti-duplication work from the S2 audit (#129), plus a precise diagnosis of the two adjacent open issues (#157, #53).

## #129 — sync/async duplication + codegen drift (Closes #129)

The `gen_sync` codegen + CI `--check` mechanism already covered the async→sync **file-pair** mirrors (client, geocoding, retry, admin — landed in #156). The **intra-file twins** — the protocol / source / ogc / workflow / geoprocessing facades, where a hand-written sync class lives next to its `Async` twin in a single module — were unguarded and free to silently diverge in their public surface.

- **New twin-parity guard** in `scripts/gen_sync.py` (`TWIN_TARGETS` + `check_twins`), wired into `gen_sync.py --check`. For every registered sync/async twin pair it verifies both classes expose the **same method surface** (names + signatures, normalized via `ast.unparse` and the async→sync transform). The twins stay hand-maintained because a few method bodies legitimately diverge beyond the mechanical transform (`anyio.to_thread` file I/O in `geoservices`, `asyncio.CancelledError` handling in `geoprocessing`), but they can no longer drift in their surface. 14 files / 24 twin pairs are now covered.
- **New CI test** `tests/test_gen_sync_twins.py`: enforces parity and fails CI if a new `Async*` twin class is added to a covered module without being registered (so nothing escapes the guard, mirroring `test_gen_sync_targets.py`).
- **Two real divergences the guard surfaced and this PR fixes:**
  - `AsyncOgcRecordsClient.record_pages` had degraded to `**kwargs` while the sync twin kept the explicit typed keyword signature → restored the explicit signature on the async twin.
  - `OgcRecordsCollectionClient` was missing `iter_items` (present on the async twin) → added it so the collection surface is symmetric.

The other audit items are already resolved on trunk (via #156): AUD-162 (`_text` routes through the client request path so per-call options apply), the leaky-abstraction typing (`SupportsSyncRequest`/`SupportsAsyncRequest` in `protocols/_base.py`), and the retry dead-code tail. AUD-161's geocoding sync/async dedup is likewise handled — `async_geocoding.py` → `geocoding.py` is a generated file-pair and already reuses `_endpoints.parse_json_response_body`. (Residual optional nicety, not a drift gap: the standalone geocoding client still builds its own httpx transport rather than sharing the main client's transport layer.)

### Gates (all green locally)
- `python scripts/gen_sync.py --check` → *"Generated sync files are up to date; sync/async twins are in lockstep."*
- `ruff check .` → clean; `mypy` → clean; `compatibility_gate.py` → passed
- `pytest tests/` → 1345 passed, 14 skipped; combined coverage 94.29% (≥94)

## #157 — ephemeral-server-smoke supported-surface 46% (Related to #157)

Reproduced live against the seeded client-compat honua-server. **All 13 failing "supported" GP ops fail identically: HTTP 404 `Process '<id>' does not exist`, at process-id resolution before any payload/layer validation** — so none is an SDK payload bug and none is a seed-fixture gap (the seeded `test_service/0` layer exists with the referenced fields). Root cause: the pinned `ghcr.io/honua-io/honua-server:latest-aot` image is **stale** (revision `9174f8d4`, built 2026-04-28), predating honua-server **#1382** (per-op OGC-process projection, merged 2026-06-05). At that revision the server exposes only the umbrella `honua-geoprocessing` process, so every per-op id 404s.

On **current** honua-server trunk the surface splits:
- **9 vector ops** (buffer ×3 + buffer_then_dissolve, spatial_join ×2, dissolve, project ×2) map to first-slice `gp.vector-deterministic` processes (`CanServe = true`) and are projected as standalone OGC processes → the 404 clears on a post-#1382 image.
- **4 data-management ops** (`calculate_field_constant`, `copy_pavement_to_backup`, `copy_features_alias`, `copy_then_calculate_field`) target `data-management.calculate-field` / `data-management.copy-features`, which honua-server classifies `CanServe = false` **by design** — they are never standalone OGC processes on any version; they are only reachable as steps inside a `honua-geoprocessing` analysis plan.

**Why it can't be cleanly closed here:** reaching 100% needs cross-repo work I cannot land/verify in this repo — (a) re-pin the ephemeral image to a post-#1382 build (fixes the 9, pending executor verification), and (b) for the 4 data-management ops either honua-server must project them as standalone processes or the honua-gp shim must route Copy/CalculateField through the `honua-geoprocessing` plan surface (and the eval reclassify them `expected_failure` — which the harness models as a client-side `HonuaGpUnsupportedError`, requiring the shim change). Full evidence + remediation posted to #157.

## #53 — live staging target (Related to #53)

demo.honua.io is healthy and reachable, but **cannot satisfy the staging smoke suite's required probes**: `query_seeded_layer` asserts the synthetic field set `{objectid, name, status, count, ratio, uid}` and the (enabled) `apply_edits_roundtrip` write smoke expects that same writable synthetic schema + point geometry — both hardwired to the `client-compat-v1.sql` seed (`test_service` / layer 0). demo.honua.io has **no `test_service`** and only curated real Maui datasets (e.g. `maui-buildings` at layer 13), and it is not an appropriate target for destructive write smoke. Pointing `HONUA_BASE_URL` at it would flip `local_stack=false` and fail the required probes, regressing the currently-green seeded-local run — so no repo variable was set. #53 needs a live target **seeded with the client-compat profile**, i.e. an infra/provisioning decision, not a variable flip. Precise requirements posted to #53.