### PR TITLE
ci(staging): make write smoke opt-out per staging target (#53)

### DIFF
--- a/.github/workflows/staging-integration.yml
+++ b/.github/workflows/staging-integration.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   PYTHON_VERSION: "3.11"
-  HONUA_ENABLE_WRITE_SMOKE: "true"
   HONUA_SMOKE_RESULTS_PATH: "staging-smoke-results.json"
   HONUA_SMOKE_UID_PREFIX: "sdk-python-smoke-${{ github.run_id }}-${{ github.run_attempt }}"
 
@@ -29,6 +28,13 @@ jobs:
       packages: read
     environment: staging
     env:
+      # Write (applyEdits) smoke defaults on, but a live staging target that
+      # does not offer FeatureServer editing (e.g. a Community-edition server,
+      # where edits require the Pro `editing.featureserver-edits` entitlement)
+      # can opt out by setting HONUA_ENABLE_WRITE_SMOKE=false in the `staging`
+      # environment. Defaults to true when the variable is unset (the
+      # seeded-local fallback and Pro-edition targets keep write coverage).
+      HONUA_ENABLE_WRITE_SMOKE: ${{ vars.HONUA_ENABLE_WRITE_SMOKE || 'true' }}
       HONUA_BASE_URL: ${{ vars.HONUA_BASE_URL }}
       HONUA_SERVICE_ID: ${{ vars.HONUA_SERVICE_ID }}
       HONUA_LAYER_ID: ${{ vars.HONUA_LAYER_ID }}


### PR DESCRIPTION
## Summary
Wires the `staging` GitHub Actions environment to the live demo (demo.honua.io) for #53 and makes the applyEdits write smoke opt-out per target.

The staging-smoke job previously hard-enabled the write smoke via a top-level `HONUA_ENABLE_WRITE_SMOKE=true`. demo.honua.io runs the **Community** edition, where FeatureServer editing requires the Pro `editing.featureserver-edits` entitlement, so the write roundtrip returns HTTP 402 against it. This change sources the flag from the `staging` environment (default `true`), so a live target without editing can opt out while read/metadata/protocol coverage still runs live.

## Changes
- Move `HONUA_ENABLE_WRITE_SMOKE` out of the top-level `env` into the job env as `${{ vars.HONUA_ENABLE_WRITE_SMOKE || 'true' }}` (respects the `staging` environment; defaults on for the seeded-local fallback and Pro targets).

## Staging environment (configured out-of-band)
- `HONUA_BASE_URL=https://demo.honua.io`, `HONUA_SERVICE_ID=test_service`, `HONUA_LAYER_ID=68823`, `HONUA_SEED_PROFILE=client-compat`, `HONUA_SERVER_IMAGE/COMMIT`, `HONUA_ENABLE_WRITE_SMOKE=false`, secret `HONUA_API_KEY`.

Related to #53