### PR TITLE
fix: address SDK quality audit backlog

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -903,7 +903,7 @@
             "scan_migration_source": {
               "async": true,
               "kind": "method",
-              "signature": "(self, request: 'MigrationInventoryScanRequest', *, export_json: 'bool' = False) -> 'MigrationSourceInventoryArtifact'"
+              "signature": "(self, request: 'MigrationInventoryScanRequest', *, export_json: 'bool' = False, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'MigrationSourceInventoryArtifact'"
             },
             "set_layer_enabled": {
               "async": true,
@@ -1248,7 +1248,7 @@
             },
             "scan_migration_source": {
               "kind": "method",
-              "signature": "(self, request: 'MigrationInventoryScanRequest', *, export_json: 'bool' = False) -> 'MigrationSourceInventoryArtifact'"
+              "signature": "(self, request: 'MigrationInventoryScanRequest', *, export_json: 'bool' = False, timeout: 'float | httpx.Timeout | None' = None, extra_headers: 'Mapping[str, str] | None' = None, idempotency_key: 'str | None' = None) -> 'MigrationSourceInventoryArtifact'"
             },
             "set_layer_enabled": {
               "kind": "method",

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -14,9 +14,13 @@ from honua_sdk.http import (
     AuthProvider,
     HonuaHttpError,
     apply_sensitive_auth_headers_async,
+    build_idempotency_headers,
     build_sensitive_auth_headers,
     encode_path_segment,
+    encode_request_path,
     extract_trusted_authority,
+    join_base_path,
+    merge_request_headers,
     normalize_base_url,
     to_http_error,
     to_transport_error,
@@ -209,11 +213,10 @@ class AsyncHonuaAdminClient:
             )
 
         effective_transport = transport
-        if max_retries > 0:
-            inner = effective_transport or httpx.AsyncHTTPTransport()
-            retry_transport = AsyncRetryTransport(inner, max_retries=max_retries)
-            effective_transport = retry_transport
-            self._retry_methods = retry_transport.retry_methods
+        inner = effective_transport or httpx.AsyncHTTPTransport()
+        retry_transport = AsyncRetryTransport(inner, max_retries=max_retries)
+        effective_transport = retry_transport
+        self._retry_methods = retry_transport.retry_methods
 
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
@@ -383,7 +386,7 @@ class AsyncHonuaAdminClient:
         extra: Mapping[str, str] | None = None,
     ) -> dict[str, str] | None:
         """Build the ``Idempotency-Key`` header dict, auto-generating if needed."""
