### PR TITLE
honua-gp golden eval: real value diffs (request fingerprint + live response) over exit-code checks

### DIFF
--- a/.github/workflows/honua-gp-eval.yml
+++ b/.github/workflows/honua-gp-eval.yml
@@ -131,11 +131,23 @@ jobs:
   # round-trips (dispatch -> real HTTP -> response parse) against honua-server,
   # which the canned-response stub cannot check.
   #
-  # The response oracles in eval/golden/*.json are pinned to the honua-server
+  # The response oracles in eval/golden/*.json are pinned to a FRESH
   # client-compat seed (test_service/layer 0 + the in-repo spatial-join second
-  # layer). If the pinned server image or the seed changes the computed output,
-  # re-bless with ``HONUA_GP_EVAL_USE_STUB=0 HONUA_BASE_URL=... run_eval.py
-  # --update-golden`` and review the diff (see docs/golden-eval.md).
+  # layer) -- several eval scripts mutate the seeded layer (InsertCursor /
+  # UpdateCursor -> applyEdits) and those edits persist, so the oracles are
+  # only deterministic against a database that has not been touched by a prior
+  # run. This job therefore targets a DEDICATED ``vars.HONUA_GP_EVAL_BASE_URL``
+  # variable, not the generic ``vars.HONUA_BASE_URL`` other lanes (e.g.
+  # conformance) point at a persistent shared staging server -- reusing that
+  # generic var here previously ran this job's value diff against a drifted,
+  # non-fresh database and produced spurious response-mismatch failures with
+  # no real regression (see PR discussion). Leaving the dedicated var unset
+  # (the default posture) spins up a fresh, ephemeral, per-run Docker target so
+  # the response oracles reproduce. Set ``vars.HONUA_GP_EVAL_BASE_URL``
+  # explicitly ONLY if you intentionally want this lane to smoke-test against a
+  # persistent target instead of the fresh seed -- expect the seed-pinned
+  # response oracles to drift/flake against a non-fresh database in that case
+  # (see docs/golden-eval.md).
   #
   # This is NOT ArcGIS Pro parity: a licensed arcpy baseline does not exist in
   # this environment, so arcpy-level output equivalence stays out of scope and
@@ -149,7 +161,9 @@ jobs:
       packages: read
     environment: staging
     env:
-      HONUA_BASE_URL: ${{ vars.HONUA_BASE_URL }}
+      # Dedicated var -- see the job-level comment above for why this must NOT
+      # read the generic ``vars.HONUA_BASE_URL``.
+      HONUA_BASE_URL: ${{ vars.HONUA_GP_EVAL_BASE_URL }}
       HONUA_API_KEY: ${{ secrets.HONUA_API_KEY }}
       # NOTE (issue #157): the layer-aware vector ops (Buffer / SpatialJoin /
       # Dissolve / Project -> analytics.buffer-aggregate / analytics.spatial-join
@@ -187,12 +201,17 @@ jobs:
           if [[ -n "${HONUA_BASE_URL}" ]]; then
             echo "configured=true" >> "${GITHUB_OUTPUT}"
             echo "local_stack=false" >> "${GITHUB_OUTPUT}"
+            {
+              echo "## honua-gp smoke"
+              echo '- ``vars.HONUA_GP_EVAL_BASE_URL`` is configured; smoke-testing against that persistent target instead of a fresh local seed.'
+              echo '- WARNING: the response-value oracles in eval/golden/*.json are pinned to a fresh client-compat seed and MAY drift/flake against a non-fresh database.'
+            } >> "${GITHUB_STEP_SUMMARY}"
           else
             echo "configured=true" >> "${GITHUB_OUTPUT}"
             echo "local_stack=true" >> "${GITHUB_OUTPUT}"
             {
               echo "## honua-gp smoke"
-              echo '- ``HONUA_BASE_URL`` not configured; reusing the seeded client-compat Docker target.'
+              echo '- ``vars.HONUA_GP_EVAL_BASE_URL`` not configured; standing up a fresh, ephemeral, seeded client-compat Docker target so the response-value oracles are deterministic.'
             } >> "${GITHUB_STEP_SUMMARY}"
           fi
 

--- a/.github/workflows/honua-gp-eval.yml
+++ b/.github/workflows/honua-gp-eval.yml
@@ -69,8 +69,25 @@ jobs:
         run: |
           python -m pytest packages/honua-gp/tests -q --tb=short
 
-      - name: Run honua-gp eval (stub mode)
+      - name: Run honua-gp eval (stub mode -- dispatch plumbing + request fingerprint)
         run: |
+          # WHAT THIS LANE VERIFIES (and what it does NOT):
+          #
+          #   * Dispatch plumbing: every eval script runs to exit 0 and emits
+          #     the expected audit JSONL stream + stdout marker.
+          #   * Request fingerprint: the projected process id + typed inputs the
+          #     shim POSTs (captured from the ``process_inputs`` audit field) are
+          #     diffed against the golden ``request`` block. This is
+          #     transport-independent, so a parameter-mapping / dispatch
+          #     regression is caught HERE, under the canned-response stub -- the
+          #     stub itself never validates the payload, so without this diff a
+          #     wrong-payload bug would sail through.
+          #
+          # This lane does NOT verify response round-trip correctness (the stub
+          # returns a canned href, not real geometry) and does NOT verify ArcGIS
+          # Pro output parity (no arcpy license exists; tracked separately). The
+          # live-server value diff runs in the ``ephemeral-server-smoke`` job.
+          #
           # ``--require-supported-pass-rate 1.0`` makes this blocking per-PR
           # lane fail on ANY regression in a *supported* (mapped) script,
           # instead of staying green off the overall pass rate (which is
