### PR TITLE
fix(honua-gp): ephemeral-server-smoke supported-surface to 100% (#157)

### DIFF
--- a/.github/workflows/honua-gp-eval.yml
+++ b/.github/workflows/honua-gp-eval.yml
@@ -119,20 +119,16 @@ jobs:
       HONUA_API_KEY: ${{ secrets.HONUA_API_KEY }}
       # NOTE (issue #157): the layer-aware vector ops (Buffer / SpatialJoin /
       # Dissolve / Project -> analytics.buffer-aggregate / analytics.spatial-join
-      # / generalization.dissolve / conversion.feature-project) cannot yet run
-      # end-to-end against ANY current honua-server AOT image. Post-#1382 images
-      # DO advertise + accept those per-op OGC processes (the process-resolution
-      # 404 is gone), but the geoprocessing dispatch runtime only registers the
-      # ``*-managed`` executors (analytics.buffer-aggregate-managed, ...) plus
-      # the geometry.*/transform.*/overlay.* families -- the per-op projection
-      # never remaps to the managed id, so the async job is refused with
-      # "unsupported process id ... this slice" and never reaches a terminal
-      # state (verified live on nightly-aot-20260628 and -20260630). Pinning a
-      # post-#1382 image here would therefore turn the fast per-op 404 into a
-      # 600s-per-op poll hang, so we do NOT re-pin until honua-server wires the
-      # OGC per-op execution path to the managed runtime. See #157 for the full
-      # ground-truth diagnosis and the tracked honua-server follow-up.
-      HONUA_LOCAL_SERVER_IMAGE: ${{ vars.HONUA_LOCAL_SERVER_IMAGE || 'ghcr.io/honua-io/honua-server:latest-aot' }}
+      # / generalization.dissolve / conversion.feature-project) now run
+      # end-to-end once honua-server#2327 wired the per-op OGC projections to the
+      # managed geoprocessing executors. That fix is NOT in the old
+      # ``latest-aot`` tag (stuck on an April build that predates the in-process
+      # GP dispatch worker, so every layer-aware job hangs in ``Queued``), so we
+      # pin ``nightly-aot`` -- verified live (2026-07 build): buffer x3 +
+      # buffer_then_dissolve, dissolve, project x2, and spatial-join x2 all reach
+      # a terminal SUCCEEDED. Operators can override via the
+      # ``HONUA_LOCAL_SERVER_IMAGE`` repo variable to pin a dated build.
+      HONUA_LOCAL_SERVER_IMAGE: ${{ vars.HONUA_LOCAL_SERVER_IMAGE || 'ghcr.io/honua-io/honua-server:nightly-aot' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -207,6 +203,17 @@ jobs:
                   echo "honua-gp smoke seed complete."
             honua:
               image: ${HONUA_LOCAL_SERVER_IMAGE}
+              environment:
+                # Run the ephemeral server in Development (same as the
+                # tests/conformance lane): the client-compat seed only activates
+                # its metadata-v2 snapshot for default/Development/Test, and
+                # Licensing:DevGrantEdition is fail-closed in Production. Granting
+                # the Enterprise edition without a signed license lets the write
+                # eval scripts (da.InsertCursor -> FeatureServer applyEdits, gated
+                # on ``editing.featureserver-edits`` since honua-server#1591)
+                # exercise editing end-to-end. Test/CI only -- never in prod.
+                ASPNETCORE_ENVIRONMENT: Development
+                Licensing__DevGrantEdition: Enterprise
               ports:
                 - "5000:5000"
           YAML
@@ -237,6 +244,14 @@ jobs:
             docker compose -f "${compose_file}" -f "${override_file}" logs honua | tail -100 || true
             exit 1
           fi
+          # The canonical client-compat seed registers a single layer (layer 0).
+          # honua-server's analytics.spatial-join rejects a self-join, so the
+          # SpatialJoin eval scripts need a second, distinct join layer. Apply
+          # the in-repo second-layer fixture against the seeded postgres. See
+          # packages/honua-gp/eval/seed/spatial-join-second-layer.sql (#157).
+          second_layer_sql="${GITHUB_WORKSPACE}/packages/honua-gp/eval/seed/spatial-join-second-layer.sql"
+          docker compose -f "${compose_file}" -f "${override_file}" exec -T postgres \
+            psql -U postgres -d honua_compat -v ON_ERROR_STOP=1 < "${second_layer_sql}"
 
       - name: Run ephemeral smoke
         env:

--- a/packages/honua-gp/eval/_generate_scripts.py
+++ b/packages/honua-gp/eval/_generate_scripts.py
@@ -250,12 +250,19 @@ print(f"insert_cursor_then_search ok rows={len(rows)}")
 EXPECTED_FAILURE_TEMPLATES: list[ScriptSpec] = []
 
 
-def _expected_failure(slug: str, body: str, marker: str) -> ScriptSpec:
+def _expected_failure(
+    slug: str,
+    body: str,
+    marker: str,
+    *,
+    docstring: str | None = None,
+    workspace: str = "legacy",
+) -> ScriptSpec:
     full_slug = f"expected_failure_{slug}"
     spec = ScriptSpec(
         slug=full_slug,
-        workspace="legacy",
-        docstring=f"Expected-failure script exercising {marker}.",
+        workspace=workspace,
+        docstring=docstring if docstring is not None else f"Expected-failure script exercising {marker}.",
         body=f"""try:
 {body}
 except arcpy.HonuaGpUnsupportedError as exc:
@@ -298,11 +305,16 @@ print(f"buffer_legacy_suffix ok output={result[0]}")
     1,
     "buffer_legacy_suffix ok",
 )
+# SpatialJoin: the join_features MUST resolve to a different layerId than
+# target_features -- honua-server's analytics.spatial-join rejects a self-join
+# ("joinLayerId must differ from the target layerId"). The trailing ``/1`` on
+# the join path resolves to layer 1, which the ephemeral-server-smoke seeds via
+# packages/honua-gp/eval/seed/spatial-join-second-layer.sql. Keep join at /1.
 _supported(
     "spatial_join_addresses_parcels",
     "transport",
     "Spatial join addresses to parcels via analytics.spatial-join.",
-    """result = arcpy.analysis.SpatialJoin("honua://services/addresses/0", "honua://services/parcels/0", "addresses_with_parcel", match_option="INTERSECT")
+    """result = arcpy.analysis.SpatialJoin("honua://services/addresses/0", "honua://services/parcels/1", "addresses_with_parcel", match_option="INTERSECT")
 print(f"spatial_join_addresses_parcels ok output={result[0]}")
 """,
     1,
@@ -312,7 +324,7 @@ _supported(
     "spatial_join_with_radius",
     "transport",
     "Spatial join within a distance via the dwithin predicate.",
-    """result = arcpy.analysis.SpatialJoin("honua://services/facilities/0", "honua://services/parcels/0", "out", match_option="WITHIN_A_DISTANCE", search_radius="100 Meters")
+    """result = arcpy.analysis.SpatialJoin("honua://services/facilities/0", "honua://services/parcels/1", "out", match_option="WITHIN_A_DISTANCE", search_radius="100 Meters")
 print(f"spatial_join_with_radius ok output={result[0]}")
 """,
     1,
@@ -328,25 +340,36 @@ print(f"dissolve_parcels_by_zoning ok output={result[0]}")
     1,
     "dissolve_parcels_by_zoning ok",
 )
-_supported(
+# data-management.copy-features / .calculate-field are CanServe=false by design
+# (honua-server#1382): never projected as standalone OGC API processes, only
+# reachable inside a honua-geoprocessing analysis plan. A one-shot execute 404s
+# on every server version, so the shim raises HonuaGpUnsupportedError and these
+# are expected-unsupported, not supported (honua-sdk-python#159).
+_expected_failure(
     "copy_pavement_to_backup",
-    "transport",
-    "Copy features into a backup layer via data-management.copy-features.",
-    """result = arcpy.management.Copy("honua://services/pavement/0", "pavement_backup")
-print(f"copy_pavement_to_backup ok output={result[0]}")
+    """    arcpy.management.Copy("honua://services/pavement/0", "pavement_backup")""",
+    "management.Copy",
+    docstring="""Expected-failure: Copy has no standalone honua-server process.
+
+honua-server classifies ``data-management.copy-features`` as CanServe=false; it
+is only reachable inside a honua-geoprocessing analysis plan, so a one-shot Copy
+404s on every server version. The shim surfaces that as a client-side
+``HonuaGpUnsupportedError``.
 """,
-    1,
-    "copy_pavement_to_backup ok",
+    workspace="transport",
 )
-_supported(
+_expected_failure(
     "copy_features_alias",
-    "transport",
-    "CopyFeatures alias routes through the same copy-features process.",
-    """result = arcpy.management.CopyFeatures("honua://services/parcels_stage/0", "parcels_published")
-print(f"copy_features_alias ok output={result[0]}")
+    """    arcpy.management.CopyFeatures("honua://services/parcels_stage/0", "parcels_published")""",
+    "management.CopyFeatures",
+    docstring="""Expected-failure: CopyFeatures has no standalone honua-server process.
+
+honua-server classifies ``data-management.copy-features`` as CanServe=false; it
+is only reachable inside a honua-geoprocessing analysis plan, so a one-shot
+Copy / CopyFeatures 404s on every server version. The shim surfaces that as a
+client-side ``HonuaGpUnsupportedError``.
 """,
-    1,
-    "copy_features_alias ok",
+    workspace="transport",
 )
 _supported(
     "project_roads_to_wgs84",
@@ -358,15 +381,18 @@ print(f"project_roads_to_wgs84 ok output={result[0]}")
     1,
     "project_roads_to_wgs84 ok",
 )
-_supported(
+_expected_failure(
     "calculate_field_constant",
-    "transport",
-    "CalculateField with a SQL/constant expression via data-management.calculate-field.",
-    """result = arcpy.management.CalculateField("honua://services/segments/0", "active", "1", where_clause="status = 'OPEN'")
-print(f"calculate_field_constant ok output={result[0]}")
+    """    arcpy.management.CalculateField("honua://services/segments/0", "active", "1", where_clause="status = 'OPEN'")""",
+    "management.CalculateField",
+    docstring="""Expected-failure: CalculateField has no standalone honua-server process.
+
+honua-server classifies ``data-management.calculate-field`` as CanServe=false;
+it is only reachable inside a honua-geoprocessing analysis plan, so a one-shot
+CalculateField 404s on every server version. The shim surfaces that as a
+client-side ``HonuaGpUnsupportedError``.
 """,
-    1,
-    "calculate_field_constant ok",
+    workspace="transport",
 )
 _supported(
     "buffer_then_dissolve",
@@ -400,16 +426,19 @@ print(f"project_kilometers_buffer ok output={result[0]}")
     2,
     "project_kilometers_buffer ok",
 )
-_supported(
+_expected_failure(
     "copy_then_calculate_field",
-    "transport",
-    "Copy features then calculate a constant field on the source layer.",
-    """arcpy.management.Copy("honua://services/stage/0", "published")
-result = arcpy.management.CalculateField("honua://services/stage/0", "reviewed", "1")
-print(f"copy_then_calculate_field ok output={result[0]}")
+    """    arcpy.management.Copy("honua://services/stage/0", "published")
+    arcpy.management.CalculateField("honua://services/stage/0", "reviewed", "1")""",
+    "management.Copy",
+    docstring="""Expected-failure: a Copy-then-CalculateField chain raises on the first step.
+
+Both ``data-management.copy-features`` and ``data-management.calculate-field``
+are classified CanServe=false on honua-server (only reachable inside a
+honua-geoprocessing analysis plan), so the leading Copy already raises a
+client-side ``HonuaGpUnsupportedError`` before CalculateField is reached.
 """,
-    2,
-    "copy_then_calculate_field ok",
+    workspace="transport",
 )
 
 # ---------------------------------------------------------------------------

--- a/packages/honua-gp/eval/scripts/spatial_join_addresses_parcels.py
+++ b/packages/honua-gp/eval/scripts/spatial_join_addresses_parcels.py
@@ -23,5 +23,5 @@ else:
 arcpy.env.workspace = "honua://services/transport"
 arcpy.env.overwriteOutput = True
 
-result = arcpy.analysis.SpatialJoin("honua://services/addresses/0", "honua://services/parcels/0", "addresses_with_parcel", match_option="INTERSECT")
+result = arcpy.analysis.SpatialJoin("honua://services/addresses/0", "honua://services/parcels/1", "addresses_with_parcel", match_option="INTERSECT")
 print(f"spatial_join_addresses_parcels ok output={result[0]}")

--- a/packages/honua-gp/eval/scripts/spatial_join_with_radius.py
+++ b/packages/honua-gp/eval/scripts/spatial_join_with_radius.py
@@ -23,5 +23,5 @@ else:
 arcpy.env.workspace = "honua://services/transport"
 arcpy.env.overwriteOutput = True
 
-result = arcpy.analysis.SpatialJoin("honua://services/facilities/0", "honua://services/parcels/0", "out", match_option="WITHIN_A_DISTANCE", search_radius="100 Meters")
+result = arcpy.analysis.SpatialJoin("honua://services/facilities/0", "honua://services/parcels/1", "out", match_option="WITHIN_A_DISTANCE", search_radius="100 Meters")
 print(f"spatial_join_with_radius ok output={result[0]}")

--- a/packages/honua-gp/eval/seed/spatial-join-second-layer.sql
+++ b/packages/honua-gp/eval/seed/spatial-join-second-layer.sql
@@ -1,0 +1,66 @@
+-- honua-gp ephemeral-server-smoke: second-layer fixture for analytics.spatial-join.
+--
+-- The canonical client-compat seed (honua-server tests/seed/client-compat-v1.sql)
+-- registers exactly one layer (layer_id 0 in service `test_service`). honua-server's
+-- analytics.spatial-join process rejects a self-join at catalog validation
+-- ("joinLayerId must differ from the target layerId"), so the SpatialJoin eval
+-- scripts need a SECOND, distinct layer to point their join_features at.
+--
+-- This idempotent snippet registers layer_id 1 in `test_service` backed by the
+-- shared `features` table (layer_id-partitioned, exactly like layer 0) and adds a
+-- few Point features that coincide with layer-0 points so both the INTERSECT and
+-- WITHIN_A_DISTANCE ("100 Meters") joins return matches. It is applied against the
+-- seeded postgres AFTER the canonical seed by the ephemeral-server-smoke job.
+--
+-- issue: honua-io/honua-sdk-python#157
+
+INSERT INTO honua.layers (
+    layer_id, layer_name, description, table_name,
+    geometry_type, srid, extent, default_visibility
+)
+VALUES (
+    1, 'Join Layer', 'Second layer so analytics.spatial-join has a distinct join target',
+    'features', 'Point', 4326,
+    ST_MakeEnvelope(-122.5, 37.7, -122.35, 37.84, 4326), true
+)
+ON CONFLICT (layer_id) DO UPDATE SET
+    layer_name = EXCLUDED.layer_name,
+    description = EXCLUDED.description,
+    table_name = EXCLUDED.table_name,
+    geometry_type = EXCLUDED.geometry_type,
+    srid = EXCLUDED.srid,
+    extent = EXCLUDED.extent,
+    default_visibility = EXCLUDED.default_visibility;
+
+UPDATE honua.layers
+SET metadata = jsonb_build_object('accessPolicy', jsonb_build_object('allowAnonymous', true))
+WHERE layer_id = 1;
+
+INSERT INTO honua.layer_fields (
+    layer_id, field_name, field_type, field_order,
+    max_length, nullable, default_value, description
+)
+VALUES
+    (1, 'objectid', 'Integer', 0, NULL, false, NULL, 'Object ID'),
+    (1, 'zone', 'String', 1, 64, true, NULL, 'Zone label')
+ON CONFLICT (layer_id, field_name) DO NOTHING;
+
+INSERT INTO honua.service_layers (service_name, layer_id, layer_order)
+VALUES ('test_service', 1, 1)
+ON CONFLICT (service_name, layer_id) DO NOTHING;
+
+-- Points coincident with layer-0 seed points (alpha/gamma/eta) so INTERSECT and
+-- WITHIN_A_DISTANCE joins both yield matches. Guarded so re-applying the snippet
+-- does not duplicate the join features.
+INSERT INTO features (layer_id, geometry, attributes)
+SELECT
+    1,
+    ST_SetSRID(ST_GeomFromText(wkt), 4326),
+    jsonb_build_object('zone', zone)
+FROM (
+    VALUES
+        ('POINT(-122.4900 37.7100)', 'zone-a'),
+        ('POINT(-122.4600 37.7300)', 'zone-b'),
+        ('POINT(-122.4000 37.7700)', 'zone-c')
+) AS seed(wkt, zone)
+WHERE NOT EXISTS (SELECT 1 FROM features WHERE layer_id = 1);


### PR DESCRIPTION
## Summary

Closes the `ephemeral-server-smoke` supported-surface gap in #157. It was **46% (11/24)**; this brings it to **100% (20/20)**, verified **live** against a seeded honua-server, without lowering the threshold or dishonestly reclassifying anything.

I rebuilt the smoke stack exactly (client-compat-seed + `client-compat-v1.sql` on postgis/redis, honua on :5000) and ran `honua-gp eval` per-op. The 13 failing ops split cleanly — and the root cause turned out to be **different** from the #158/#159/#2322 diagnosis, because honua-server#2327 has since landed.

### Per-op verdict

| Op(s) | Verdict | Fix |
| --- | --- | --- |
| Buffer x3, buffer_then_dissolve, Dissolve, Project x2 (7) | **stale image pin** (not an SDK bug) | Re-pin smoke image `latest-aot` → `nightly-aot` |
| SpatialJoin x2 | **fixture gap** (server supports it; self-join rejected) | Seed a 2nd layer + point join_features at layer 1 |
| InsertCursor x2 | **env/licensing gap** (would newly 402 on the re-pinned image) | Run smoke server in Development + `Licensing:DevGrantEdition=Enterprise` |
| Copy/CopyFeatures/CalculateField x4 | already correctly **expected_failure** (#159) | Fixed latent generator drift so a regen keeps them expected_failure |

**Real SDK payload bugs: 0. Fixture/env gaps: all of them. Dishonest reclassifications: 0.**

### Root causes (reproduced live)

1. **Image pin.** The smoke defaulted to `honua-server:latest-aot`, which is stuck on an **April build** (verified `Created 2026-04-29`, rev `9174f8d`) that predates the in-process geoprocessing dispatch worker — every layer-aware job hangs in `Queued` forever (only `honua-geoprocessing` is even advertised; the per-op processes 404). honua-server#2327 (2026-07) wired the per-op OGC projections to the managed executors. On `nightly-aot` (2026-07-02) buffer/dissolve/project all reach terminal **SUCCEEDED**. Re-pinned; operators can still override via the `HONUA_LOCAL_SERVER_IMAGE` repo variable.

2. **SpatialJoin fixture gap.** `analytics.spatial-join` rejects a self-join (`joinLayerId must differ from the target layerId`), and the canonical seed only registers **layer 0**, so both inputs resolved to layer 0. Added `packages/honua-gp/eval/seed/spatial-join-second-layer.sql` (applied after the canonical seed via `docker compose exec postgres`) and pointed the two SpatialJoin scripts' join_features at `.../parcels/1`. Verified both `INTERSECT` and `WITHIN_A_DISTANCE` reach SUCCEEDED.

3. **Editing entitlement.** Newer images gate FeatureServer edits behind `editing.featureserver-edits` (honua-server#1591), so the InsertCursor scripts 402'd on the re-pinned image (they passed on the April image only because editing was ungated then). Run the ephemeral server in **Development** (same env the conformance lane uses; the client-compat metadata-v2 seed activates for Development/Test, and `DevGrantEdition` is fail-closed in Production) with `Licensing:DevGrantEdition=Enterprise`. Test/CI only.

4. **Generator drift (from #159).** `_generate_scripts.py` still emitted the 4 data-management ops as `_supported`, so a regen resurrected them (→ 54 scripts, 24 supported). They are correctly expected-failure (CanServe=false, plan-only). The generator now emits them as `_expected_failure` and reproduces the committed tree with **zero drift**.

## Verification

- **Live** (nightly-aot, seeded, 2nd layer): `50/50 passed (100%); supported 20/20 (100%); supported-required 100%` (exit 0).
- **Stub lane** (the required per-PR gate): `50/50; supported 20/20 (100%)`.
- `pytest packages/honua-gp/tests`: **151 passed**.
- Compatibility-matrix drift check: clean.
- `_generate_scripts.py` regen: only the two intended SpatialJoin scripts differ.

Refs #157. honua-server#2322 (the executor wiring) is resolved by #2327; this PR consumes it.