-        return _endpoints.build_idempotency_headers(
+        return build_idempotency_headers(
             idempotency_key,
             retry_methods=self._retry_methods,
             extra=extra,
@@ -415,8 +418,9 @@ class AsyncHonuaAdminClient:
         * ``idempotency_key``: when set, attaches an ``Idempotency-Key``
           header to the outbound request.
         """
-        url = self._base_url.copy_with(raw_path=path.encode("ascii"))
-        merged_headers = _merge_request_headers(headers, extra_headers, idempotency_key)
+        raw_path = join_base_path(self._base_url, path)
+        url = self._base_url.copy_with(raw_path=encode_request_path(raw_path))
+        merged_headers = merge_request_headers(headers, extra_headers, idempotency_key)
         request_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,
@@ -1072,6 +1076,9 @@ class AsyncHonuaAdminClient:
         request: MigrationInventoryScanRequest,
         *,
         export_json: bool = False,
+        timeout: float | httpx.Timeout | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
     ) -> MigrationSourceInventoryArtifact:
         """POST /api/v1/admin/import/scan"""
         params = {"export": "json"} if export_json else None
@@ -1080,6 +1087,9 @@ class AsyncHonuaAdminClient:
             "/api/v1/admin/import/scan",
             params=params,
             json_body=request.to_dict(),
+            headers=self._idempotency_headers(idempotency_key),
+            timeout=timeout,
+            extra_headers=extra_headers,
         )
         return MigrationSourceInventoryArtifact.from_dict(data)
 
@@ -1842,29 +1852,6 @@ class AsyncHonuaAdminClient:
         if isinstance(data, dict):
             return data
         return {}
-
-
-def _merge_request_headers(
-    headers: Mapping[str, str] | None,
-    extra_headers: Mapping[str, str] | None,
-    idempotency_key: str | None,
-) -> dict[str, str] | None:
-    """Merge per-request header overrides.
-
-    Precedence (lowest → highest): ``extra_headers`` → ``headers`` →
-    explicit ``idempotency_key``.
-    """
-    if headers is None and extra_headers is None and idempotency_key is None:
-        return None
-    merged: dict[str, str] = {}
-    if extra_headers:
-        merged.update(extra_headers)
-    if headers:
-        merged.update(headers)
-    if idempotency_key is not None:
-        merged["Idempotency-Key"] = idempotency_key
-    return merged
-
 
 def _json_object(response: httpx.Response) -> dict[str, Any]:
     """Parse an unenveloped OGC JSON response body as an object.

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -16,9 +16,13 @@ from honua_sdk.http import (
     NonClosingTransport,
     RetryTransport,
     apply_sensitive_auth_headers,
+    build_idempotency_headers,
     build_sensitive_auth_headers,
     encode_path_segment,
+    encode_request_path,
     extract_trusted_authority,
+    join_base_path,
+    merge_request_headers,
     normalize_base_url,
     to_http_error,
     to_transport_error,
@@ -211,11 +215,10 @@ class HonuaAdminClient:
             )
 
         effective_transport = transport
-        if max_retries > 0:
-            inner = effective_transport or httpx.HTTPTransport()
-            retry_transport = RetryTransport(inner, max_retries=max_retries)
-            effective_transport = retry_transport
-            self._retry_methods = retry_transport.retry_methods
+        inner = effective_transport or httpx.HTTPTransport()
+        retry_transport = RetryTransport(inner, max_retries=max_retries)
+        effective_transport = retry_transport
+        self._retry_methods = retry_transport.retry_methods
 
         self._client = httpx.Client(
             base_url=self._base_url,
@@ -384,7 +387,7 @@ class HonuaAdminClient:
         extra: Mapping[str, str] | None = None,
     ) -> dict[str, str] | None:
         """Build the ``Idempotency-Key`` header dict, auto-generating if needed."""
-        return _endpoints.build_idempotency_headers(
+        return build_idempotency_headers(
             idempotency_key,
             retry_methods=self._retry_methods,
             extra=extra,
@@ -416,8 +419,9 @@ class HonuaAdminClient:
         * ``idempotency_key``: when set, attaches an ``Idempotency-Key``
           header to the outbound request.
         """
-        url = self._base_url.copy_with(raw_path=path.encode("ascii"))
-        merged_headers = _merge_request_headers(headers, extra_headers, idempotency_key)
+        raw_path = join_base_path(self._base_url, path)
+        url = self._base_url.copy_with(raw_path=encode_request_path(raw_path))
+        merged_headers = merge_request_headers(headers, extra_headers, idempotency_key)
         request_kwargs: dict[str, Any] = {
             "method": method,
             "url": url,
@@ -1073,6 +1077,9 @@ class HonuaAdminClient:
         request: MigrationInventoryScanRequest,
         *,
         export_json: bool = False,
+        timeout: float | httpx.Timeout | None = None,
+        extra_headers: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
     ) -> MigrationSourceInventoryArtifact:
         """POST /api/v1/admin/import/scan"""
         params = {"export": "json"} if export_json else None
@@ -1081,6 +1088,9 @@ class HonuaAdminClient:
             "/api/v1/admin/import/scan",
             params=params,
             json_body=request.to_dict(),
+            headers=self._idempotency_headers(idempotency_key),
+            timeout=timeout,
+            extra_headers=extra_headers,
         )
         return MigrationSourceInventoryArtifact.from_dict(data)
 
@@ -1843,29 +1853,6 @@ class HonuaAdminClient:
         if isinstance(data, dict):
             return data
         return {}
-
-
-def _merge_request_headers(
-    headers: Mapping[str, str] | None,
-    extra_headers: Mapping[str, str] | None,
-    idempotency_key: str | None,
-) -> dict[str, str] | None:
-    """Merge per-request header overrides.
-
-    Precedence (lowest → highest): ``extra_headers`` → ``headers`` →
-    explicit ``idempotency_key``.
-    """
-    if headers is None and extra_headers is None and idempotency_key is None:
-        return None
-    merged: dict[str, str] = {}
-    if extra_headers:
-        merged.update(extra_headers)
-    if headers:
-        merged.update(headers)
-    if idempotency_key is not None:
-        merged["Idempotency-Key"] = idempotency_key
-    return merged
-
 
 def _json_object(response: httpx.Response) -> dict[str, Any]:
     """Parse an unenveloped OGC JSON response body as an object.

--- a/packages/honua-admin/honua_admin/_endpoints.py
+++ b/packages/honua-admin/honua_admin/_endpoints.py
@@ -10,11 +10,11 @@ keywords and the sync/async ``def`` declarations.
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import Mapping
 from typing import Any
 
 import httpx
+from honua_sdk.http import build_idempotency_headers
 
 
 def unwrap_envelope(response: httpx.Response) -> Any:
@@ -34,29 +34,6 @@ def unwrap_envelope(response: httpx.Response) -> Any:
     if isinstance(payload, Mapping) and "data" in payload:
         return payload["data"]
     return payload
-
-
-def build_idempotency_headers(
-    idempotency_key: str | None,
-    *,
-    retry_methods: frozenset[str],
-    extra: Mapping[str, str] | None = None,
-) -> dict[str, str] | None:
-    """Build the ``Idempotency-Key`` header dict, auto-generating if needed.
-
-    When ``idempotency_key`` is ``None`` and ``retry_methods`` opts
-    ``POST`` in, a fresh ``uuid4().hex`` is used. ``extra`` is merged in
-    first (caller wins on collisions). Returns ``None`` when no header
-    should be sent.
-    """
-    headers: dict[str, str] = {}
-    if extra:
-        headers.update(extra)
-    if idempotency_key is not None:
-        headers["Idempotency-Key"] = idempotency_key
-    elif "POST" in retry_methods:
-        headers["Idempotency-Key"] = uuid.uuid4().hex
-    return headers or None
 
 
 __all__ = [

--- a/packages/honua-sdk/honua_sdk/_async_retry.py
+++ b/packages/honua-sdk/honua_sdk/_async_retry.py
@@ -10,6 +10,7 @@ shared, I/O-free :mod:`honua_sdk._retry_core`.
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import httpx
 
@@ -31,6 +32,8 @@ __all__ = [
     "AsyncNonClosingTransport",
     "AsyncRetryTransport",
 ]
+
+_LOGGER = logging.getLogger("honua_sdk.transport")
 
 
 class AsyncNonClosingTransport(httpx.AsyncBaseTransport):
@@ -134,15 +137,25 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
         # signals an override by stashing the value in ``request.extensions``.
         override = request.extensions.get("honua_max_retries")
         retries_remaining = override if isinstance(override, int) else self._max_retries
+        retry_budget = retries_remaining
         attempt = 0
 
         while True:
             try:
                 response = await self._wrapped.handle_async_request(request)
-            except _RETRIABLE_TRANSPORT_EXCEPTIONS:
+            except _RETRIABLE_TRANSPORT_EXCEPTIONS as exc:
                 if retries_remaining <= 0:
                     raise
                 delay = self._compute_backoff(attempt)
+                _LOGGER.debug(
+                    "Retrying %s %s after transport error %s (attempt %s/%s, delay %.3fs)",
+                    request.method,
+                    request.url.path,
+                    exc.__class__.__name__,
+                    attempt + 1,
+                    retry_budget,
+                    delay,
+                )
                 await asyncio.sleep(delay)
                 retries_remaining -= 1
                 attempt += 1
@@ -154,6 +167,15 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
                 return response
 
             delay = self._compute_delay(response, attempt)
+            _LOGGER.debug(
+                "Retrying %s %s after HTTP %s (attempt %s/%s, delay %.3fs)",
+                request.method,
+                request.url.path,
+                response.status_code,
+                attempt + 1,
+                retry_budget,
+                delay,
+            )
 
             # Read and close the unsuccessful response BEFORE sleeping so the
             # underlying connection is returned to the pool during the backoff

--- a/packages/honua-sdk/honua_sdk/_endpoints.py
+++ b/packages/honua-sdk/honua_sdk/_endpoints.py
@@ -17,22 +17,22 @@ where the sync/async split is unavoidable.
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from ._http import _encode_path_segment, raise_for_geoservices_error
+from ._http import (
+    _encode_path_segment,
+    build_idempotency_headers,
+    raise_for_geoservices_error,
+)
 from .models import (
     ApplyEditsResult,
     DataPlaneCapabilities,
     FeatureSet,
     ServiceSummary,
 )
-
-
-def _bool_text(value: bool) -> str:
-    return "true" if value else "false"
+from .protocols._base import _bool_text
 
 
 @dataclass(frozen=True)
@@ -253,24 +253,6 @@ def page_record_count(page_size: int, remaining: int | None) -> int:
     if remaining is None:
         return page_size
     return min(page_size, remaining)
-
-
-def build_idempotency_headers(
-    idempotency_key: str | None,
-    *,
-    retry_methods: frozenset[str],
-) -> dict[str, str] | None:
-    """Build the ``Idempotency-Key`` header dict, auto-generating if needed.
-
-    When ``idempotency_key`` is ``None`` and ``retry_methods`` opts
-    ``POST`` in, a fresh ``uuid4().hex`` is used. Returns ``None`` when
-    no header should be sent.
-    """
-    if idempotency_key is not None:
-        return {"Idempotency-Key": idempotency_key}
-    if "POST" in retry_methods:
-        return {"Idempotency-Key": uuid.uuid4().hex}
-    return None
 
 
 def parse_json_response_body(response: "Any") -> dict[str, Any]:

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import uuid
 import warnings
 from collections.abc import Mapping
 from datetime import UTC, datetime
@@ -73,6 +74,52 @@ def encode_request_path(raw_path: str) -> bytes:
             char if ord(char) < 128 else quote(char, safe="") for char in raw_path
         )
         return encoded.encode("ascii")
+
+
+def build_idempotency_headers(
+    idempotency_key: str | None,
+    *,
+    retry_methods: frozenset[str],
+    extra: Mapping[str, str] | None = None,
+) -> dict[str, str] | None:
+    """Build an ``Idempotency-Key`` header dict, auto-generating when needed.
+
+    ``extra`` is merged first, then an explicit ``idempotency_key`` wins. When
+    no explicit key is supplied and ``POST`` has been opted into retryable
+    methods, a fresh UUID hex key is generated so retried mutations can be
+    de-duplicated server-side.
+    """
+    headers: dict[str, str] = {}
+    if extra:
+        headers.update(extra)
+    if idempotency_key is not None:
+        headers["Idempotency-Key"] = idempotency_key
+    elif "POST" in retry_methods:
+        headers["Idempotency-Key"] = uuid.uuid4().hex
+    return headers or None
+
+
+def merge_request_headers(
+    headers: Mapping[str, str] | None,
+    extra_headers: Mapping[str, str] | None,
+    idempotency_key: str | None,
+) -> dict[str, str] | None:
+    """Merge per-request header overrides with stable precedence.
+
+    Precedence from lowest to highest is ``extra_headers`` -> ``headers`` ->
+    explicit ``idempotency_key``. Returns ``None`` when no headers are set so
+    httpx's default header handling remains untouched.
+    """
+    if headers is None and extra_headers is None and idempotency_key is None:
+        return None
+    merged: dict[str, str] = {}
+    if extra_headers:
+        merged.update(extra_headers)
+    if headers:
+        merged.update(headers)
+    if idempotency_key is not None:
+        merged["Idempotency-Key"] = idempotency_key
+    return merged
 
 
 def _build_sensitive_auth_headers(

--- a/packages/honua-sdk/honua_sdk/_query_dispatch.py
+++ b/packages/honua-sdk/honua_sdk/_query_dispatch.py
@@ -30,16 +30,24 @@ from typing import Any
 
 import httpx
 
+from ._http import merge_request_headers
 from ._query import (
     bbox_text,
     feature_server_extra_params,
+    features_from_geojson_page,
     field_list,
     field_text,
+    odata_features_from_page,
     odata_layer_id,
+    odata_pagination_signals,
+    ogc_pagination_signals,
+    query_feature_from_feature_server,
+    query_feature_from_geojson,
+    query_feature_from_mapping,
     query_filter,
     query_page_size,
 )
-from .models import FeatureQuery
+from .models import FeatureQuery, QueryFeature
 
 # Protocols whose ``filter`` slot expects CQL2-text; rejecting silent
 # ``where``→CQL forwarding here keeps the legacy dispatcher honest.
@@ -110,29 +118,6 @@ def merge_idempotency_into_headers(
         return extra_headers
     merged: dict[str, str] = dict(extra_headers) if extra_headers else {}
     merged["Idempotency-Key"] = idempotency_key
-    return merged
-
-
-def merge_request_headers(
-    headers: Mapping[str, str] | None,
-    extra_headers: Mapping[str, str] | None,
-    idempotency_key: str | None,
-) -> dict[str, str] | None:
-    """Merge per-request header overrides.
-
-    Precedence (lowest → highest): ``extra_headers`` → ``headers`` →
-    explicit ``idempotency_key``. Returns ``None`` when no headers are set
-    so we don't perturb httpx's default header handling.
-    """
-    if headers is None and extra_headers is None and idempotency_key is None:
-        return None
-    merged: dict[str, str] = {}
-    if extra_headers:
-        merged.update(extra_headers)
-    if headers:
-        merged.update(headers)
-    if idempotency_key is not None:
-        merged["Idempotency-Key"] = idempotency_key
     return merged
 
 
@@ -314,7 +299,197 @@ def odata_items_kwargs(
     return odata_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers)
 
 
+def _extend_collected_query_features(
+    collected: list[QueryFeature],
+    items: list[QueryFeature],
+    limit: int | None,
+) -> bool:
+    if limit is not None:
+        remaining = limit - len(collected)
+        if remaining <= 0:
+            return True
+        items = items[:remaining]
+    collected.extend(items)
+    return limit is not None and len(collected) >= limit
+
+
+def collect_query_pages(
+    client: Any,
+    query: FeatureQuery,
+    normalized_protocol: str,
+    *,
+    timeout: float | httpx.Timeout | None = None,
+    extra_headers: Mapping[str, str] | None = None,
+) -> tuple[tuple[QueryFeature, ...], bool, int | None, int]:
+    """Walk protocol pages and collect normalized query features (sync)."""
+    collected: list[QueryFeature] = []
+    exceeded = False
+    total_count: int | None = None
+    pages_seen = 0
+    limit = query.limit
+
+    if normalized_protocol == "feature-server":
+        for page in client.feature_server(query.source).query_pages(
+            **feature_server_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+        ):
+            pages_seen += 1
+            exceeded = bool(page.exceeded_transfer_limit)
+            page_features = [
+                query_feature_from_feature_server(
+                    feature, source=query.source, protocol=normalized_protocol
+                )
+                for feature in page.features
+            ]
+            if _extend_collected_query_features(collected, page_features, limit):
+                break
+        return tuple(collected), exceeded, None, pages_seen
+
+    if normalized_protocol == "ogc-features":
+        last_page: Any = None
+        for page in client.ogc_features().collection(query.source).items_pages(
+            **ogc_features_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+        ):
+            pages_seen += 1
+            last_page = page
+            page_features = [
+                query_feature_from_geojson(
+                    item, source=query.source, protocol=normalized_protocol
+                )
+                for item in features_from_geojson_page(page)
+            ]
+            if _extend_collected_query_features(collected, page_features, limit):
+                break
+        total_count, exceeded = ogc_pagination_signals(last_page)
+        return tuple(collected), exceeded, total_count, pages_seen
+
+    if normalized_protocol == "stac":
+        last_page = None
+        for page in client.stac().item_pages(
+            query.source,
+            **stac_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+        ):
+            pages_seen += 1
+            last_page = page
+            page_features = [
+                query_feature_from_geojson(
+                    item, source=query.source, protocol=normalized_protocol
+                )
+                for item in features_from_geojson_page(page)
+            ]
+            if _extend_collected_query_features(collected, page_features, limit):
+                break
+        total_count, exceeded = ogc_pagination_signals(last_page)
+        return tuple(collected), exceeded, total_count, pages_seen
+
+    reject_odata_bbox(query)
+    last_page = None
+    for page in client.odata().features_pages(
+        **odata_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+    ):
+        pages_seen += 1
+        last_page = page
+        page_features = [
+            query_feature_from_mapping(
+                item, source=query.source, protocol=normalized_protocol
+            )
+            for item in odata_features_from_page(page)
+        ]
+        if _extend_collected_query_features(collected, page_features, limit):
+            break
+    total_count, exceeded = odata_pagination_signals(last_page)
+    return tuple(collected), exceeded, total_count, pages_seen
+
+
+async def collect_query_pages_async(
+    client: Any,
+    query: FeatureQuery,
+    normalized_protocol: str,
+    *,
+    timeout: float | httpx.Timeout | None = None,
+    extra_headers: Mapping[str, str] | None = None,
+) -> tuple[tuple[QueryFeature, ...], bool, int | None, int]:
+    """Walk protocol pages and collect normalized query features (async)."""
+    collected: list[QueryFeature] = []
+    exceeded = False
+    total_count: int | None = None
+    pages_seen = 0
+    limit = query.limit
+
+    if normalized_protocol == "feature-server":
+        async for page in client.feature_server(query.source).query_pages(
+            **feature_server_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+        ):
+            pages_seen += 1
+            exceeded = bool(page.exceeded_transfer_limit)
+            page_features = [
+                query_feature_from_feature_server(
+                    feature, source=query.source, protocol=normalized_protocol
+                )
+                for feature in page.features
+            ]
+            if _extend_collected_query_features(collected, page_features, limit):
+                break
+        return tuple(collected), exceeded, None, pages_seen
+
+    if normalized_protocol == "ogc-features":
+        last_page: Any = None
+        async for page in client.ogc_features().collection(query.source).items_pages(
+            **ogc_features_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+        ):
+            pages_seen += 1
+            last_page = page
+            page_features = [
+                query_feature_from_geojson(
+                    item, source=query.source, protocol=normalized_protocol
+                )
+                for item in features_from_geojson_page(page)
+            ]
+            if _extend_collected_query_features(collected, page_features, limit):
+                break
+        total_count, exceeded = ogc_pagination_signals(last_page)
+        return tuple(collected), exceeded, total_count, pages_seen
+
+    if normalized_protocol == "stac":
+        last_page = None
+        async for page in client.stac().item_pages(
+            query.source,
+            **stac_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+        ):
+            pages_seen += 1
+            last_page = page
+            page_features = [
+                query_feature_from_geojson(
+                    item, source=query.source, protocol=normalized_protocol
+                )
+                for item in features_from_geojson_page(page)
+            ]
+            if _extend_collected_query_features(collected, page_features, limit):
+                break
+        total_count, exceeded = ogc_pagination_signals(last_page)
+        return tuple(collected), exceeded, total_count, pages_seen
+
+    reject_odata_bbox(query)
+    last_page = None
+    async for page in client.odata().features_pages(
+        **odata_pages_kwargs(query, timeout=timeout, extra_headers=extra_headers),
+    ):
+        pages_seen += 1
+        last_page = page
+        page_features = [
+            query_feature_from_mapping(
+                item, source=query.source, protocol=normalized_protocol
+            )
+            for item in odata_features_from_page(page)
+        ]
+        if _extend_collected_query_features(collected, page_features, limit):
+            break
+    total_count, exceeded = odata_pagination_signals(last_page)
+    return tuple(collected), exceeded, total_count, pages_seen
+
+
 __all__ = [
+    "collect_query_pages",
+    "collect_query_pages_async",
     "feature_server_items_kwargs",
     "feature_server_pages_kwargs",
     "merge_idempotency_into_headers",

--- a/packages/honua-sdk/honua_sdk/_retry.py
+++ b/packages/honua-sdk/honua_sdk/_retry.py
@@ -11,6 +11,7 @@ shared, I/O-free :mod:`honua_sdk._retry_core`.
 
 from __future__ import annotations
 
+import logging
 import time
 
 import httpx
@@ -33,6 +34,8 @@ __all__ = [
     "NonClosingTransport",
     "RetryTransport",
 ]
+
+_LOGGER = logging.getLogger("honua_sdk.transport")
 
 
 class NonClosingTransport(httpx.BaseTransport):
@@ -136,15 +139,25 @@ class RetryTransport(httpx.BaseTransport):
         # signals an override by stashing the value in ``request.extensions``.
         override = request.extensions.get("honua_max_retries")
         retries_remaining = override if isinstance(override, int) else self._max_retries
+        retry_budget = retries_remaining
         attempt = 0
 
         while True:
             try:
                 response = self._wrapped.handle_request(request)
-            except _RETRIABLE_TRANSPORT_EXCEPTIONS:
+            except _RETRIABLE_TRANSPORT_EXCEPTIONS as exc:
                 if retries_remaining <= 0:
                     raise
                 delay = self._compute_backoff(attempt)
+                _LOGGER.debug(
+                    "Retrying %s %s after transport error %s (attempt %s/%s, delay %.3fs)",
+                    request.method,
+                    request.url.path,
+                    exc.__class__.__name__,
+                    attempt + 1,
+                    retry_budget,
+                    delay,
+                )
                 time.sleep(delay)
                 retries_remaining -= 1
                 attempt += 1
@@ -156,6 +169,15 @@ class RetryTransport(httpx.BaseTransport):
                 return response
 
             delay = self._compute_delay(response, attempt)
+            _LOGGER.debug(
+                "Retrying %s %s after HTTP %s (attempt %s/%s, delay %.3fs)",
+                request.method,
+                request.url.path,
+                response.status_code,
+                attempt + 1,
+                retry_budget,
+                delay,
+            )
 
             # Read and close the unsuccessful response BEFORE sleeping so the
             # underlying connection is returned to the pool during the backoff

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import warnings
 from collections.abc import AsyncIterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
@@ -25,28 +26,21 @@ from ._http import (
     join_base_path,
 )
 from ._query import (
-    features_from_geojson_page,
     normalize_query_protocol,
-    odata_features_from_page,
-    odata_pagination_signals,
-    ogc_pagination_signals,
     query_feature_from_feature_server,
     query_feature_from_geojson,
     query_feature_from_mapping,
     resolve_feature_query,
 )
 from ._query_dispatch import (
+    collect_query_pages_async,
     feature_server_items_kwargs,
-    feature_server_pages_kwargs,
     merge_idempotency_into_headers,
     merge_request_headers,
     odata_items_kwargs,
-    odata_pages_kwargs,
     ogc_features_items_kwargs,
-    ogc_features_pages_kwargs,
     reject_odata_bbox,
     stac_items_kwargs,
-    stac_pages_kwargs,
     validate_filter_routing,
     warn_if_truncated,
 )
@@ -62,6 +56,8 @@ from .models import (
     QueryProtocol,
     ServiceSummary,
 )
+
+_LOGGER = logging.getLogger("honua_sdk.client")
 
 if TYPE_CHECKING:
     from .async_geocoding import AsyncHonuaGeocodingClient
@@ -444,6 +440,10 @@ class AsyncHonuaClient:
         except HonuaHttpError as exc:
             if exc.status_code != 404:
                 raise
+            _LOGGER.warning(
+                "Server lacks /api/v1/capabilities; falling back to readiness "
+                "and service catalog discovery."
+            )
             return DataPlaneCapabilities.from_discovery(
                 readiness=await self.readiness(timeout=timeout, extra_headers=extra_headers),
                 catalog=await self.list_services(timeout=timeout, extra_headers=extra_headers),
@@ -1003,104 +1003,13 @@ class AsyncHonuaClient:
         :mod:`._query_dispatch` so the sync and async dispatchers share
         every non-IO step.
         """
-        collected: list[QueryFeature] = []
-        exceeded = False
-        total_count: int | None = None
-        pages_seen = 0
-        limit = query.limit
-
-        def _extend(items: list[QueryFeature]) -> bool:
-            if limit is not None:
-                remaining = limit - len(collected)
-                if remaining <= 0:
-                    return True
-                items = items[:remaining]
-            collected.extend(items)
-            return limit is not None and len(collected) >= limit
-
-        if normalized_protocol == "feature-server":
-            async for page in self.feature_server(query.source).query_pages(
-                **feature_server_pages_kwargs(
-                    query, timeout=timeout, extra_headers=extra_headers
-                ),
-            ):
-                pages_seen += 1
-                exceeded = bool(page.exceeded_transfer_limit)
-                page_features = [
-                    query_feature_from_feature_server(
-                        feature, source=query.source, protocol=normalized_protocol
-                    )
-                    for feature in page.features
-                ]
-                if _extend(page_features):
-                    break
-            # FeatureServer ``query`` responses do not carry a grand total
-            # (no ``numberMatched`` equivalent), so ``total_count`` is unknown.
-            # Reporting ``len(collected)`` here is misleading because it is the
-            # number of features *returned* — capped by ``limit``/``max_pages``
-            # — not the server's total match count. Surface ``None`` instead.
-            return tuple(collected), exceeded, None, pages_seen
-
-        if normalized_protocol == "ogc-features":
-            last_page: Any = None
-            async for page in self.ogc_features().collection(query.source).items_pages(  # type: ignore[assignment]
-                **ogc_features_pages_kwargs(
-                    query, timeout=timeout, extra_headers=extra_headers
-                ),
-            ):
-                pages_seen += 1
-                last_page = page
-                page_features = [
-                    query_feature_from_geojson(
-                        item, source=query.source, protocol=normalized_protocol
-                    )
-                    for item in features_from_geojson_page(page)  # type: ignore[arg-type]
-                ]
-                if _extend(page_features):
-                    break
-            total_count, exceeded = ogc_pagination_signals(last_page)
-            return tuple(collected), exceeded, total_count, pages_seen
-
-        if normalized_protocol == "stac":
-            last_page = None
-            async for page in self.stac().item_pages(  # type: ignore[assignment]
-                query.source,
-                **stac_pages_kwargs(
-                    query, timeout=timeout, extra_headers=extra_headers
-                ),
-            ):
-                pages_seen += 1
-                last_page = page
-                page_features = [
-                    query_feature_from_geojson(
-                        item, source=query.source, protocol=normalized_protocol
-                    )
-                    for item in features_from_geojson_page(page)  # type: ignore[arg-type]
-                ]
-                if _extend(page_features):
-                    break
-            total_count, exceeded = ogc_pagination_signals(last_page)
-            return tuple(collected), exceeded, total_count, pages_seen
-
-        reject_odata_bbox(query)
-        last_page = None
-        async for page in self.odata().features_pages(  # type: ignore[assignment]
-            **odata_pages_kwargs(
-                query, timeout=timeout, extra_headers=extra_headers
-            ),
-        ):
-            pages_seen += 1
-            last_page = page
-            page_features = [
-                query_feature_from_mapping(
-                    item, source=query.source, protocol=normalized_protocol
-                )
-                for item in odata_features_from_page(page)  # type: ignore[arg-type]
-            ]
-            if _extend(page_features):
-                break
-        total_count, exceeded = odata_pagination_signals(last_page)
-        return tuple(collected), exceeded, total_count, pages_seen
+        return await collect_query_pages_async(
+            self,
+            query,
+            normalized_protocol,
+            timeout=timeout,
+            extra_headers=extra_headers,
+        )
 
     async def iter_query(
         self,
@@ -1384,7 +1293,7 @@ class AsyncHonuaClient:
         features: list[Feature] = []
         offset = _endpoints.initial_offset(extra_params)
         base_extra_params = dict(extra_params or {})
-        seen_object_ids: set[int] = set()
+        previous_object_ids: set[int] = set()
         for _ in range(max_pages):
             remaining = None if limit is None else limit - len(features)
             if remaining is not None and remaining <= 0:
@@ -1406,17 +1315,15 @@ class AsyncHonuaClient:
             )
             page_features = list(page.features)
             # Non-advancing-cursor guard: a server that ignores ``resultOffset``
-            # keeps returning the same page with ``exceededTransferLimit=true``,
-            # which would otherwise loop to ``max_pages`` and duplicate every
-            # feature. When object ids are present, stop once a page adds no new
-            # ones (and drop the duplicates we already collected this page).
+            # keeps returning the same page with ``exceededTransferLimit=true``.
+            # Compare only with the previous page so the tracking set stays
+            # bounded to one page, matching the protocol wrapper.
             new_object_ids = {
                 oid for f in page_features if (oid := f.object_id) is not None
             }
-            stalled = bool(new_object_ids) and new_object_ids.issubset(seen_object_ids)
-            if stalled:
+            if new_object_ids and new_object_ids.issubset(previous_object_ids):
                 break
-            seen_object_ids |= new_object_ids
+            previous_object_ids = new_object_ids
             if remaining is not None:
                 page_features = page_features[:remaining]
             features.extend(page_features)

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import warnings
 from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
@@ -26,28 +27,21 @@ from ._http import (
     join_base_path,
 )
 from ._query import (
-    features_from_geojson_page,
     normalize_query_protocol,
-    odata_features_from_page,
-    odata_pagination_signals,
-    ogc_pagination_signals,
     query_feature_from_feature_server,
     query_feature_from_geojson,
     query_feature_from_mapping,
     resolve_feature_query,
 )
 from ._query_dispatch import (
+    collect_query_pages,
     feature_server_items_kwargs,
-    feature_server_pages_kwargs,
     merge_idempotency_into_headers,
     merge_request_headers,
     odata_items_kwargs,
-    odata_pages_kwargs,
     ogc_features_items_kwargs,
-    ogc_features_pages_kwargs,
     reject_odata_bbox,
     stac_items_kwargs,
-    stac_pages_kwargs,
     validate_filter_routing,
     warn_if_truncated,
 )
@@ -64,6 +58,8 @@ from .models import (
     QueryProtocol,
     ServiceSummary,
 )
+
+_LOGGER = logging.getLogger("honua_sdk.client")
 
 if TYPE_CHECKING:
     from .auth import AuthProvider
@@ -445,6 +441,10 @@ class HonuaClient:
         except HonuaHttpError as exc:
             if exc.status_code != 404:
                 raise
+            _LOGGER.warning(
+                "Server lacks /api/v1/capabilities; falling back to readiness "
+                "and service catalog discovery."
+            )
             return DataPlaneCapabilities.from_discovery(
                 readiness=self.readiness(timeout=timeout, extra_headers=extra_headers),
                 catalog=self.list_services(timeout=timeout, extra_headers=extra_headers),
@@ -1004,104 +1004,13 @@ class HonuaClient:
         :mod:`._query_dispatch` so the sync and dispatchers share
         every non-IO step.
         """
-        collected: list[QueryFeature] = []
-        exceeded = False
-        total_count: int | None = None
-        pages_seen = 0
-        limit = query.limit
-
-        def _extend(items: list[QueryFeature]) -> bool:
-            if limit is not None:
-                remaining = limit - len(collected)
-                if remaining <= 0:
-                    return True
-                items = items[:remaining]
-            collected.extend(items)
-            return limit is not None and len(collected) >= limit
-
-        if normalized_protocol == "feature-server":
-            for page in self.feature_server(query.source).query_pages(
-                **feature_server_pages_kwargs(
-                    query, timeout=timeout, extra_headers=extra_headers
-                ),
-            ):
-                pages_seen += 1
-                exceeded = bool(page.exceeded_transfer_limit)
-                page_features = [
-                    query_feature_from_feature_server(
-                        feature, source=query.source, protocol=normalized_protocol
-                    )
-                    for feature in page.features
-                ]
-                if _extend(page_features):
-                    break
-            # FeatureServer ``query`` responses do not carry a grand total
-            # (no ``numberMatched`` equivalent), so ``total_count`` is unknown.
-            # Reporting ``len(collected)`` here is misleading because it is the
-            # number of features *returned* — capped by ``limit``/``max_pages``
-            # — not the server's total match count. Surface ``None`` instead.
-            return tuple(collected), exceeded, None, pages_seen
-
-        if normalized_protocol == "ogc-features":
-            last_page: Any = None
-            for page in self.ogc_features().collection(query.source).items_pages(  # type: ignore[assignment]
-                **ogc_features_pages_kwargs(
-                    query, timeout=timeout, extra_headers=extra_headers
-                ),
-            ):
-                pages_seen += 1
-                last_page = page
-                page_features = [
-                    query_feature_from_geojson(
-                        item, source=query.source, protocol=normalized_protocol
-                    )
-                    for item in features_from_geojson_page(page)  # type: ignore[arg-type]
-                ]
-                if _extend(page_features):
-                    break
-            total_count, exceeded = ogc_pagination_signals(last_page)
-            return tuple(collected), exceeded, total_count, pages_seen
-
-        if normalized_protocol == "stac":
-            last_page = None
-            for page in self.stac().item_pages(  # type: ignore[assignment]
-                query.source,
-                **stac_pages_kwargs(
-                    query, timeout=timeout, extra_headers=extra_headers
-                ),
-            ):
-                pages_seen += 1
-                last_page = page
-                page_features = [
-                    query_feature_from_geojson(
-                        item, source=query.source, protocol=normalized_protocol
-                    )
-                    for item in features_from_geojson_page(page)  # type: ignore[arg-type]
-                ]
-                if _extend(page_features):
-                    break
-            total_count, exceeded = ogc_pagination_signals(last_page)
-            return tuple(collected), exceeded, total_count, pages_seen
-
-        reject_odata_bbox(query)
-        last_page = None
-        for page in self.odata().features_pages(  # type: ignore[assignment]
-            **odata_pages_kwargs(
-                query, timeout=timeout, extra_headers=extra_headers
-            ),
-        ):
-            pages_seen += 1
-            last_page = page
-            page_features = [
-                query_feature_from_mapping(
-                    item, source=query.source, protocol=normalized_protocol
-                )
-                for item in odata_features_from_page(page)  # type: ignore[arg-type]
-            ]
-            if _extend(page_features):
-                break
-        total_count, exceeded = odata_pagination_signals(last_page)
-        return tuple(collected), exceeded, total_count, pages_seen
+        return collect_query_pages(
+            self,
+            query,
+            normalized_protocol,
+            timeout=timeout,
+            extra_headers=extra_headers,
+        )
 
     def iter_query(
         self,
@@ -1385,7 +1294,7 @@ class HonuaClient:
         features: list[Feature] = []
         offset = _endpoints.initial_offset(extra_params)
         base_extra_params = dict(extra_params or {})
-        seen_object_ids: set[int] = set()
+        previous_object_ids: set[int] = set()
         for _ in range(max_pages):
             remaining = None if limit is None else limit - len(features)
             if remaining is not None and remaining <= 0:
@@ -1407,17 +1316,15 @@ class HonuaClient:
             )
             page_features = list(page.features)
             # Non-advancing-cursor guard: a server that ignores ``resultOffset``
-            # keeps returning the same page with ``exceededTransferLimit=true``,
-            # which would otherwise loop to ``max_pages`` and duplicate every
-            # feature. When object ids are present, stop once a page adds no new
-            # ones (and drop the duplicates we already collected this page).
+            # keeps returning the same page with ``exceededTransferLimit=true``.
+            # Compare only with the previous page so the tracking set stays
+            # bounded to one page, matching the protocol wrapper.
             new_object_ids = {
                 oid for f in page_features if (oid := f.object_id) is not None
             }
-            stalled = bool(new_object_ids) and new_object_ids.issubset(seen_object_ids)
-            if stalled:
+            if new_object_ids and new_object_ids.issubset(previous_object_ids):
                 break
-            seen_object_ids |= new_object_ids
+            previous_object_ids = new_object_ids
             if remaining is not None:
                 page_features = page_features[:remaining]
             features.extend(page_features)

--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -40,8 +40,8 @@ reuse the bound :class:`~honua_sdk.client.HonuaClient` /
 
 from __future__ import annotations
 
-import contextlib
 import json
+import logging
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
@@ -65,6 +65,8 @@ CANONICAL_PROCESS_ID = "honua-geoprocessing"
 
 #: OGC job statuses that are terminal (no further transition will occur).
 TERMINAL_JOB_STATUSES: frozenset[str] = frozenset({"successful", "failed", "dismissed"})
+_LOGGER = logging.getLogger("honua_sdk.geoprocessing")
+_MAX_POLL_INTERVAL = 10.0
 
 #: Namespaced catalog process ids that execute at *layer scope* (feature
 #: collection in / out) and are projected through OGC API Processes today.
@@ -335,6 +337,16 @@ def _job_path(root: str, job_id: str) -> str:
 
 def _job_results_path(root: str, job_id: str) -> str:
     return f"{_job_path(root, job_id)}/results"
+
+
+def _initial_poll_delay(poll_interval: float) -> float:
+    return min(max(0.0, poll_interval), _MAX_POLL_INTERVAL)
+
+
+def _next_poll_delay(current: float) -> float:
+    if current <= 0.0:
+        return 0.0
+    return min(current * 2.0, _MAX_POLL_INTERVAL)
 
 
 def _href_path_and_params(href: str) -> tuple[str, dict[str, str]]:
@@ -638,8 +650,14 @@ class HonuaGeoprocessing:
         """Best-effort :meth:`dismiss`; never raises (cleanup-only path)."""
         if not job_id:
             return
-        with contextlib.suppress(Exception):
+        try:
             self.dismiss(job_id)
+        except Exception:
+            _LOGGER.debug(
+                "Failed to dismiss geoprocessing job %r during cleanup.",
+                job_id,
+                exc_info=True,
+            )
 
     def wait(
         self,
@@ -656,6 +674,7 @@ class HonuaGeoprocessing:
         job_id = job.job_id if isinstance(job, GeoprocessingJob) else str(job)
         current = job if isinstance(job, GeoprocessingJob) else self.job(job_id)
         deadline = None if timeout is None else time.monotonic() + timeout
+        poll_delay = _initial_poll_delay(poll_interval)
         while not current.is_terminal:
             if deadline is not None and time.monotonic() >= deadline:
                 self._safe_dismiss(job_id)
@@ -663,8 +682,9 @@ class HonuaGeoprocessing:
                     f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
                     f"(last status: {current.status!r})."
                 )
-            time.sleep(max(0.0, poll_interval))
+            time.sleep(poll_delay)
             current = self.job(job_id)
+            poll_delay = _next_poll_delay(poll_delay)
         return current
 
 
@@ -913,8 +933,14 @@ class AsyncHonuaGeoprocessing:
         """Best-effort :meth:`dismiss`; never raises (cleanup-only path)."""
         if not job_id:
             return
-        with contextlib.suppress(Exception):
+        try:
             await self.dismiss(job_id)
+        except Exception:
+            _LOGGER.debug(
+                "Failed to dismiss geoprocessing job %r during cleanup.",
+                job_id,
+                exc_info=True,
+            )
 
     async def wait(
         self,
@@ -934,6 +960,7 @@ class AsyncHonuaGeoprocessing:
         job_id = job.job_id if isinstance(job, GeoprocessingJob) else str(job)
         current = job if isinstance(job, GeoprocessingJob) else await self.job(job_id)
         deadline = None if timeout is None else time.monotonic() + timeout
+        poll_delay = _initial_poll_delay(poll_interval)
         try:
             while not current.is_terminal:
                 if deadline is not None and time.monotonic() >= deadline:
@@ -942,8 +969,9 @@ class AsyncHonuaGeoprocessing:
                         f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
                         f"(last status: {current.status!r})."
                     )
-                await asyncio.sleep(max(0.0, poll_interval))
+                await asyncio.sleep(poll_delay)
                 current = await self.job(job_id)
+                poll_delay = _next_poll_delay(poll_delay)
         except asyncio.CancelledError:
             await self._safe_dismiss(job_id)
             raise

--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -676,13 +676,17 @@ class HonuaGeoprocessing:
         deadline = None if timeout is None else time.monotonic() + timeout
         poll_delay = _initial_poll_delay(poll_interval)
         while not current.is_terminal:
-            if deadline is not None and time.monotonic() >= deadline:
-                self._safe_dismiss(job_id)
-                raise TimeoutError(
-                    f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
-                    f"(last status: {current.status!r})."
-                )
-            time.sleep(poll_delay)
+            sleep_delay = poll_delay
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self._safe_dismiss(job_id)
+                    raise TimeoutError(
+                        f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
+                        f"(last status: {current.status!r})."
+                    )
+                sleep_delay = min(sleep_delay, remaining)
+            time.sleep(sleep_delay)
             current = self.job(job_id)
             poll_delay = _next_poll_delay(poll_delay)
         return current
@@ -963,13 +967,17 @@ class AsyncHonuaGeoprocessing:
         poll_delay = _initial_poll_delay(poll_interval)
         try:
             while not current.is_terminal:
-                if deadline is not None and time.monotonic() >= deadline:
-                    await self._safe_dismiss(job_id)
-                    raise TimeoutError(
-                        f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
-                        f"(last status: {current.status!r})."
-                    )
-                await asyncio.sleep(poll_delay)
+                sleep_delay = poll_delay
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        await self._safe_dismiss(job_id)
+                        raise TimeoutError(
+                            f"Geoprocessing job {job_id!r} did not reach a terminal status within {timeout}s "
+                            f"(last status: {current.status!r})."
+                        )
+                    sleep_delay = min(sleep_delay, remaining)
+                await asyncio.sleep(sleep_delay)
                 current = await self.job(job_id)
                 poll_delay = _next_poll_delay(poll_delay)
         except asyncio.CancelledError:

--- a/packages/honua-sdk/honua_sdk/http.py
+++ b/packages/honua-sdk/honua_sdk/http.py
@@ -21,6 +21,10 @@ HTTP helpers (no leading underscore):
 
 * :func:`normalize_base_url`        — strip + re-append trailing slash
 * :func:`encode_path_segment`       — URL-safe path segment encoder
+* :func:`join_base_path`            — preserve sub-path deployments
+* :func:`encode_request_path`       — raw-path bytes for httpx URL overrides
+* :func:`merge_request_headers`
+* :func:`build_idempotency_headers`
 * :func:`build_sensitive_auth_headers`
 * :func:`apply_sensitive_auth_headers`
 * :func:`apply_sensitive_auth_headers_async` — awaitable variant for async
@@ -68,6 +72,10 @@ from ._http import (
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
     _warn_deprecated_bearer_token,
+    build_idempotency_headers,
+    encode_request_path,
+    join_base_path,
+    merge_request_headers,
 )
 from ._retry import NonClosingTransport, RetryTransport
 from .auth import AuthProvider
@@ -117,9 +125,13 @@ __all__ = [
     "_warn_deprecated_bearer_token",
     "apply_sensitive_auth_headers",
     "apply_sensitive_auth_headers_async",
+    "build_idempotency_headers",
     "build_sensitive_auth_headers",
     "encode_path_segment",
+    "encode_request_path",
     "extract_trusted_authority",
+    "join_base_path",
+    "merge_request_headers",
     "normalize_base_url",
     "parse_retry_after",
     "to_http_error",

--- a/packages/honua-sdk/honua_sdk/protocols/geoservices.py
+++ b/packages/honua-sdk/honua_sdk/protocols/geoservices.py
@@ -8,7 +8,7 @@ import os
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import partial
-from typing import IO, Any
+from typing import IO, Any, Self
 
 import httpx
 from anyio import to_thread
@@ -122,7 +122,28 @@ class AttachmentQueryResult:
 
 
 @dataclass(frozen=True)
-class AddAttachmentResult:
+class AttachmentOperationResult:
+    """Common parsed result shape for attachment add/update operations."""
+    object_id: "int | None"
+    success: bool
+    global_id: "str | None" = None
+    raw: "JsonObject | None" = None
+
+    @classmethod
+    def _from_envelope(cls, payload: Mapping[str, Any], envelope_key: str) -> Self:
+        result = payload.get(envelope_key)
+        if not isinstance(result, Mapping):
+            result = payload
+        raw_id = result.get("objectId")
+        return cls(
+            object_id=int(raw_id) if isinstance(raw_id, (int, float)) else None,
+            success=bool(result.get("success", False)),
+            global_id=_opt_str(result.get("globalId")),
+            raw=dict(payload),
+        )
+
+
+class AddAttachmentResult(AttachmentOperationResult):
     """Parsed ``addAttachment`` response.
 
     ``object_id`` is the id of the newly created attachment (Esri returns the
@@ -130,46 +151,17 @@ class AddAttachmentResult:
     :meth:`download_attachment` / :meth:`delete_attachment`.
     """
 
-    object_id: "int | None"
-    success: bool
-    global_id: "str | None" = None
-    raw: "JsonObject | None" = None
-
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "AddAttachmentResult":
-        result = payload.get("addAttachmentResult")
-        if not isinstance(result, Mapping):
-            result = payload
-        raw_id = result.get("objectId")
-        return cls(
-            object_id=int(raw_id) if isinstance(raw_id, (int, float)) else None,
-            success=bool(result.get("success", False)),
-            global_id=_opt_str(result.get("globalId")),
-            raw=dict(payload),
-        )
+        return cls._from_envelope(payload, "addAttachmentResult")
 
 
-@dataclass(frozen=True)
-class UpdateAttachmentResult:
+class UpdateAttachmentResult(AttachmentOperationResult):
     """Parsed ``updateAttachment`` response."""
-
-    object_id: "int | None"
-    success: bool
-    global_id: "str | None" = None
-    raw: "JsonObject | None" = None
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> "UpdateAttachmentResult":
-        result = payload.get("updateAttachmentResult")
-        if not isinstance(result, Mapping):
-            result = payload
-        raw_id = result.get("objectId")
-        return cls(
-            object_id=int(raw_id) if isinstance(raw_id, (int, float)) else None,
-            success=bool(result.get("success", False)),
-            global_id=_opt_str(result.get("globalId")),
-            raw=dict(payload),
-        )
+        return cls._from_envelope(payload, "updateAttachmentResult")
 
 
 @dataclass(frozen=True)

--- a/scripts/gen_sync.py
+++ b/scripts/gen_sync.py
@@ -215,6 +215,7 @@ _COMMON_RULES: tuple[Rule, ...] = (
         r"\bapply_sensitive_auth_headers_async\b",
         "apply_sensitive_auth_headers",
     ),
+    _rule(r"\bcollect_query_pages_async\b", "collect_query_pages"),
     #
     # --- module-name seams -------------------------------------------------
     # Async-only sibling modules collapse onto their sync equivalents.

--- a/tests/admin/test_async_admin_client.py
+++ b/tests/admin/test_async_admin_client.py
@@ -447,6 +447,33 @@ async def test_async_get_service_settings_returns_typed_response() -> None:
     assert result.service_name == "default"
 
 
+async def test_async_admin_request_preserves_base_path_and_encodes_non_ascii_service() -> None:
+    seen: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["raw_path"] = request.url.raw_path.decode("ascii").split("?")[0]
+        return httpx.Response(
+            200,
+            json=make_api_response(
+                {
+                    "serviceName": "café",
+                    "enabledProtocols": [],
+                    "availableProtocols": [],
+                    "accessPolicy": None,
+                    "timeInfo": None,
+                    "mapServer": None,
+                }
+            ),
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaAdminClient("http://test.honua.io/honua", transport=transport) as client:
+        result = await client.get_service_settings("café")
+
+    assert seen["raw_path"] == "/honua/api/v1/admin/services/caf%C3%A9/settings"
+    assert result.service_name == "café"
+
+
 async def test_async_update_protocols_sends_list_body() -> None:
     import json
 

--- a/tests/admin/test_migration.py
+++ b/tests/admin/test_migration.py
@@ -222,6 +222,34 @@ def test_scan_migration_source_export_json_sets_query() -> None:
     assert result.artifact_version == "1.0"
 
 
+def test_scan_migration_source_accepts_per_call_options() -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["headers"] = request.headers
+        seen["timeout"] = request.extensions.get("timeout", {})
+        return httpx.Response(200, json=_INVENTORY_ARTIFACT)
+
+    transport = httpx.MockTransport(handler)
+    request = MigrationInventoryScanRequest(
+        source_kind="geoservices",
+        source_url="https://example.com/arcgis/rest/services/Parcels/FeatureServer",
+    )
+
+    with HonuaAdminClient("http://test.honua.io", transport=transport) as client:
+        result = client.scan_migration_source(
+            request,
+            timeout=1.25,
+            extra_headers={"X-Trace-Id": "trace-1"},
+            idempotency_key="scan-key",
+        )
+
+    assert result.source_kind == "arcgis-geoservices-rest"
+    assert seen["headers"]["x-trace-id"] == "trace-1"
+    assert seen["headers"]["idempotency-key"] == "scan-key"
+    assert seen["timeout"]["connect"] == 1.25
+
+
 @pytest.mark.anyio
 async def test_async_scan_migration_source() -> None:
     seen: dict[str, Any] = {}
@@ -246,6 +274,35 @@ async def test_async_scan_migration_source() -> None:
         "sourceUrl": "https://example.com/arcgis/rest/services/Parcels/FeatureServer",
     }
     assert result.source_kind == "arcgis-geoservices-rest"
+
+
+@pytest.mark.anyio
+async def test_async_scan_migration_source_accepts_per_call_options() -> None:
+    seen: dict[str, Any] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["headers"] = request.headers
+        seen["timeout"] = request.extensions.get("timeout", {})
+        return httpx.Response(200, json=_INVENTORY_ARTIFACT)
+
+    transport = httpx.MockTransport(handler)
+    request = MigrationInventoryScanRequest(
+        source_kind="geoservices",
+        source_url="https://example.com/arcgis/rest/services/Parcels/FeatureServer",
+    )
+
+    async with AsyncHonuaAdminClient("http://test.honua.io", transport=transport) as client:
+        result = await client.scan_migration_source(
+            request,
+            timeout=1.25,
+            extra_headers={"X-Trace-Id": "trace-1"},
+            idempotency_key="scan-key",
+        )
+
+    assert result.source_kind == "arcgis-geoservices-rest"
+    assert seen["headers"]["x-trace-id"] == "trace-1"
+    assert seen["headers"]["idempotency-key"] == "scan-key"
+    assert seen["timeout"]["connect"] == 1.25
 
 
 def test_migration_inventory_scan_request_repr_redacts_password() -> None:

--- a/tests/admin/test_services.py
+++ b/tests/admin/test_services.py
@@ -112,6 +112,33 @@ def test_get_service_settings_returns_nested_models(make_client) -> None:
     assert result.map_server.default_format == "png"
 
 
+def test_admin_request_preserves_base_path_and_encodes_non_ascii_service() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["raw_path"] = request.url.raw_path.decode("ascii").split("?")[0]
+        return httpx.Response(
+            200,
+            json=make_api_response(
+                {
+                    "serviceName": "café",
+                    "enabledProtocols": [],
+                    "availableProtocols": [],
+                    "accessPolicy": None,
+                    "timeInfo": None,
+                    "mapServer": None,
+                }
+            ),
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaAdminClient("http://test.honua.io/honua", transport=transport) as client:
+        result = client.get_service_settings("café")
+
+    assert seen["raw_path"] == "/honua/api/v1/admin/services/caf%C3%A9/settings"
+    assert result.service_name == "café"
+
+
 def test_update_protocols_sends_list_body(make_client) -> None:
     seen: dict[str, Any] = {}
 

--- a/tests/admin/test_shared_sdk_boundary.py
+++ b/tests/admin/test_shared_sdk_boundary.py
@@ -16,6 +16,10 @@ from honua_sdk._http import (
     _to_transport_error,
     _validate_auth_configuration,
     _validate_external_client_auth_configuration,
+    build_idempotency_headers,
+    encode_request_path,
+    join_base_path,
+    merge_request_headers,
 )
 from honua_sdk._retry import RetryTransport
 from honua_sdk.auth import AuthProvider
@@ -40,6 +44,10 @@ def test_public_http_module_reexports_admin_dependencies() -> None:
         honua_http._validate_external_client_auth_configuration
         is _validate_external_client_auth_configuration
     )
+    assert honua_http.build_idempotency_headers is build_idempotency_headers
+    assert honua_http.encode_request_path is encode_request_path
+    assert honua_http.join_base_path is join_base_path
+    assert honua_http.merge_request_headers is merge_request_headers
 
 
 def test_shared_sdk_boundary_reexports_admin_dependencies() -> None:
@@ -60,6 +68,10 @@ def test_shared_sdk_boundary_reexports_admin_dependencies() -> None:
         _shared._validate_external_client_auth_configuration
         is _validate_external_client_auth_configuration
     )
+    assert _shared.build_idempotency_headers is build_idempotency_headers
+    assert _shared.encode_request_path is encode_request_path
+    assert _shared.join_base_path is join_base_path
+    assert _shared.merge_request_headers is merge_request_headers
 
 
 def test_admin_clients_use_public_http_boundary() -> None:
@@ -69,6 +81,9 @@ def test_admin_clients_use_public_http_boundary() -> None:
     assert admin_client.RetryTransport is honua_http.RetryTransport
     assert admin_client.apply_sensitive_auth_headers is honua_http.apply_sensitive_auth_headers
     assert admin_client.encode_path_segment is honua_http.encode_path_segment
+    assert admin_client.encode_request_path is honua_http.encode_request_path
+    assert admin_client.join_base_path is honua_http.join_base_path
+    assert admin_client.merge_request_headers is honua_http.merge_request_headers
     assert admin_client.to_http_error is honua_http.to_http_error
 
     assert admin_async_client.AsyncRetryTransport is honua_http.AsyncRetryTransport
@@ -79,4 +94,7 @@ def test_admin_clients_use_public_http_boundary() -> None:
         is honua_http.apply_sensitive_auth_headers_async
     )
     assert admin_async_client.encode_path_segment is honua_http.encode_path_segment
+    assert admin_async_client.encode_request_path is honua_http.encode_request_path
+    assert admin_async_client.join_base_path is honua_http.join_base_path
+    assert admin_async_client.merge_request_headers is honua_http.merge_request_headers
     assert admin_async_client.to_http_error is honua_http.to_http_error

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -197,6 +197,33 @@ async def test_query_features_all_stops_on_non_advancing_cursor() -> None:
     assert call_count["n"] < 100
 
 
+async def test_query_features_all_compares_cursor_ids_to_previous_page_only() -> None:
+    pages = [
+        [1, 2],
+        [3, 4],
+        [1, 2],
+    ]
+    call_count = {"n": 0}
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        ids = pages[call_count["n"]]
+        call_count["n"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "features": [{"attributes": {"objectid": oid}} for oid in ids],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with AsyncHonuaClient("http://example.test", transport=transport) as client:
+        features = await client.query_features_all("parcels", 0, page_size=2, max_pages=3)
+
+    assert [feature.object_id for feature in features] == [1, 2, 3, 4, 1, 2]
+    assert call_count["n"] == 3
+
+
 async def test_shared_query_feature_server_normalizes_common_args() -> None:
     seen: dict[str, str] = {}
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 import httpx
@@ -108,7 +109,9 @@ def test_capabilities_reads_data_plane_contract() -> None:
     assert capabilities.supports("experimental") is False
 
 
-def test_capabilities_falls_back_to_readiness_and_catalog_for_older_servers() -> None:
+def test_capabilities_falls_back_to_readiness_and_catalog_for_older_servers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -131,9 +134,11 @@ def test_capabilities_falls_back_to_readiness_and_catalog_for_older_servers() ->
 
     transport = httpx.MockTransport(handler)
     with HonuaClient("http://example.test", transport=transport) as client:
-        capabilities = client.capabilities()
+        with caplog.at_level(logging.WARNING, logger="honua_sdk.client"):
+            capabilities = client.capabilities()
 
     assert seen == ["/api/v1/capabilities", "/healthz/ready", "/rest/services"]
+    assert "Server lacks /api/v1/capabilities" in caplog.text
     assert capabilities.server_version == "2026.3.0"
     assert capabilities.supports("geoservices") is True
     assert capabilities.supports("feature-server") is True
@@ -242,6 +247,33 @@ def test_query_features_all_stops_on_non_advancing_cursor() -> None:
     # the stall (one extra probe page) rather than walking all 100 pages.
     assert [feature.object_id for feature in features] == [1, 2]
     assert call_count["n"] <= 2
+
+
+def test_query_features_all_compares_cursor_ids_to_previous_page_only() -> None:
+    pages = [
+        [1, 2],
+        [3, 4],
+        [1, 2],
+    ]
+    call_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        ids = pages[call_count["n"]]
+        call_count["n"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "features": [{"attributes": {"objectid": oid}} for oid in ids],
+                "exceededTransferLimit": True,
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with HonuaClient("http://example.test", transport=transport) as client:
+        features = client.query_features_all("parcels", 0, page_size=2, max_pages=3)
+
+    assert [feature.object_id for feature in features] == [1, 2, 3, 4, 1, 2]
+    assert call_count["n"] == 3
 
 
 def test_shared_query_feature_server_normalizes_common_args() -> None:

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -345,6 +345,26 @@ def test_wait_uses_exponential_poll_backoff() -> None:
     assert delays == [0.5, 1.0]
 
 
+def test_wait_clamps_poll_delay_to_timeout_deadline() -> None:
+    statuses = iter(["running", "running", "successful"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        return httpx.Response(200, json=_status("job-deadline", next(statuses)))
+
+    delays: list[float] = []
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        with (
+            patch("honua_sdk.geoprocessing.time.monotonic", side_effect=[100.0, 100.0, 100.25]),
+            patch("honua_sdk.geoprocessing.time.sleep", side_effect=delays.append),
+        ):
+            terminal = gp.wait("job-deadline", poll_interval=0.5, timeout=0.75)
+
+    assert terminal.succeeded is True
+    assert delays == [0.5, 0.5]
+
+
 def test_submit_uses_location_header_when_body_lacks_job_id() -> None:
     """A 201-empty-body response identifies the job via the Location header."""
 
@@ -691,6 +711,31 @@ async def test_async_wait_dismisses_on_timeout() -> None:
             await gp.wait("ajob-to", poll_interval=0.0, timeout=0.0)
 
     assert deleted == ["/ogc/processes/jobs/ajob-to"]
+
+
+@pytest.mark.anyio
+async def test_async_wait_clamps_poll_delay_to_timeout_deadline() -> None:
+    statuses = iter(["running", "running", "successful"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        return httpx.Response(200, json=_status("ajob-deadline", next(statuses)))
+
+    delays: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        delays.append(delay)
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        with (
+            patch("honua_sdk.geoprocessing.time.monotonic", side_effect=[100.0, 100.0, 100.25]),
+            patch("asyncio.sleep", new=sleep),
+        ):
+            terminal = await gp.wait("ajob-deadline", poll_interval=0.5, timeout=0.75)
+
+    assert terminal.succeeded is True
+    assert delays == [0.5, 0.5]
 
 
 @pytest.mark.anyio

--- a/tests/test_geoprocessing.py
+++ b/tests/test_geoprocessing.py
@@ -12,7 +12,9 @@ honua-server OGC API Processes contract:
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -307,7 +309,9 @@ def test_wait_dismisses_job_on_timeout() -> None:
     assert deleted == ["/ogc/processes/jobs/job-to"]
 
 
-def test_wait_timeout_swallows_dismiss_failure() -> None:
+def test_wait_timeout_swallows_dismiss_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Dismiss failure during timeout cleanup does not mask the TimeoutError."""
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -317,8 +321,28 @@ def test_wait_timeout_swallows_dismiss_failure() -> None:
 
     with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
         gp = client.geoprocessing()
-        with pytest.raises(TimeoutError):
-            gp.wait("job-tf", poll_interval=0.0, timeout=0.0)
+        with caplog.at_level(logging.DEBUG, logger="honua_sdk.geoprocessing"):
+            with pytest.raises(TimeoutError):
+                gp.wait("job-tf", poll_interval=0.0, timeout=0.0)
+
+    assert "Failed to dismiss geoprocessing job 'job-tf' during cleanup." in caplog.text
+
+
+def test_wait_uses_exponential_poll_backoff() -> None:
+    statuses = iter(["running", "running", "successful"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        return httpx.Response(200, json=_status("job-backoff", next(statuses)))
+
+    delays: list[float] = []
+    with HonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        with patch("honua_sdk.geoprocessing.time.sleep", side_effect=delays.append):
+            terminal = gp.wait("job-backoff", poll_interval=0.5, timeout=10.0)
+
+    assert terminal.succeeded is True
+    assert delays == [0.5, 1.0]
 
 
 def test_submit_uses_location_header_when_body_lacks_job_id() -> None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 from unittest.mock import patch
 
@@ -56,6 +57,23 @@ def test_retry_on_502() -> None:
     assert response.status_code == 200
     assert transport._call_count["n"] == 2  # type: ignore[attr-defined]
     mock_sleep.assert_called_once_with(0.5)
+
+
+def test_retry_logs_http_status_trigger(caplog: pytest.LogCaptureFixture) -> None:
+    transport = _make_transport(
+        [
+            httpx.Response(503, text="Service Unavailable"),
+            httpx.Response(200, json={"ok": True}),
+        ],
+    )
+    request = httpx.Request("GET", "http://example.test/")
+
+    with caplog.at_level(logging.DEBUG, logger="honua_sdk.transport"):
+        with patch("honua_sdk._retry.time.sleep"):
+            response = transport.handle_request(request)
+
+    assert response.status_code == 200
+    assert "Retrying GET / after HTTP 503" in caplog.text
 
 
 def test_retry_on_503() -> None:

--- a/tests/test_with_options.py
+++ b/tests/test_with_options.py
@@ -400,6 +400,53 @@ def test_with_options_enables_retries_on_zero_built_async_client() -> None:
     assert call_count["n"] == 3
 
 
+def test_with_options_enables_retries_on_zero_built_admin_client() -> None:
+    call_count = {"n": 0}
+
+    def handler(_r: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            return httpx.Response(503, text="retry")
+        return httpx.Response(200, json={"data": []})
+
+    transport = httpx.MockTransport(handler)
+    original = HonuaAdminClient("http://example.test", transport=transport, max_retries=0)
+    try:
+        retrying = original.with_options(max_retries=5)
+        with patch("honua_sdk._retry.time.sleep"):
+            result = retrying.list_services()
+        assert result == []
+        assert call_count["n"] == 3
+    finally:
+        original.close()
+
+
+def test_with_options_enables_retries_on_zero_built_async_admin_client() -> None:
+    call_count = {"n": 0}
+
+    def handler(_r: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if call_count["n"] <= 2:
+            return httpx.Response(503, text="retry")
+        return httpx.Response(200, json={"data": []})
+
+    async def run() -> list[Any]:
+        transport = httpx.MockTransport(handler)
+        original = AsyncHonuaAdminClient(
+            "http://example.test", transport=transport, max_retries=0
+        )
+        try:
+            retrying = original.with_options(max_retries=5)
+            with patch("honua_sdk._async_retry.asyncio.sleep"):
+                return await retrying.list_services()
+        finally:
+            await original.close()
+
+    result = asyncio.run(run())
+    assert result == []
+    assert call_count["n"] == 3
+
+
 # ---------------------------------------------------------------------------
 # AUD-162 (issue #129): protocol ``_text`` requests must route through the
 # client's normal request path so per-call options carried by ``with_options``


### PR DESCRIPTION
## Summary
- Address Python SDK quality audit backlog findings from issue #164.
- Consolidate shared HTTP/header helpers, admin base-path request handling, retry/logging visibility, GP polling cleanup, attachment result parsing, and query page dispatch.
- Add regression coverage and refresh the public API snapshot for additive admin scan options.

## Validation
- python -m ruff check .
- python -m mypy packages/honua-sdk/honua_sdk packages/honua-admin/honua_admin
- python scripts/compatibility_gate.py
- python -m pytest tests/ -q

Closes #164