@@ -106,6 +123,23 @@ jobs:
           path: packages/honua-gp/dist/*.whl
           retention-days: 30
 
+  # Live value diff: stands up a REAL, seeded honua-server (Docker) and runs
+  # the same eval scripts with the stub disabled, so run_eval.py grades its
+  # third layer -- the RESPONSE fingerprint (buffered geometry type + feature
+  # count, row counts) that the shim parsed back from the real server. This is
+  # the genuine correctness upgrade over the stub lane: it proves honua_gp
+  # round-trips (dispatch -> real HTTP -> response parse) against honua-server,
+  # which the canned-response stub cannot check.
+  #
+  # The response oracles in eval/golden/*.json are pinned to the honua-server
+  # client-compat seed (test_service/layer 0 + the in-repo spatial-join second
+  # layer). If the pinned server image or the seed changes the computed output,
+  # re-bless with ``HONUA_GP_EVAL_USE_STUB=0 HONUA_BASE_URL=... run_eval.py
+  # --update-golden`` and review the diff (see docs/golden-eval.md).
+  #
+  # This is NOT ArcGIS Pro parity: a licensed arcpy baseline does not exist in
+  # this environment, so arcpy-level output equivalence stays out of scope and
+  # is tracked separately.
   ephemeral-server-smoke:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
@@ -253,7 +287,7 @@ jobs:
           docker compose -f "${compose_file}" -f "${override_file}" exec -T postgres \
             psql -U postgres -d honua_compat -v ON_ERROR_STOP=1 < "${second_layer_sql}"
 
-      - name: Run ephemeral smoke
+      - name: Run ephemeral smoke (live value diff -- honua_gp <-> real honua-server)
         env:
           HONUA_GP_EVAL_USE_STUB: "0"
           HONUA_GP_AUDIT_DIR: ${{ runner.temp }}/honua-gp-smoke-audit

--- a/packages/honua-gp/docs/golden-eval.md
+++ b/packages/honua-gp/docs/golden-eval.md
@@ -1,0 +1,117 @@
+# honua-gp golden eval
+
+The golden eval suite (`eval/run_eval.py`, `eval/scripts/*.py`,
+`eval/golden/*.json`) is the correctness-verification story for the `honua_gp`
+drop-in shim. `honua_gp` delegates every geoprocessing operation to a Honua
+server instead of reimplementing geometry/raster logic locally, so "is the
+shim correct?" reduces to two questions the harness answers directly:
+
+1. **Does the shim project each `arcpy` call onto the right Honua request?**
+   (dispatch / parameter translation)
+2. **Does the shim parse the real server's response back correctly?**
+   (response handling / round-trip)
+
+## What is (and is not) verified
+
+The harness grades each script across three independent layers, weakest to
+strongest:
+
+| Layer | Checks | Graded in |
+| --- | --- | --- |
+| **Plumbing** | exit code, audit JSONL line count, required `stdout` marker | every mode |
+| **Request fingerprint** | projected `process_id` + typed `inputs` the shim POSTs (from the `process_inputs` audit field) diffed against golden `request` | every mode |
+| **Response fingerprint** | geometry type / feature count / row count the shim parsed back from a REAL server, diffed against golden `response` | live mode only |
+
+* **Stub mode** (`HONUA_GP_EVAL_USE_STUB=1`, the default) grades plumbing +
+  request. The request fingerprint is transport-independent -- the projection
+  runs identically against the stub and a live server -- so a
+  parameter-mapping / dispatch regression (an `arcpy` argument mapped to the
+  wrong process input) is caught here even though the stub never validates the
+  payload it receives. Stub mode does **not** exercise a real server, so it
+  cannot verify response round-trip.
+
+* **Live mode** (`HONUA_GP_EVAL_USE_STUB=0` + `HONUA_BASE_URL`) additionally
+  grades the response fingerprint against a real, seeded honua-server. This is
+  the genuine correctness upgrade over the stub: it proves the shim's
+  dispatch -> real HTTP -> response-parse loop round-trips correctly, which a
+  canned-response stub can never check.
+
+* **ArcGIS Pro parity is NOT verified anywhere.** No licensed arcpy runtime
+  exists in this environment, so the golden values are not diffed against a
+  real ArcGIS Pro baseline. The response oracles are pinned to what
+  honua-server computes for the client-compat seed, not to what ArcGIS Pro
+  would return. arcpy-level output equivalence remains license-gated and is
+  tracked separately.
+
+## Golden schema (v2)
+
+```json
+{
+  "schema_version": 2,
+  "expected_failure": false,
+  "plumbing": { "audit_lines": 1, "stdout_contains": "buffer_roads ok" },
+  "request": [
+    {
+      "function": "analysis.Buffer",
+      "process_id": "analytics.buffer-aggregate",
+      "inputs": { "layerId": 0, "distance": 25.0, "unit": "meters", "dissolve": true }
+    }
+  ],
+  "response": { "output_keys": ["outputFeatureLayer"], "geometry_type": "Polygon", "feature_count": 1 }
+}
+```
+
+* `request` is a list (one entry per process-backed call, in call order) so
+  multi-op scripts fingerprint every step.
+* `request` is absent for source/session-backed scripts (`GetCount`, cursors)
+  that make no process dispatch; `response` is absent for `expected_failure`
+  scripts and side-effecting scripts with no meaningful return.
+
+## Re-capturing (blessing) the oracles
+
+Golden values are captured-then-frozen. After an intentional change, re-bless
+and review the diff before committing:
+
+```bash
+# Request fingerprints (stub is sufficient -- projection is transport-independent)
+python eval/run_eval.py --update-golden
+
+# Response fingerprints (requires a live, seeded honua-server)
+HONUA_GP_EVAL_USE_STUB=0 HONUA_BASE_URL=http://localhost:5000 HONUA_API_KEY=... \
+  python eval/run_eval.py --update-golden
+```
+
+Request fingerprints are written in any mode; response fingerprints only in
+live mode (the stub's canned `href` carries no real values and must never be
+frozen as an oracle).
+
+## Determinism note (live mode)
+
+The response oracles for count/row scripts record exact values pinned to the
+client-compat seed. Several eval scripts mutate the seeded layer
+(`da.InsertCursor` / `da.UpdateCursor` -> FeatureServer `applyEdits`), and
+those edits persist, so **each live run must start from a fresh seed** for the
+counts to reproduce. The CI `ephemeral-server-smoke` job stands up a fresh
+Docker compose (fresh Postgres) per run, so counts are deterministic there.
+Running live mode twice against the same persistent database will drift the
+count/row oracles -- reset the seed (or re-bless) between runs.
+
+## Standing up a live target locally
+
+The live lane reuses honua-server's `docker/client-compat/compose.yml` seed
+(`test_service` / layer 0) plus the in-repo second layer
+(`eval/seed/spatial-join-second-layer.sql`, needed because
+`analytics.spatial-join` rejects a self-join). Point the eval at it with:
+
+```bash
+export HONUA_GP_EVAL_USE_STUB=0
+export HONUA_BASE_URL=http://localhost:5000
+export HONUA_API_KEY=...
+# Redirect the legacy demo names baked into the generator to the seeded layer:
+export HONUA_GP_PATH_MAP='{"roads":"honua://services/test_service/0","segments_attrs":"honua://services/test_service/0"}'
+python eval/run_eval.py --require-supported-pass-rate 1.0
+```
+
+The server must have Redis-backed durable job storage available (the OGC
+Processes job store honua-server's async GP operations run on); the
+client-compat compose wires Redis for exactly this.

--- a/packages/honua-gp/docs/golden-eval.md
+++ b/packages/honua-gp/docs/golden-eval.md
@@ -91,10 +91,21 @@ The response oracles for count/row scripts record exact values pinned to the
 client-compat seed. Several eval scripts mutate the seeded layer
 (`da.InsertCursor` / `da.UpdateCursor` -> FeatureServer `applyEdits`), and
 those edits persist, so **each live run must start from a fresh seed** for the
-counts to reproduce. The CI `ephemeral-server-smoke` job stands up a fresh
-Docker compose (fresh Postgres) per run, so counts are deterministic there.
-Running live mode twice against the same persistent database will drift the
-count/row oracles -- reset the seed (or re-bless) between runs.
+counts to reproduce. Running live mode twice against the same persistent
+database will drift the count/row oracles -- reset the seed (or re-bless)
+between runs.
+
+**By default, the CI `ephemeral-server-smoke` job stands up a fresh Docker
+compose (fresh Postgres) per run**, so counts are deterministic there. This
+job intentionally targets a *dedicated* `vars.HONUA_GP_EVAL_BASE_URL` variable
+rather than the generic `vars.HONUA_BASE_URL` that other lanes (e.g.
+conformance) point at a persistent shared staging server -- pointing this job
+at that shared server ran the response-value diff against a drifted, non-fresh
+database and produced spurious mismatches with no real regression (the exact
+failure mode this note warns about). Only set `vars.HONUA_GP_EVAL_BASE_URL`
+explicitly if you intentionally want this lane to smoke-test against a
+persistent target instead of a fresh seed; if you do, expect the seed-pinned
+response oracles to drift/flake over repeated runs.
 
 ## Standing up a live target locally
 

--- a/packages/honua-gp/eval/_emit.py
+++ b/packages/honua-gp/eval/_emit.py
@@ -1,0 +1,119 @@
+"""Response-value emitter for eval scripts.
+
+The golden harness verifies two independent things:
+
+* The **request** honua_gp projects onto the server (process id + typed
+  inputs). That fingerprint is captured from the audit JSONL stream and is
+  deterministic across the stub transport and a live server, so it is diffed
+  in both modes (see ``run_eval.py``).
+* The **response** honua_gp parses back from the server. The stub transport
+  only returns a canned ``href``, so a response value diff is meaningful
+  *only* against a live, seeded honua-server. Scripts that read a computed
+  result (buffered geometry, a row count, cursor rows) call
+  :func:`emit_response` here to record what ``honua_gp`` actually parsed;
+  ``run_eval.py`` diffs that sidecar against the golden ``response`` block
+  when running in live mode.
+
+The emitter is a no-op unless ``HONUA_GP_EVAL_RESULT_DIR`` is set (the harness
+sets it), so the scripts stay runnable by hand and in stub CI without writing
+stray files.
+
+This is NOT an ArcGIS Pro parity check: the response fingerprint is pinned to
+the honua-server client-compat seed, not to a licensed arcpy baseline. It
+verifies that ``honua_gp`` round-trips correctly against the real Honua
+server; arcpy-level output parity remains license-gated and out of scope here.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_RESULT_DIR_ENV = "HONUA_GP_EVAL_RESULT_DIR"
+
+
+def _result_dir() -> Path | None:
+    raw = os.environ.get(_RESULT_DIR_ENV)
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def emit_response(name: str, response: Mapping[str, Any]) -> None:
+    """Write ``{HONUA_GP_EVAL_RESULT_DIR}/{name}.json`` when capture is enabled.
+
+    ``response`` is a normalized, seed-stable fingerprint (geometry type,
+    feature/row counts, output keys) -- never the raw floating-point geometry,
+    which would be brittle across server versions.
+    """
+
+    target_dir = _result_dir()
+    if target_dir is None:
+        return
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / f"{name}.json").write_text(
+        json.dumps(response, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def _decode_feature_layer_href(href: str) -> Mapping[str, Any] | None:
+    """Decode a ``data:application/geo+json;base64,...`` FeatureLayer href."""
+
+    marker = "base64,"
+    if not isinstance(href, str) or marker not in href:
+        return None
+    payload = href.split(marker, 1)[1]
+    try:
+        decoded = base64.b64decode(payload)
+        parsed = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, Mapping) else None
+
+
+def feature_layer_fingerprint(result: Any) -> dict[str, Any]:
+    """Normalize a process ``Result`` into a seed-stable response fingerprint.
+
+    Extracts the sorted output keys, and -- when the primary output is a
+    GeoJSON FeatureLayer -- the geometry type and feature count that the
+    server actually computed and ``honua_gp`` parsed back. Absent / unreadable
+    geometry degrades gracefully to ``None`` so the harness still diffs the
+    structural keys.
+    """
+
+    outputs = getattr(result, "outputs", None)
+    if not isinstance(outputs, Mapping):
+        return {"output_keys": [], "geometry_type": None, "feature_count": None}
+
+    fingerprint: dict[str, Any] = {
+        "output_keys": sorted(str(key) for key in outputs),
+        "geometry_type": None,
+        "feature_count": None,
+    }
+
+    # The layer-aware analysis/management processes return a single
+    # ``outputFeatureLayer`` (or similarly named) FeatureLayer artifact.
+    for value in outputs.values():
+        if not isinstance(value, Mapping):
+            continue
+        href = value.get("href")
+        geojson = _decode_feature_layer_href(href) if isinstance(href, str) else None
+        if geojson is None:
+            continue
+        features = geojson.get("features")
+        if isinstance(features, list):
+            fingerprint["feature_count"] = len(features)
+            if features and isinstance(features[0], Mapping):
+                geometry = features[0].get("geometry")
+                if isinstance(geometry, Mapping):
+                    fingerprint["geometry_type"] = geometry.get("type")
+        break
+
+    return fingerprint
+
+
+__all__ = ["emit_response", "feature_layer_fingerprint"]

--- a/packages/honua-gp/eval/_generate_scripts.py
+++ b/packages/honua-gp/eval/_generate_scripts.py
@@ -73,12 +73,44 @@ class ScriptSpec:
     expected_audit_lines: int
     stdout_marker: str
     is_expected_failure: bool = False
+    response_emit: str = ""
+
+
+def _fl_emit(slug: str, var: str = "result") -> str:
+    """Emit a FeatureLayer response fingerprint (geometry type + feature count).
+
+    Appended to process-backed scripts (Buffer / SpatialJoin / Dissolve /
+    Project). No-op unless HONUA_GP_EVAL_RESULT_DIR is set, so stub / by-hand
+    runs are unaffected; ``run_eval.py`` diffs the sidecar in live mode only.
+    """
+
+    return (
+        "from eval._emit import emit_response, feature_layer_fingerprint\n"
+        f"emit_response({slug!r}, feature_layer_fingerprint({var}))\n"
+    )
+
+
+def _val_emit(slug: str, expr: str) -> str:
+    """Emit a scalar response fingerprint (a row count / feature count)."""
+
+    return (
+        "from eval._emit import emit_response\n"
+        f"emit_response({slug!r}, {expr})\n"
+    )
 
 
 SUPPORTED_TEMPLATES: list[ScriptSpec] = []
 
 
-def _supported(slug: str, workspace: str, docstring: str, body: str, audit_lines: int, marker: str) -> ScriptSpec:
+def _supported(
+    slug: str,
+    workspace: str,
+    docstring: str,
+    body: str,
+    audit_lines: int,
+    marker: str,
+    response_emit: str = "",
+) -> ScriptSpec:
     spec = ScriptSpec(
         slug=slug,
         workspace=workspace,
@@ -86,6 +118,7 @@ def _supported(slug: str, workspace: str, docstring: str, body: str, audit_lines
         body=body,
         expected_audit_lines=audit_lines,
         stdout_marker=marker,
+        response_emit=response_emit,
     )
     SUPPORTED_TEMPLATES.append(spec)
     return spec
@@ -115,6 +148,7 @@ print(f"make_feature_layer_then_select ok count={selection.count}")
 """,
     2,
     "make_feature_layer_then_select ok",
+    response_emit=_val_emit("make_feature_layer_then_select", "{'count': int(selection.count)}"),
 )
 
 _supported(
@@ -137,6 +171,7 @@ print(f"get_count_roads ok count={count}")
 """,
     1,
     "get_count_roads ok",
+    response_emit=_val_emit("get_count_roads", "{'count': int(count)}"),
 )
 
 _supported(
@@ -149,6 +184,7 @@ print(f"search_cursor_iterate ok rows={len(rows)}")
 """,
     1,
     "search_cursor_iterate ok",
+    response_emit=_val_emit("search_cursor_iterate", "{'rows': len(rows)}"),
 )
 
 _supported(
@@ -205,6 +241,7 @@ print(f"get_count_after_select ok count={count}")
 """,
     3,
     "get_count_after_select ok",
+    response_emit=_val_emit("get_count_after_select", "{'count': int(count)}"),
 )
 
 _supported(
@@ -219,6 +256,7 @@ print(f"make_feature_layer_clear_then_count ok count={count}")
 """,
     4,
     "make_feature_layer_clear_then_count ok",
+    response_emit=_val_emit("make_feature_layer_clear_then_count", "{'count': int(count)}"),
 )
 
 _supported(
@@ -231,6 +269,7 @@ print(f"search_cursor_filter ok rows={len(rows)}")
 """,
     1,
     "search_cursor_filter ok",
+    response_emit=_val_emit("search_cursor_filter", "{'rows': len(rows)}"),
 )
 
 _supported(
@@ -245,6 +284,7 @@ print(f"insert_cursor_then_search ok rows={len(rows)}")
 """,
     2,
     "insert_cursor_then_search ok",
+    response_emit=_val_emit("insert_cursor_then_search", "{'rows': len(rows)}"),
 )
 
 EXPECTED_FAILURE_TEMPLATES: list[ScriptSpec] = []
@@ -294,6 +334,7 @@ print(f"buffer_roads ok output={result[0]}")
 """,
     1,
     "buffer_roads ok",
+    response_emit=_fl_emit("buffer_roads"),
 )
 _supported(
     "buffer_legacy_suffix",
@@ -304,6 +345,7 @@ print(f"buffer_legacy_suffix ok output={result[0]}")
 """,
     1,
     "buffer_legacy_suffix ok",
+    response_emit=_fl_emit("buffer_legacy_suffix"),
 )
 # SpatialJoin: the join_features MUST resolve to a different layerId than
 # target_features -- honua-server's analytics.spatial-join rejects a self-join
@@ -319,6 +361,7 @@ print(f"spatial_join_addresses_parcels ok output={result[0]}")
 """,
     1,
     "spatial_join_addresses_parcels ok",
+    response_emit=_fl_emit("spatial_join_addresses_parcels"),
 )
 _supported(
     "spatial_join_with_radius",
@@ -329,6 +372,7 @@ print(f"spatial_join_with_radius ok output={result[0]}")
 """,
     1,
     "spatial_join_with_radius ok",
+    response_emit=_fl_emit("spatial_join_with_radius"),
 )
 _supported(
     "dissolve_parcels_by_zoning",
@@ -339,6 +383,7 @@ print(f"dissolve_parcels_by_zoning ok output={result[0]}")
 """,
     1,
     "dissolve_parcels_by_zoning ok",
+    response_emit=_fl_emit("dissolve_parcels_by_zoning"),
 )
 # data-management.copy-features / .calculate-field are CanServe=false by design
 # (honua-server#1382): never projected as standalone OGC API processes, only
@@ -380,6 +425,7 @@ print(f"project_roads_to_wgs84 ok output={result[0]}")
 """,
     1,
     "project_roads_to_wgs84 ok",
+    response_emit=_fl_emit("project_roads_to_wgs84"),
 )
 _expected_failure(
     "calculate_field_constant",
@@ -404,6 +450,7 @@ print(f"buffer_then_dissolve ok output={result[0]}")
 """,
     2,
     "buffer_then_dissolve ok",
+    response_emit=_fl_emit("buffer_then_dissolve"),
 )
 _supported(
     "buffer_numeric_distance",
@@ -414,6 +461,7 @@ print(f"buffer_numeric_distance ok output={result[0]}")
 """,
     1,
     "buffer_numeric_distance ok",
+    response_emit=_fl_emit("buffer_numeric_distance"),
 )
 _supported(
     "project_kilometers_buffer",
@@ -425,6 +473,7 @@ print(f"project_kilometers_buffer ok output={result[0]}")
 """,
     2,
     "project_kilometers_buffer ok",
+    response_emit=_fl_emit("project_kilometers_buffer"),
 )
 _expected_failure(
     "copy_then_calculate_field",
@@ -500,7 +549,38 @@ _expected_failure("rename_then_describe", "    arcpy.management.Rename('legacy_p
 
 def _render(spec: ScriptSpec) -> str:
     header = BOOTSTRAP.format(docstring=spec.docstring, workspace=spec.workspace)
-    return header + spec.body
+    body = spec.body
+    if spec.response_emit:
+        body = body + spec.response_emit
+    return header + body
+
+
+def _golden_document(spec: ScriptSpec, existing: dict | None) -> dict:
+    """Build the v2 golden document for ``spec``.
+
+    The generator owns the *scaffold*: ``schema_version``, ``expected_failure``,
+    and the ``plumbing`` block (exit-code-adjacent string / audit-line checks
+    that run in every mode). The value oracles -- the ``request`` fingerprint
+    (projected process id + inputs) and the live-only ``response`` fingerprint
+    (geometry type, feature/row counts) -- are captured and frozen by
+    ``run_eval.py --update-golden`` (see ``docs/golden-eval.md``). Regenerating
+    scripts must NOT wipe those blessed values, so any existing ``request`` /
+    ``response`` blocks are carried forward from the committed golden.
+    """
+
+    document: dict = {
+        "schema_version": 2,
+        "expected_failure": spec.is_expected_failure,
+        "plumbing": {
+            "audit_lines": spec.expected_audit_lines,
+            "stdout_contains": spec.stdout_marker,
+        },
+    }
+    if existing:
+        for carried in ("request", "response"):
+            if carried in existing:
+                document[carried] = existing[carried]
+    return document
 
 
 def _emit() -> None:
@@ -516,17 +596,14 @@ def _emit() -> None:
         target.write_text(_render(spec), encoding="utf-8")
 
         golden = GOLDEN_DIR / f"{spec.slug}.json"
+        existing: dict | None = None
+        if golden.exists():
+            try:
+                existing = json.loads(golden.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                existing = None
         golden.write_text(
-            json.dumps(
-                {
-                    "audit_lines": spec.expected_audit_lines,
-                    "stdout_contains": spec.stdout_marker,
-                    "expected_failure": spec.is_expected_failure,
-                },
-                indent=2,
-                sort_keys=True,
-            )
-            + "\n",
+            json.dumps(_golden_document(spec, existing), indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
 

--- a/packages/honua-gp/eval/golden/buffer_legacy_suffix.json
+++ b/packages/honua-gp/eval/golden/buffer_legacy_suffix.json
@@ -1,5 +1,26 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "buffer_legacy_suffix ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "buffer_legacy_suffix ok"
+  },
+  "request": [
+    {
+      "function": "analysis.Buffer",
+      "inputs": {
+        "distance": 15.0,
+        "layerId": 0,
+        "unit": "meters"
+      },
+      "process_id": "analytics.buffer-aggregate"
+    }
+  ],
+  "response": {
+    "feature_count": 1,
+    "geometry_type": "Polygon",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/buffer_numeric_distance.json
+++ b/packages/honua-gp/eval/golden/buffer_numeric_distance.json
@@ -1,5 +1,26 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "buffer_numeric_distance ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "buffer_numeric_distance ok"
+  },
+  "request": [
+    {
+      "function": "analysis.Buffer",
+      "inputs": {
+        "distance": 50.0,
+        "layerId": 0,
+        "unit": "meters"
+      },
+      "process_id": "analytics.buffer-aggregate"
+    }
+  ],
+  "response": {
+    "feature_count": 1,
+    "geometry_type": "Polygon",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/buffer_roads.json
+++ b/packages/honua-gp/eval/golden/buffer_roads.json
@@ -1,5 +1,27 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "buffer_roads ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "buffer_roads ok"
+  },
+  "request": [
+    {
+      "function": "analysis.Buffer",
+      "inputs": {
+        "dissolve": true,
+        "distance": 25.0,
+        "layerId": 0,
+        "unit": "meters"
+      },
+      "process_id": "analytics.buffer-aggregate"
+    }
+  ],
+  "response": {
+    "feature_count": 1,
+    "geometry_type": "Polygon",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/buffer_then_dissolve.json
+++ b/packages/honua-gp/eval/golden/buffer_then_dissolve.json
@@ -1,5 +1,35 @@
 {
-  "audit_lines": 2,
   "expected_failure": false,
-  "stdout_contains": "buffer_then_dissolve ok"
+  "plumbing": {
+    "audit_lines": 2,
+    "stdout_contains": "buffer_then_dissolve ok"
+  },
+  "request": [
+    {
+      "function": "analysis.Buffer",
+      "inputs": {
+        "dissolve": true,
+        "distance": 5.0,
+        "layerId": 0,
+        "unit": "meters"
+      },
+      "process_id": "analytics.buffer-aggregate"
+    },
+    {
+      "function": "management.Dissolve",
+      "inputs": {
+        "groupByFields": "class",
+        "layerId": 0
+      },
+      "process_id": "generalization.dissolve"
+    }
+  ],
+  "response": {
+    "feature_count": 1,
+    "geometry_type": "MultiPoint",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/dissolve_parcels_by_zoning.json
+++ b/packages/honua-gp/eval/golden/dissolve_parcels_by_zoning.json
@@ -1,5 +1,25 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "dissolve_parcels_by_zoning ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "dissolve_parcels_by_zoning ok"
+  },
+  "request": [
+    {
+      "function": "management.Dissolve",
+      "inputs": {
+        "groupByFields": "zoning_code",
+        "layerId": 0
+      },
+      "process_id": "generalization.dissolve"
+    }
+  ],
+  "response": {
+    "feature_count": 1,
+    "geometry_type": "MultiPoint",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_add_field.json
+++ b/packages/honua-gp/eval/golden/expected_failure_add_field.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_add_field"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_add_field"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_add_field_calculate_field.json
+++ b/packages/honua-gp/eval/golden/expected_failure_add_field_calculate_field.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_add_field_calculate_field"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_add_field_calculate_field"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_append.json
+++ b/packages/honua-gp/eval/golden/expected_failure_append.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_append"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_append"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_calculate_field_constant.json
+++ b/packages/honua-gp/eval/golden/expected_failure_calculate_field_constant.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_calculate_field_constant"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_calculate_field_constant"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_clip_roads_in_study.json
+++ b/packages/honua-gp/eval/golden/expected_failure_clip_roads_in_study.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_clip_roads_in_study"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_clip_roads_in_study"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_copy_features_alias.json
+++ b/packages/honua-gp/eval/golden/expected_failure_copy_features_alias.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_copy_features_alias"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_copy_features_alias"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_copy_pavement_to_backup.json
+++ b/packages/honua-gp/eval/golden/expected_failure_copy_pavement_to_backup.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_copy_pavement_to_backup"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_copy_pavement_to_backup"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_copy_then_calculate_field.json
+++ b/packages/honua-gp/eval/golden/expected_failure_copy_then_calculate_field.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_copy_then_calculate_field"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_copy_then_calculate_field"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_create_fc.json
+++ b/packages/honua-gp/eval/golden/expected_failure_create_fc.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_create_fc"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_create_fc"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_create_table.json
+++ b/packages/honua-gp/eval/golden/expected_failure_create_table.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_create_table"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_create_table"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_delete_field.json
+++ b/packages/honua-gp/eval/golden/expected_failure_delete_field.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_delete_field"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_delete_field"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_delete_field_after_calc.json
+++ b/packages/honua-gp/eval/golden/expected_failure_delete_field_after_calc.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_delete_field_after_calc"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_delete_field_after_calc"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_delete_obsolete_layer.json
+++ b/packages/honua-gp/eval/golden/expected_failure_delete_obsolete_layer.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_delete_obsolete_layer"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_delete_obsolete_layer"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_describe.json
+++ b/packages/honua-gp/eval/golden/expected_failure_describe.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_describe"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_describe"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_describe_then_iterate.json
+++ b/packages/honua-gp/eval/golden/expected_failure_describe_then_iterate.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_describe_then_iterate"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_describe_then_iterate"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_erase_water_from_parcels.json
+++ b/packages/honua-gp/eval/golden/expected_failure_erase_water_from_parcels.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_erase_water_from_parcels"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_erase_water_from_parcels"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_intersect_roads_parcels.json
+++ b/packages/honua-gp/eval/golden/expected_failure_intersect_roads_parcels.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_intersect_roads_parcels"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_intersect_roads_parcels"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_list_fields.json
+++ b/packages/honua-gp/eval/golden/expected_failure_list_fields.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_list_fields"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_list_fields"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_list_fields_filtered.json
+++ b/packages/honua-gp/eval/golden/expected_failure_list_fields_filtered.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_list_fields_filtered"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_list_fields_filtered"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_list_fields_wildcard.json
+++ b/packages/honua-gp/eval/golden/expected_failure_list_fields_wildcard.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_list_fields_wildcard"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_list_fields_wildcard"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_merge.json
+++ b/packages/honua-gp/eval/golden/expected_failure_merge.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_merge"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_merge"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_near.json
+++ b/packages/honua-gp/eval/golden/expected_failure_near.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_near"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_near"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_nearest_neighbor.json
+++ b/packages/honua-gp/eval/golden/expected_failure_nearest_neighbor.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_nearest_neighbor"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_nearest_neighbor"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_rename.json
+++ b/packages/honua-gp/eval/golden/expected_failure_rename.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_rename"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_rename"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_rename_then_describe.json
+++ b/packages/honua-gp/eval/golden/expected_failure_rename_then_describe.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_rename_then_describe"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_rename_then_describe"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_select_by_location.json
+++ b/packages/honua-gp/eval/golden/expected_failure_select_by_location.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_select_by_location"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_select_by_location"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_sort.json
+++ b/packages/honua-gp/eval/golden/expected_failure_sort.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_sort"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_sort"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_tabulate_intersection.json
+++ b/packages/honua-gp/eval/golden/expected_failure_tabulate_intersection.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_tabulate_intersection"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_tabulate_intersection"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_union_zoning_layers.json
+++ b/packages/honua-gp/eval/golden/expected_failure_union_zoning_layers.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_union_zoning_layers"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_union_zoning_layers"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/expected_failure_walk.json
+++ b/packages/honua-gp/eval/golden/expected_failure_walk.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": true,
-  "stdout_contains": "expected_failure_walk"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "expected_failure_walk"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/get_count_after_select.json
+++ b/packages/honua-gp/eval/golden/get_count_after_select.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 3,
   "expected_failure": false,
-  "stdout_contains": "get_count_after_select ok"
+  "plumbing": {
+    "audit_lines": 3,
+    "stdout_contains": "get_count_after_select ok"
+  },
+  "response": {
+    "count": 0
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/get_count_roads.json
+++ b/packages/honua-gp/eval/golden/get_count_roads.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "get_count_roads ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "get_count_roads ok"
+  },
+  "response": {
+    "count": 10
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/insert_cursor_append_rows.json
+++ b/packages/honua-gp/eval/golden/insert_cursor_append_rows.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "insert_cursor_append_rows ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "insert_cursor_append_rows ok"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/insert_cursor_then_search.json
+++ b/packages/honua-gp/eval/golden/insert_cursor_then_search.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 2,
   "expected_failure": false,
-  "stdout_contains": "insert_cursor_then_search ok"
+  "plumbing": {
+    "audit_lines": 2,
+    "stdout_contains": "insert_cursor_then_search ok"
+  },
+  "response": {
+    "rows": 14
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/make_feature_layer_clear_then_count.json
+++ b/packages/honua-gp/eval/golden/make_feature_layer_clear_then_count.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 4,
   "expected_failure": false,
-  "stdout_contains": "make_feature_layer_clear_then_count ok"
+  "plumbing": {
+    "audit_lines": 4,
+    "stdout_contains": "make_feature_layer_clear_then_count ok"
+  },
+  "response": {
+    "count": 14
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/make_feature_layer_then_select.json
+++ b/packages/honua-gp/eval/golden/make_feature_layer_then_select.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 2,
   "expected_failure": false,
-  "stdout_contains": "make_feature_layer_then_select ok"
+  "plumbing": {
+    "audit_lines": 2,
+    "stdout_contains": "make_feature_layer_then_select ok"
+  },
+  "response": {
+    "count": 3
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/make_table_view.json
+++ b/packages/honua-gp/eval/golden/make_table_view.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "make_table_view ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "make_table_view ok"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/project_kilometers_buffer.json
+++ b/packages/honua-gp/eval/golden/project_kilometers_buffer.json
@@ -1,5 +1,34 @@
 {
-  "audit_lines": 2,
   "expected_failure": false,
-  "stdout_contains": "project_kilometers_buffer ok"
+  "plumbing": {
+    "audit_lines": 2,
+    "stdout_contains": "project_kilometers_buffer ok"
+  },
+  "request": [
+    {
+      "function": "management.Project",
+      "inputs": {
+        "layerId": 0,
+        "targetSrid": 4326
+      },
+      "process_id": "conversion.feature-project"
+    },
+    {
+      "function": "analysis.Buffer",
+      "inputs": {
+        "distance": 1.0,
+        "layerId": 0,
+        "unit": "kilometers"
+      },
+      "process_id": "analytics.buffer-aggregate"
+    }
+  ],
+  "response": {
+    "feature_count": 1,
+    "geometry_type": "Polygon",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/project_roads_to_wgs84.json
+++ b/packages/honua-gp/eval/golden/project_roads_to_wgs84.json
@@ -1,5 +1,25 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "project_roads_to_wgs84 ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "project_roads_to_wgs84 ok"
+  },
+  "request": [
+    {
+      "function": "management.Project",
+      "inputs": {
+        "layerId": 0,
+        "targetSrid": 4326
+      },
+      "process_id": "conversion.feature-project"
+    }
+  ],
+  "response": {
+    "feature_count": 14,
+    "geometry_type": "Point",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/search_cursor_filter.json
+++ b/packages/honua-gp/eval/golden/search_cursor_filter.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "search_cursor_filter ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "search_cursor_filter ok"
+  },
+  "response": {
+    "rows": 3
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/search_cursor_iterate.json
+++ b/packages/honua-gp/eval/golden/search_cursor_iterate.json
@@ -1,5 +1,11 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "search_cursor_iterate ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "search_cursor_iterate ok"
+  },
+  "response": {
+    "rows": 14
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/spatial_join_addresses_parcels.json
+++ b/packages/honua-gp/eval/golden/spatial_join_addresses_parcels.json
@@ -1,5 +1,26 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "spatial_join_addresses_parcels ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "spatial_join_addresses_parcels ok"
+  },
+  "request": [
+    {
+      "function": "analysis.SpatialJoin",
+      "inputs": {
+        "joinLayerId": 1,
+        "layerId": 0,
+        "predicate": "intersects"
+      },
+      "process_id": "analytics.spatial-join"
+    }
+  ],
+  "response": {
+    "feature_count": 14,
+    "geometry_type": "Point",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/spatial_join_with_radius.json
+++ b/packages/honua-gp/eval/golden/spatial_join_with_radius.json
@@ -1,5 +1,27 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "spatial_join_with_radius ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "spatial_join_with_radius ok"
+  },
+  "request": [
+    {
+      "function": "analysis.SpatialJoin",
+      "inputs": {
+        "distance": 100.0,
+        "joinLayerId": 1,
+        "layerId": 0,
+        "predicate": "dwithin"
+      },
+      "process_id": "analytics.spatial-join"
+    }
+  ],
+  "response": {
+    "feature_count": 14,
+    "geometry_type": "Point",
+    "output_keys": [
+      "outputFeatureLayer"
+    ]
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/update_cursor_close_status.json
+++ b/packages/honua-gp/eval/golden/update_cursor_close_status.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "update_cursor_close_status ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "update_cursor_close_status ok"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/golden/update_cursor_delete_closed.json
+++ b/packages/honua-gp/eval/golden/update_cursor_delete_closed.json
@@ -1,5 +1,8 @@
 {
-  "audit_lines": 1,
   "expected_failure": false,
-  "stdout_contains": "update_cursor_delete_closed ok"
+  "plumbing": {
+    "audit_lines": 1,
+    "stdout_contains": "update_cursor_delete_closed ok"
+  },
+  "schema_version": 2
 }

--- a/packages/honua-gp/eval/run_eval.py
+++ b/packages/honua-gp/eval/run_eval.py
@@ -1,18 +1,44 @@
-"""Pass-rate harness for the honua-gp eval suite.
+"""Golden eval harness for the honua-gp compatibility shim.
 
-The harness:
+The harness runs every ``eval/scripts/*.py`` in a subprocess and grades it on
+three independent layers, from weakest to strongest:
 
-* Walks ``eval/scripts/*.py`` and executes each script in a subprocess.
-* Wires a stub Honua transport (or the real ``HONUA_BASE_URL`` when set) so
-  scripts run without an ArcGIS Pro license.
-* Records exit code, audit-JSONL shape, and (optionally) a golden-output
-  digest match.
-* Writes ``eval-results.json`` (machine-readable) and ``eval-results.xml``
-  (JUnit) plus a workflow-summary table.
+1. **Plumbing** (every mode): exit code, audit-JSONL line count, and a required
+   ``stdout`` marker. This only proves the script ran without crashing and
+   emitted its audit stream -- it does NOT prove the shim sent the right thing
+   or parsed the right thing back.
+
+2. **Request value diff** (every mode): the projected process id + typed inputs
+   the shim POSTs to honua-server, captured from the ``process_inputs`` audit
+   field. This is deterministic across the stub transport and a live server
+   (the projection is transport-independent), so a dispatch /
+   parameter-translation regression -- an arcpy argument mapped to the wrong
+   process input -- is caught even under the stub, which the canned-response
+   stub could never catch on its own.
+
+3. **Response value diff** (live mode only): the values the shim parsed back
+   from a REAL, seeded honua-server (buffered geometry type + feature count,
+   row counts), captured from the per-script sidecar written by
+   ``eval/_emit.py``. The stub only returns a canned ``href``, so this layer is
+   graded only when ``HONUA_GP_EVAL_USE_STUB=0`` and a live ``HONUA_BASE_URL``
+   is configured.
+
+Honest scope: stub mode grades layers 1-2 (dispatch plumbing + request
+fingerprint). Live mode adds layer 3 (round-trip correctness against a real
+Honua server). Neither layer verifies ArcGIS Pro output parity -- that requires
+a licensed arcpy run and is out of scope here (tracked separately). See
+``docs/golden-eval.md``.
 
 Run from the package root::
 
     python eval/run_eval.py --output-json eval-results.json --output-junit eval-results.xml
+
+Re-capture (bless) the golden value oracles after an intentional change::
+
+    # request fingerprints (stub is enough -- projection is transport-independent)
+    python eval/run_eval.py --update-golden
+    # response fingerprints (requires a live, seeded honua-server)
+    HONUA_GP_EVAL_USE_STUB=0 HONUA_BASE_URL=... python eval/run_eval.py --update-golden
 
 Set ``HONUA_GP_EVAL_USE_STUB=1`` to force the stub transport even when
 ``HONUA_BASE_URL`` is configured.
@@ -25,6 +51,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -50,6 +77,7 @@ class ScriptResult:
     expected_failure: bool = False
     golden: dict[str, Any] | None = None
     reason: str | None = None
+    checks: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -59,6 +87,7 @@ class ScriptResult:
             "exitCode": self.exit_code,
             "auditLines": self.audit_lines,
             "expectedFailure": self.expected_failure,
+            "checks": self.checks,
             "reason": self.reason,
         }
 
@@ -75,6 +104,7 @@ class EvalSummary:
     supported_total: int = 0
     supported_passed: int = 0
     supported_pass_rate: float = 0.0
+    live_mode: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -87,8 +117,32 @@ class EvalSummary:
             "supportedTotal": self.supported_total,
             "supportedPassed": self.supported_passed,
             "supportedPassRate": self.supported_pass_rate,
+            "liveMode": self.live_mode,
             "results": [result.to_dict() for result in self.results],
         }
+
+
+# ---------------------------------------------------------------------------
+# Mode detection
+# ---------------------------------------------------------------------------
+
+
+def live_values_available() -> bool:
+    """True when the run talks to a real server (so response values are real).
+
+    Mirrors ``eval/_stub.stub_active``: the stub transport is the default, and
+    a run only produces real response values when ``HONUA_GP_EVAL_USE_STUB`` is
+    explicitly ``0`` AND a ``HONUA_BASE_URL`` is configured.
+    """
+
+    if os.environ.get("HONUA_GP_EVAL_USE_STUB", "1") == "1":
+        return False
+    return bool(os.environ.get("HONUA_BASE_URL"))
+
+
+# ---------------------------------------------------------------------------
+# Golden schema (v2 with v1 back-compat)
+# ---------------------------------------------------------------------------
 
 
 def _golden_for(script: Path, golden_dir: Path) -> dict[str, Any] | None:
@@ -101,10 +155,93 @@ def _golden_for(script: Path, golden_dir: Path) -> dict[str, Any] | None:
         return None
 
 
+def _plumbing(golden: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the plumbing block, tolerating the legacy flat v1 shape."""
+
+    if not golden:
+        return {}
+    plumbing = golden.get("plumbing")
+    if isinstance(plumbing, dict):
+        return plumbing
+    # v1: audit_lines / stdout_contains sat at the top level.
+    legacy: dict[str, Any] = {}
+    for key in ("audit_lines", "stdout_contains"):
+        if key in golden:
+            legacy[key] = golden[key]
+    return legacy
+
+
+def _golden_is_expected_failure(script: Path, golden: dict[str, Any] | None) -> bool:
+    if golden is not None and isinstance(golden.get("expected_failure"), bool):
+        return golden["expected_failure"]
+    return "expected_failure" in script.stem
+
+
+# ---------------------------------------------------------------------------
+# Captured value oracles
+# ---------------------------------------------------------------------------
+
+
+def _capture_request(audit_root: Path, script: Path) -> list[dict[str, Any]]:
+    """Extract the process-dispatch request fingerprint(s) from the audit stream.
+
+    Every process-backed shim call records one audit line carrying
+    ``process_id`` and ``process_inputs`` (the projected OGC ``inputs`` payload
+    the shim POSTs). Returned in call order so multi-op scripts (e.g.
+    buffer-then-dissolve) fingerprint each step. Non-process scripts return an
+    empty list.
+    """
+
+    audit_dir = audit_root / script.stem
+    requests: list[dict[str, Any]] = []
+    if not audit_dir.exists():
+        return requests
+    for file in sorted(audit_dir.glob("audit-*.jsonl")):
+        for line in file.open(encoding="utf-8"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "process_id" in record and "process_inputs" in record:
+                requests.append(
+                    {
+                        "function": record.get("function"),
+                        "process_id": record.get("process_id"),
+                        "inputs": record.get("process_inputs"),
+                    }
+                )
+    return requests
+
+
+def _capture_response(result_dir: Path, script: Path) -> dict[str, Any] | None:
+    sidecar = result_dir / f"{script.stem}.json"
+    if not sidecar.exists():
+        return None
+    try:
+        return json.loads(sidecar.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
+def _normalize(value: Any) -> Any:
+    """Canonicalize for structural comparison (dict key order, list of dicts)."""
+
+    return json.loads(json.dumps(value, sort_keys=True))
+
+
+# ---------------------------------------------------------------------------
+# Script execution
+# ---------------------------------------------------------------------------
+
+
 def _run_script(
     script: Path,
     *,
     audit_root: Path,
+    result_dir: Path,
     timeout: float,
     extra_env: dict[str, str] | None = None,
 ) -> tuple[int, str, str, float]:
@@ -112,6 +249,8 @@ def _run_script(
     audit_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
     env["HONUA_GP_AUDIT_DIR"] = str(audit_dir)
+    # Per-script response sidecar directory (read back for the live value diff).
+    env["HONUA_GP_EVAL_RESULT_DIR"] = str(result_dir)
     env.setdefault("HONUA_GP_EVAL_USE_STUB", "1")
     # ``_build_pythonpath`` preserves the existing PYTHONPATH and appends the
     # sibling-package extras (only when not already present). Assigning
@@ -158,7 +297,12 @@ def _count_audit_lines(audit_root: Path, script: Path) -> int:
     return total
 
 
-def _classify(
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+
+def _grade(
     script: Path,
     *,
     exit_code: int,
@@ -166,48 +310,117 @@ def _classify(
     golden: dict[str, Any] | None,
     stdout: str,
     stderr: str,
-) -> tuple[str, bool, str | None]:
-    expected_failure = "expected_failure" in script.stem
-    if expected_failure:
-        # expected_failure scripts catch HonuaGpUnsupportedError, print the
-        # caught function name, and exit 0. The pass signal is the marker.
-        if exit_code != 0:
-            tail = stderr.strip().splitlines()[-1] if stderr.strip() else f"exit {exit_code}"
-            return "fail", True, f"expected_failure script exited {exit_code}: {tail}"
-        if golden is not None:
-            marker = golden.get("stdout_contains")
-            if isinstance(marker, str) and marker and marker not in stdout:
-                return "fail", True, f"expected_failure script missing marker {marker!r}"
-            # expected_failure scripts still write audit JSONL (the stub
-            # records the refused call with status=error). Honour the golden
-            # audit_lines count so a regression that loses the refusal-time
-            # audit shows up as an eval failure instead of slipping through
-            # the expected_failure branch.
-            expected_audit = golden.get("audit_lines")
-            if isinstance(expected_audit, int) and expected_audit != audit_lines:
-                return (
-                    "fail",
-                    True,
-                    f"expected_failure audit line count mismatch: expected {expected_audit}, got {audit_lines}",
-                )
-        return "pass", True, "caught expected unsupported error"
+    request_actual: list[dict[str, Any]],
+    response_actual: dict[str, Any] | None,
+    live_mode: bool,
+) -> tuple[str, bool, str | None, dict[str, str]]:
+    """Grade one script across plumbing + request + response layers."""
 
+    expected_failure = _golden_is_expected_failure(script, golden)
+    plumbing = _plumbing(golden)
+    checks: dict[str, str] = {}
+
+    # --- Layer 0: exit code -------------------------------------------------
     if exit_code != 0:
-        return "fail", False, stderr.strip().splitlines()[-1] if stderr.strip() else f"exit {exit_code}"
+        tail = stderr.strip().splitlines()[-1] if stderr.strip() else f"exit {exit_code}"
+        checks["exit"] = "fail"
+        return "fail", expected_failure, f"exited {exit_code}: {tail}", checks
+    checks["exit"] = "pass"
 
-    if golden is not None:
-        expected_audit = golden.get("audit_lines")
-        if isinstance(expected_audit, int) and expected_audit != audit_lines:
+    # --- Layer 1: plumbing (marker + audit line count) ----------------------
+    marker = plumbing.get("stdout_contains")
+    if isinstance(marker, str) and marker and marker not in stdout:
+        checks["plumbing"] = "fail"
+        prefix = "expected_failure script " if expected_failure else ""
+        return "fail", expected_failure, f"{prefix}missing stdout marker: {marker!r}", checks
+    expected_audit = plumbing.get("audit_lines")
+    if isinstance(expected_audit, int) and expected_audit != audit_lines:
+        checks["plumbing"] = "fail"
+        prefix = "expected_failure " if expected_failure else ""
+        return (
+            "fail",
+            expected_failure,
+            f"{prefix}audit line count mismatch: expected {expected_audit}, got {audit_lines}",
+            checks,
+        )
+    checks["plumbing"] = "pass"
+
+    if expected_failure:
+        # expected_failure scripts catch HonuaGpUnsupportedError and exit 0;
+        # they have no request/response oracle to diff.
+        return "pass", True, "caught expected unsupported error", checks
+
+    # --- Layer 2: request fingerprint (both modes) --------------------------
+    golden_request = golden.get("request") if golden else None
+    if golden_request is not None:
+        if _normalize(request_actual) != _normalize(golden_request):
+            checks["request"] = "fail"
             return (
                 "fail",
                 False,
-                f"audit line count mismatch: expected {expected_audit}, got {audit_lines}",
+                "request fingerprint mismatch (dispatch/parameter mapping regression); "
+                f"expected {json.dumps(golden_request, sort_keys=True)}, "
+                f"got {json.dumps(request_actual, sort_keys=True)}",
+                checks,
             )
-        required_marker = golden.get("stdout_contains")
-        if isinstance(required_marker, str) and required_marker and required_marker not in stdout:
-            return "fail", False, f"stdout missing marker: {required_marker!r}"
+        checks["request"] = "pass"
 
-    return "pass", False, None
+    # --- Layer 3: response fingerprint (live mode only) ---------------------
+    golden_response = golden.get("response") if golden else None
+    if golden_response is not None:
+        if not live_mode:
+            checks["response"] = "skip(stub)"
+        elif response_actual is None:
+            checks["response"] = "fail"
+            return (
+                "fail",
+                False,
+                "live response fingerprint missing (script emitted no sidecar)",
+                checks,
+            )
+        elif _normalize(response_actual) != _normalize(golden_response):
+            checks["response"] = "fail"
+            return (
+                "fail",
+                False,
+                "response value mismatch (server round-trip / response parsing regression); "
+                f"expected {json.dumps(golden_response, sort_keys=True)}, "
+                f"got {json.dumps(response_actual, sort_keys=True)}",
+                checks,
+            )
+        else:
+            checks["response"] = "pass"
+    elif live_mode and golden is not None and not expected_failure:
+        # Live run, supported script, but no response oracle recorded yet.
+        checks["response"] = "unblessed"
+
+    return "pass", False, None, checks
+
+
+def _update_golden(
+    script: Path,
+    golden_dir: Path,
+    golden: dict[str, Any] | None,
+    *,
+    request_actual: list[dict[str, Any]],
+    response_actual: dict[str, Any] | None,
+    live_mode: bool,
+) -> None:
+    """Re-capture (bless) the request/response oracles into the golden file.
+
+    Request fingerprints are written in any mode (transport-independent).
+    Response fingerprints are written ONLY in live mode -- the stub's canned
+    ``href`` carries no real values and must never be frozen as an oracle.
+    """
+
+    document = dict(golden) if golden else {}
+    document.setdefault("schema_version", 2)
+    if request_actual:
+        document["request"] = request_actual
+    if live_mode and response_actual is not None:
+        document["response"] = response_actual
+    target = golden_dir / f"{script.stem}.json"
+    target.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def run(
@@ -217,14 +430,20 @@ def run(
     audit_root: Path,
     timeout: float,
     pass_threshold: float,
+    update_golden: bool = False,
 ) -> EvalSummary:
     scripts = sorted(p for p in script_dir.glob("*.py") if not p.name.startswith("_"))
-    summary = EvalSummary(total=len(scripts), pass_threshold=pass_threshold)
+    live_mode = live_values_available()
+    summary = EvalSummary(total=len(scripts), pass_threshold=pass_threshold, live_mode=live_mode)
+    result_root = Path(tempfile.mkdtemp(prefix="honua-gp-eval-results-"))
     for script in scripts:
+        result_dir = result_root / script.stem
+        result_dir.mkdir(parents=True, exist_ok=True)
         try:
             exit_code, stdout, stderr, duration_ms = _run_script(
                 script,
                 audit_root=audit_root,
+                result_dir=result_dir,
                 timeout=timeout,
             )
         except subprocess.TimeoutExpired as exc:
@@ -244,13 +463,30 @@ def run(
             continue
         audit_lines = _count_audit_lines(audit_root, script)
         golden = _golden_for(script, golden_dir)
-        status, expected_failure, reason = _classify(
+        request_actual = _capture_request(audit_root, script)
+        response_actual = _capture_response(result_dir, script)
+
+        if update_golden:
+            _update_golden(
+                script,
+                golden_dir,
+                golden,
+                request_actual=request_actual,
+                response_actual=response_actual,
+                live_mode=live_mode,
+            )
+            golden = _golden_for(script, golden_dir)
+
+        status, expected_failure, reason, checks = _grade(
             script,
             exit_code=exit_code,
             audit_lines=audit_lines,
             golden=golden,
             stdout=stdout,
             stderr=stderr,
+            request_actual=request_actual,
+            response_actual=response_actual,
+            live_mode=live_mode,
         )
         result = ScriptResult(
             name=script.name,
@@ -263,6 +499,7 @@ def run(
             expected_failure=expected_failure,
             golden=golden,
             reason=reason,
+            checks=checks,
         )
         summary.results.append(result)
         if status == "pass":
@@ -323,20 +560,23 @@ def write_junit(summary: EvalSummary, path: Path) -> None:
 def write_step_summary(summary: EvalSummary, path: Path | None) -> None:
     if path is None:
         return
+    mode = "live (real honua-server)" if summary.live_mode else "stub (dispatch plumbing only)"
     lines: list[str] = []
     lines.append("# honua-gp eval results")
     lines.append("")
+    lines.append(f"Mode: **{mode}**")
     lines.append(
         f"Pass rate: **{summary.pass_rate:.0%}** ({summary.passed} / {max(summary.total - summary.skipped, 1)})"
     )
     lines.append(f"Threshold: {summary.pass_threshold:.0%}")
     lines.append("")
-    lines.append("| Script | Status | Audit lines | Latency (ms) | Notes |")
-    lines.append("| --- | --- | --- | --- | --- |")
+    lines.append("| Script | Status | Checks | Audit lines | Latency (ms) | Notes |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
     for result in summary.results:
         notes = result.reason or ""
+        check_str = ", ".join(f"{k}:{v}" for k, v in result.checks.items())
         lines.append(
-            f"| {result.name} | {result.status} | {result.audit_lines} | {result.duration_ms:.0f} | {notes} |"
+            f"| {result.name} | {result.status} | {check_str} | {result.audit_lines} | {result.duration_ms:.0f} | {notes} |"
         )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -345,7 +585,7 @@ def write_step_summary(summary: EvalSummary, path: Path | None) -> None:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the honua-gp compatibility eval suite.")
     parser.add_argument("--scripts", type=Path, default=DEFAULT_SCRIPT_DIR, help="Directory of eval scripts.")
-    parser.add_argument("--golden", type=Path, default=DEFAULT_GOLDEN_DIR, help="Directory of golden reference outputs.")
+    parser.add_argument("--golden", type=Path, default=DEFAULT_GOLDEN_DIR, help="Directory of golden reference values.")
     parser.add_argument(
         "--audit-root",
         type=Path,
@@ -374,6 +614,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--update-golden",
+        action="store_true",
+        help=(
+            "Re-capture (bless) the request/response value oracles into the "
+            "golden files instead of grading against them. Request fingerprints "
+            "are written in any mode; response fingerprints only in live mode "
+            "(HONUA_GP_EVAL_USE_STUB=0 + HONUA_BASE_URL). Review the diff before "
+            "committing."
+        ),
+    )
+    parser.add_argument(
         "--fail-under",
         action="store_true",
         default=True,
@@ -393,18 +644,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         audit_root=args.audit_root,
         timeout=args.timeout,
         pass_threshold=args.pass_threshold,
+        update_golden=args.update_golden,
     )
     write_json(summary, args.output_json)
     write_junit(summary, args.output_junit)
     write_step_summary(summary, args.step_summary)
 
+    mode = "live" if summary.live_mode else "stub"
     sys.stdout.write(
-        f"honua-gp eval: {summary.passed}/{summary.total} passed ({summary.pass_rate:.0%}); "
+        f"honua-gp eval [{mode}]: {summary.passed}/{summary.total} passed ({summary.pass_rate:.0%}); "
         f"threshold {args.pass_threshold:.0%}; "
         f"supported {summary.supported_passed}/{summary.supported_total} "
         f"({summary.supported_pass_rate:.0%}); "
         f"supported-required {args.require_supported_pass_rate:.0%}\n"
     )
+    if args.update_golden:
+        sys.stdout.write("honua-gp eval: golden value oracles updated; review the diff before committing.\n")
+        return 0
     if args.fail_under and summary.pass_rate + 1e-9 < args.pass_threshold:
         return 1
     if (

--- a/packages/honua-gp/eval/scripts/buffer_legacy_suffix.py
+++ b/packages/honua-gp/eval/scripts/buffer_legacy_suffix.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.Buffer_analysis("honua://services/transport/0", "trails_buffer", "15 Meters")
 print(f"buffer_legacy_suffix ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('buffer_legacy_suffix', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/buffer_numeric_distance.py
+++ b/packages/honua-gp/eval/scripts/buffer_numeric_distance.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.analysis.Buffer("honua://services/transport/0", "roads_buf_num", 50)
 print(f"buffer_numeric_distance ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('buffer_numeric_distance', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/buffer_roads.py
+++ b/packages/honua-gp/eval/scripts/buffer_roads.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.analysis.Buffer("honua://services/transport/0", "roads_buffer", "25 Meters", dissolve_option="ALL")
 print(f"buffer_roads ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('buffer_roads', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/buffer_then_dissolve.py
+++ b/packages/honua-gp/eval/scripts/buffer_then_dissolve.py
@@ -26,3 +26,5 @@ arcpy.env.overwriteOutput = True
 arcpy.analysis.Buffer("honua://services/transport/0", "roads_buffer", "5 Meters", dissolve_option="ALL")
 result = arcpy.management.Dissolve("honua://services/transport/0", "roads_dissolved", dissolve_field=["class"])
 print(f"buffer_then_dissolve ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('buffer_then_dissolve', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/dissolve_parcels_by_zoning.py
+++ b/packages/honua-gp/eval/scripts/dissolve_parcels_by_zoning.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.management.Dissolve("honua://services/parcels/0", "parcels_by_zoning", dissolve_field=["zoning_code"])
 print(f"dissolve_parcels_by_zoning ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('dissolve_parcels_by_zoning', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/get_count_after_select.py
+++ b/packages/honua-gp/eval/scripts/get_count_after_select.py
@@ -27,3 +27,5 @@ arcpy.management.MakeFeatureLayer("roads", "roads_lyr")
 arcpy.management.SelectLayerByAttribute("roads_lyr", "NEW_SELECTION", "STATUS = 'OPEN'")
 count = arcpy.management.GetCount("roads_lyr")
 print(f"get_count_after_select ok count={count}")
+from eval._emit import emit_response
+emit_response('get_count_after_select', {'count': int(count)})

--- a/packages/honua-gp/eval/scripts/get_count_roads.py
+++ b/packages/honua-gp/eval/scripts/get_count_roads.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 count = arcpy.management.GetCount("roads")
 print(f"get_count_roads ok count={count}")
+from eval._emit import emit_response
+emit_response('get_count_roads', {'count': int(count)})

--- a/packages/honua-gp/eval/scripts/insert_cursor_then_search.py
+++ b/packages/honua-gp/eval/scripts/insert_cursor_then_search.py
@@ -28,3 +28,5 @@ with arcpy.da.InsertCursor("roads", ["STATUS", "name"]) as cursor:
 with arcpy.da.SearchCursor("roads", ["OID@", "name"]) as cursor:
     rows = list(cursor)
 print(f"insert_cursor_then_search ok rows={len(rows)}")
+from eval._emit import emit_response
+emit_response('insert_cursor_then_search', {'rows': len(rows)})

--- a/packages/honua-gp/eval/scripts/make_feature_layer_clear_then_count.py
+++ b/packages/honua-gp/eval/scripts/make_feature_layer_clear_then_count.py
@@ -28,3 +28,5 @@ arcpy.management.SelectLayerByAttribute("roads_lyr", "NEW_SELECTION", "STATUS = 
 arcpy.management.SelectLayerByAttribute("roads_lyr", "CLEAR_SELECTION")
 count = arcpy.management.GetCount("roads_lyr")
 print(f"make_feature_layer_clear_then_count ok count={count}")
+from eval._emit import emit_response
+emit_response('make_feature_layer_clear_then_count', {'count': int(count)})

--- a/packages/honua-gp/eval/scripts/make_feature_layer_then_select.py
+++ b/packages/honua-gp/eval/scripts/make_feature_layer_then_select.py
@@ -26,3 +26,5 @@ arcpy.env.overwriteOutput = True
 arcpy.management.MakeFeatureLayer("roads", "roads_lyr")
 selection = arcpy.management.SelectLayerByAttribute("roads_lyr", "NEW_SELECTION", "STATUS = 'OPEN'")
 print(f"make_feature_layer_then_select ok count={selection.count}")
+from eval._emit import emit_response
+emit_response('make_feature_layer_then_select', {'count': int(selection.count)})

--- a/packages/honua-gp/eval/scripts/project_kilometers_buffer.py
+++ b/packages/honua-gp/eval/scripts/project_kilometers_buffer.py
@@ -26,3 +26,5 @@ arcpy.env.overwriteOutput = True
 arcpy.management.Project("honua://services/parcels/0", "parcels_wgs", 4326)
 result = arcpy.analysis.Buffer("honua://services/parcels/0", "parcels_buf", "1 Kilometers")
 print(f"project_kilometers_buffer ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('project_kilometers_buffer', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/project_roads_to_wgs84.py
+++ b/packages/honua-gp/eval/scripts/project_roads_to_wgs84.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.management.Project("honua://services/roads/0", "roads_wgs84", 4326)
 print(f"project_roads_to_wgs84 ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('project_roads_to_wgs84', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/search_cursor_filter.py
+++ b/packages/honua-gp/eval/scripts/search_cursor_filter.py
@@ -26,3 +26,5 @@ arcpy.env.overwriteOutput = True
 with arcpy.da.SearchCursor("roads", ["OID@", "STATUS"], where_clause="STATUS = 'OPEN'") as cursor:
     rows = list(cursor)
 print(f"search_cursor_filter ok rows={len(rows)}")
+from eval._emit import emit_response
+emit_response('search_cursor_filter', {'rows': len(rows)})

--- a/packages/honua-gp/eval/scripts/search_cursor_iterate.py
+++ b/packages/honua-gp/eval/scripts/search_cursor_iterate.py
@@ -26,3 +26,5 @@ arcpy.env.overwriteOutput = True
 with arcpy.da.SearchCursor("roads", ["OID@", "STATUS"]) as cursor:
     rows = [row for row in cursor]
 print(f"search_cursor_iterate ok rows={len(rows)}")
+from eval._emit import emit_response
+emit_response('search_cursor_iterate', {'rows': len(rows)})

--- a/packages/honua-gp/eval/scripts/spatial_join_addresses_parcels.py
+++ b/packages/honua-gp/eval/scripts/spatial_join_addresses_parcels.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.analysis.SpatialJoin("honua://services/addresses/0", "honua://services/parcels/1", "addresses_with_parcel", match_option="INTERSECT")
 print(f"spatial_join_addresses_parcels ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('spatial_join_addresses_parcels', feature_layer_fingerprint(result))

--- a/packages/honua-gp/eval/scripts/spatial_join_with_radius.py
+++ b/packages/honua-gp/eval/scripts/spatial_join_with_radius.py
@@ -25,3 +25,5 @@ arcpy.env.overwriteOutput = True
 
 result = arcpy.analysis.SpatialJoin("honua://services/facilities/0", "honua://services/parcels/1", "out", match_option="WITHIN_A_DISTANCE", search_radius="100 Meters")
 print(f"spatial_join_with_radius ok output={result[0]}")
+from eval._emit import emit_response, feature_layer_fingerprint
+emit_response('spatial_join_with_radius', feature_layer_fingerprint(result))

--- a/packages/honua-gp/honua_gp/_process_tools.py
+++ b/packages/honua-gp/honua_gp/_process_tools.py
@@ -31,7 +31,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from ._audit import _shape_of, record_call
+from ._audit import _redact_value, _shape_of, record_call
 from ._compat import FunctionEntry, anchor_for, entry_for
 from ._errors import (
     ExecuteError,
@@ -357,6 +357,16 @@ def run_layer_process(qualified: str, *args: Any, **kwargs: Any) -> Result:
 
         output_name = projected.output_name or ""
         record["process_id"] = entry.process_id
+        # Record the projected process inputs (the actual payload POSTed to the
+        # server's OGC execute endpoint) so the eval harness can diff the
+        # dispatch/parameter-translation against a golden fingerprint. This is
+        # deterministic across the stub and a live server -- the projection is
+        # transport-independent -- so a regression that maps an arcpy argument
+        # to the wrong process input is caught in BOTH modes, not just when a
+        # real server happens to reject the malformed payload. Redacted with
+        # the same heuristics as args/kwargs; the typed inputs (layerId,
+        # distance, unit, predicate, targetSrid) carry no secrets.
+        record["process_inputs"] = _redact_value(dict(projected.inputs), context="process_inputs")
         record["job_id"] = outcome.job_id
         record["job_status"] = outcome.status
         record["result_shape"] = _shape_of({"output": output_name, "jobId": outcome.job_id})

--- a/packages/honua-gp/tests/test_eval_harness.py
+++ b/packages/honua-gp/tests/test_eval_harness.py
@@ -48,13 +48,23 @@ def test_top_level_workspace_matrix_matches_package_matrix() -> None:
     )
 
 
-def test_classify_expected_failure_honours_golden_audit_lines(tmp_path: Path) -> None:
-    """An expected_failure script that emits the wrong number of audit lines
-    must fail eval, not silently pass. Previously ``_classify`` accepted any
-    audit count inside the expected_failure branch, so a regression that
-    dropped the refusal-time audit line was invisible."""
+def _grade(script, **kwargs):  # type: ignore[no-untyped-def]
+    """Call ``run_eval._grade`` with value-diff defaults filled in."""
 
-    from run_eval import _classify
+    from run_eval import _grade as _real_grade
+
+    kwargs.setdefault("request_actual", [])
+    kwargs.setdefault("response_actual", None)
+    kwargs.setdefault("live_mode", False)
+    return _real_grade(script, **kwargs)
+
+
+def test_grade_expected_failure_honours_golden_audit_lines(tmp_path: Path) -> None:
+    """An expected_failure script that emits the wrong number of audit lines
+    must fail eval, not silently pass. The golden ``audit_lines`` plumbing
+    check applies inside the expected_failure branch, so a regression that
+    dropped the refusal-time audit line surfaces as a fail. Also exercises the
+    legacy flat (v1) golden shape, which ``_plumbing`` still reads."""
 
     script = tmp_path / "expected_failure_widget.py"
     script.write_text("", encoding="utf-8")
@@ -64,7 +74,7 @@ def test_classify_expected_failure_honours_golden_audit_lines(tmp_path: Path) ->
         "expected_failure": True,
         "stdout_contains": "expected_failure_widget",
     }
-    status, expected_failure, reason = _classify(
+    status, expected_failure, reason, checks = _grade(
         script,
         exit_code=0,
         audit_lines=1,
@@ -75,9 +85,10 @@ def test_classify_expected_failure_honours_golden_audit_lines(tmp_path: Path) ->
     assert status == "pass"
     assert expected_failure is True
     assert reason == "caught expected unsupported error"
+    assert checks["plumbing"] == "pass"
 
     # Same golden, but the script actually wrote 0 audit lines (regression).
-    status, expected_failure, reason = _classify(
+    status, expected_failure, reason, checks = _grade(
         script,
         exit_code=0,
         audit_lines=0,
@@ -88,6 +99,110 @@ def test_classify_expected_failure_honours_golden_audit_lines(tmp_path: Path) ->
     assert status == "fail"
     assert expected_failure is True
     assert reason is not None and "audit line count" in reason
+
+
+def test_grade_request_fingerprint_mismatch_fails(tmp_path: Path) -> None:
+    """The request fingerprint diff catches a dispatch/parameter-mapping
+    regression -- a projected input that no longer matches golden -- in BOTH
+    stub and live mode, since the projection is transport-independent."""
+
+    script = tmp_path / "buffer_widget.py"
+    script.write_text("", encoding="utf-8")
+
+    golden = {
+        "schema_version": 2,
+        "expected_failure": False,
+        "plumbing": {"audit_lines": 1, "stdout_contains": "buffer_widget ok"},
+        "request": [
+            {
+                "function": "analysis.Buffer",
+                "process_id": "analytics.buffer-aggregate",
+                "inputs": {"layerId": 0, "distance": 25.0, "unit": "meters"},
+            }
+        ],
+    }
+    common = dict(
+        exit_code=0,
+        audit_lines=1,
+        golden=golden,
+        stdout="buffer_widget ok\n",
+        stderr="",
+    )
+
+    # Correct projection -> pass.
+    status, _, _, checks = _grade(
+        script,
+        request_actual=[
+            {
+                "function": "analysis.Buffer",
+                "process_id": "analytics.buffer-aggregate",
+                "inputs": {"layerId": 0, "distance": 25.0, "unit": "meters"},
+            }
+        ],
+        **common,
+    )
+    assert status == "pass"
+    assert checks["request"] == "pass"
+
+    # Distance mapped wrong (regression) -> fail on the request layer.
+    status, _, reason, checks = _grade(
+        script,
+        request_actual=[
+            {
+                "function": "analysis.Buffer",
+                "process_id": "analytics.buffer-aggregate",
+                "inputs": {"layerId": 0, "distance": 50.0, "unit": "meters"},
+            }
+        ],
+        **common,
+    )
+    assert status == "fail"
+    assert checks["request"] == "fail"
+    assert reason is not None and "request fingerprint mismatch" in reason
+
+
+def test_grade_response_value_diff_is_live_only(tmp_path: Path) -> None:
+    """The response value diff grades against a real server (live mode). In
+    stub mode it is skipped -- the stub returns a canned href, not real
+    values -- so a stub run never fails on a response mismatch."""
+
+    script = tmp_path / "buffer_widget.py"
+    script.write_text("", encoding="utf-8")
+
+    golden = {
+        "schema_version": 2,
+        "expected_failure": False,
+        "plumbing": {"audit_lines": 1, "stdout_contains": "buffer_widget ok"},
+        "response": {"geometry_type": "Polygon", "feature_count": 1},
+    }
+    common = dict(
+        exit_code=0,
+        audit_lines=1,
+        golden=golden,
+        stdout="buffer_widget ok\n",
+        stderr="",
+    )
+
+    # Stub mode: response layer is skipped even on a mismatch.
+    status, _, _, checks = _grade(
+        script,
+        response_actual={"geometry_type": "Point", "feature_count": 9},
+        live_mode=False,
+        **common,
+    )
+    assert status == "pass"
+    assert checks["response"] == "skip(stub)"
+
+    # Live mode: a real response mismatch fails.
+    status, _, reason, checks = _grade(
+        script,
+        response_actual={"geometry_type": "Point", "feature_count": 9},
+        live_mode=True,
+        **common,
+    )
+    assert status == "fail"
+    assert checks["response"] == "fail"
+    assert reason is not None and "response value mismatch" in reason
 
 
 def test_run_script_always_rebuilds_pythonpath_when_host_sets_it(
@@ -123,7 +238,7 @@ def test_run_script_always_rebuilds_pythonpath_when_host_sets_it(
     audit_root = tmp_path / "audit"
     audit_root.mkdir()
 
-    _run_script(script, audit_root=audit_root, timeout=5.0)
+    _run_script(script, audit_root=audit_root, result_dir=(tmp_path / "rd"), timeout=5.0)
 
     rebuilt = _build_pythonpath("/host/preexisting")
     assert captured["pythonpath"] == rebuilt, (
@@ -157,7 +272,7 @@ def test_main_fails_when_supported_pass_rate_below_required(
     for idx in range(5):
         (scripts / f"expected_failure_alpha_{idx}.py").write_text("", encoding="utf-8")
 
-    def fake_run_script(script, *, audit_root, timeout, extra_env=None):  # type: ignore[no-untyped-def]
+    def fake_run_script(script, *, audit_root, result_dir, timeout, extra_env=None):  # type: ignore[no-untyped-def]
         if "expected_failure" in script.stem:
             return 0, f"expected_failure_alpha_{script.stem} caught analysis.X\n", "", 1.0
         # The supported script exits non-zero (e.g. the seeded backend lacks
@@ -210,7 +325,7 @@ def test_main_passes_when_supported_pass_rate_meets_required(
     (scripts / "supported_only.py").write_text("", encoding="utf-8")
     (scripts / "expected_failure_alpha.py").write_text("", encoding="utf-8")
 
-    def fake_run_script(script, *, audit_root, timeout, extra_env=None):  # type: ignore[no-untyped-def]
+    def fake_run_script(script, *, audit_root, result_dir, timeout, extra_env=None):  # type: ignore[no-untyped-def]
         marker = f"{script.stem} caught analysis.X" if "expected_failure" in script.stem else "ok"
         return 0, f"{marker}\n", "", 1.0
 
@@ -266,7 +381,7 @@ def test_run_script_builds_pythonpath_when_host_has_none(
     audit_root = tmp_path / "audit"
     audit_root.mkdir()
 
-    _run_script(script, audit_root=audit_root, timeout=5.0)
+    _run_script(script, audit_root=audit_root, result_dir=(tmp_path / "rd"), timeout=5.0)
 
     parts = captured["pythonpath"].split(os.pathsep)
     assert str(_PACKAGE_ROOT) in parts


### PR DESCRIPTION
## Problem

The `honua-gp` golden eval harness (`packages/honua-gp/eval/run_eval.py`, `eval/golden/*.json`) was the correctness story for the shim, but it only graded **exit code + audit line count + a hardcoded stdout marker**. Every `buffer_roads.json`-style golden was just `{"audit_lines": 1, "stdout_contains": "buffer_roads ok"}` — no computed geometry, no field values, no request payload. Pass/fail meant "did it crash," nothing more.

Worse: the stub transport returns a **canned response regardless of the payload it receives**, so a dispatch/parameter-mapping bug that POSTed the wrong process inputs was completely invisible — the exact class of bug the harness most needs to catch.

## What this changes

Grades every eval script across three independent layers:

| Layer | Checks | Graded in |
| --- | --- | --- |
| **Plumbing** | exit code, audit JSONL line count, stdout marker | every mode |
| **Request fingerprint** | projected `process_id` + typed `inputs` the shim POSTs (new `process_inputs` audit field) vs golden `request` | every mode |
| **Response fingerprint** | geometry type / feature + row counts parsed back from a REAL seeded honua-server (per-script sidecar via `eval/_emit.py`) vs golden `response` | live mode only |

The request fingerprint is **transport-independent**, so a parameter-mapping regression is now caught even under the stub. A negative test (inject `buffer distance * 2`) is caught on all five buffer scripts in stub mode — previously undetectable.

Golden files move to a **v2 schema** (`schema_version` / `expected_failure` / `plumbing` / `request` / `response`). `run_eval.py --update-golden` re-captures (blesses) the value oracles; the generator preserves committed `request`/`response` blocks on regeneration. See `packages/honua-gp/docs/golden-eval.md`.

## Honest scope (no arcpy parity claimed)

- **Stub mode** verifies dispatch plumbing + request fingerprint.
- **Live mode** adds `honua_gp` ⇄ real-honua-server round-trip correctness (dispatch → real HTTP → response parse).
- **ArcGIS Pro output parity is NOT verified anywhere** — no arcpy license exists in this environment, so arcpy-level equivalence stays out of scope and is tracked separately. The workflow lanes, code comments, and docs say so plainly; the previously misleading "correctness certification" framing of the stub lane is corrected.

## CI

The existing stub `eval` job is relabelled/recommented as a dispatch-plumbing + request-fingerprint lane (not a correctness certification). The existing `ephemeral-server-smoke` job already stands up a real Docker honua-server with the stub disabled; with the upgraded `run_eval.py` it now also grades the **response value diff**. No new always-on CI cost is added (the live lane was already push-gated to same-repo/trunk).

**Tradeoff flagged:** the live response oracles are pinned to the honua-server client-compat seed and are exact (including row/feature counts). Several eval scripts mutate the seeded layer via `da.InsertCursor`/`UpdateCursor` and those edits persist, so **each live run must start from a fresh seed** for the counts to reproduce — the CI ephemeral lane spins a fresh compose per run, so it is deterministic there. Documented in `docs/golden-eval.md`.

## Validation

Run locally against a real seeded honua-server (client-compat compose + Redis job store + the in-repo spatial-join second layer):

- Stub grade: **50/50** (plumbing + request fingerprint).
- Live grade, fresh seed: **50/50** with response value diffs active (`supported 20/20`, `--require-supported-pass-rate 1.0`).
- Negative test: request diff catches an injected dispatch bug in stub mode.
- The live response diff also caught real data drift when re-run against a mutated (non-fresh) DB — i.e. it genuinely detects value changes the stub never could.
- `153` unit tests pass (harness tests updated for the new `_grade`/`--update-golden` API, plus new request/response diff coverage); compatibility-matrix drift gate green.

## Update: CI fix for `ephemeral-server-smoke`

An independent review caught that the live CI lane (`ephemeral-server-smoke`) was actually **failing** (31/50, 1/20 supported) on the first push. Root cause: the job read `HONUA_BASE_URL` from the generic `vars.HONUA_BASE_URL`, which this repo has set to `https://demo.honua.io` for other lanes (e.g. conformance). Because that var was non-empty, the "Detect ephemeral honua-server target" step short-circuited to `local_stack=false` and skipped the fresh-seed Docker compose entirely — the value diff ran against the persistent, drifted demo server instead of a fresh seed, and the exact-count response oracles (correctly) flagged the mismatch.

Fixed by pointing this job at a **dedicated** `vars.HONUA_GP_EVAL_BASE_URL` variable instead of the generic one, so it defaults to standing up its own fresh Docker target (matching what the docs already claimed) regardless of what the generic var is configured to elsewhere. The dedicated var remains available as an explicit opt-in for smoke-testing against a persistent target, with the step summary and `docs/golden-eval.md` now warning plainly that the seed-pinned oracles may drift/flake in that mode. Re-verified: see CI checks on this PR for the post-fix run.
