### PR TITLE
fix(compat): reconcile server-matrix metadata schema to metadata.honua.io/v2alpha1

### DIFF
--- a/compatibility/server-matrix.json
+++ b/compatibility/server-matrix.json
@@ -20,7 +20,7 @@
         },
         "metadataSchemas": [
           {
-            "version": "v1",
+            "version": "metadata.honua.io/v2alpha1",
             "deprecated": false
           }
         ],
@@ -55,7 +55,7 @@
         },
         "metadataSchemas": [
           {
-            "version": "v1",
+            "version": "metadata.honua.io/v2alpha1",
             "deprecated": false
           }
         ],
@@ -88,7 +88,7 @@
         },
         "metadataSchemas": [
           {
-            "version": "v1",
+            "version": "metadata.honua.io/v2alpha1",
             "deprecated": false
           }
         ],
@@ -189,7 +189,7 @@
         },
         "metadataSchemas": [
           {
-            "version": "v1",
+            "version": "metadata.honua.io/v2alpha1",
             "deprecated": false
           }
         ],
@@ -221,7 +221,7 @@
         },
         "metadataSchemas": [
           {
-            "version": "v1",
+            "version": "metadata.honua.io/v2alpha1",
             "deprecated": false
           }
         ],

--- a/tests/admin/test_compatibility.py
+++ b/tests/admin/test_compatibility.py
@@ -47,8 +47,8 @@ def _make_capabilities_payload(
                 "deprecated": deprecated,
             },
             "metadataSchemas": [
-                {"version": "v1", "deprecated": False},
-                {"version": "v1beta1", "deprecated": True},
+                {"version": "metadata.honua.io/v2alpha1", "deprecated": False},
+                {"version": "metadata.honua.io/v1", "deprecated": True},
             ],
             "features": {
                 "metadataResources": metadata_resources,
@@ -62,7 +62,7 @@ def _make_capabilities_payload(
     if include_legacy_fields:
         payload.update(
             {
-                "metadataApiVersions": ["v1", "v1beta1"],
+                "metadataApiVersions": ["metadata.honua.io/v2alpha1", "metadata.honua.io/v1"],
                 "resourceKinds": ["Layer", "Service"],
                 "manifestSupported": True,
                 "manifestDryRunSupported": True,


### PR DESCRIPTION
## Summary

The honua-server capability envelope advertises the metadata surface as `metadata.honua.io/v2alpha1` (`MetadataV2Constants.ApiVersion`; schemaVersion `2.0.0-alpha.1`), but the Python SDK's compatibility fixtures still declared the legacy `v1` expectation. This reconciles them.

## Changes Made

- `compatibility/server-matrix.json`: the 5 supported-server cases (minimum-preview, current-stable, deprecated-compatible-control-plane, legacy-control-plane-base-path, pre-preview-release-channel) now advertise `metadataSchemas[].version = "metadata.honua.io/v2alpha1"`. The `server-version-below-baseline` (`v1beta1`) and `unsupported-control-plane-major` (`v2`) cases keep their existing values — they intentionally model non-current / breaking servers.
- `tests/admin/test_compatibility.py`: the `_make_capabilities_payload` fixture now advertises `metadata.honua.io/v2alpha1` as the current (non-deprecated) schema and `metadata.honua.io/v1` as the deprecated legacy schema; the legacy `metadataApiVersions` flat list is updated to match.

The exact `version` string matches what the server emits: `AdminInfoEndpoints` sets `metadataSchemas[].Version = MetadataV2Constants.ApiVersion = "metadata.honua.io/v2alpha1"`. The `2.0.0-alpha.1` SchemaVersion is a separate sibling field (`metadataSchemaVersion`), not the array's `version`, so it is not the value used here.

## Verification

- `python scripts/compatibility_gate.py` → passed
- `pytest tests/admin/test_compatibility.py tests/test_compatibility_gate.py` → 16 passed
- `pytest tests/admin` → 157 passed
- `ruff check` → clean

Closes #161