### PR TITLE
feat(geoprocessing): wire raster/surface process inputs

### DIFF
--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -439,10 +439,11 @@ def _data_uri_bytes(uri: str) -> bytes | None:
 def _output_json_bytes(member: Mapping[str, Any]) -> bytes | None:
     """Return the JSON payload bytes carried inline by an output ``member``.
 
-    Reads an inline ``value`` (data URI, raw JSON string, or base64) or a
+    Reads an inline ``value`` (a ``data:`` URI or a raw JSON string) or a
     ``data:`` ``href``. Returns ``None`` when the payload is only reachable via a
     fetchable (``http(s)``) ``href`` -- the caller fetches that through the bound
-    client so base URL, auth, and retry policy apply.
+    client so base URL, auth, and retry policy apply -- or is carried as a raw
+    (non-string) ``value`` the caller can use as-is.
     """
     value = member.get("value")
     if isinstance(value, str):
@@ -452,10 +453,7 @@ def _output_json_bytes(member: Mapping[str, Any]) -> bytes | None:
         stripped = value.strip()
         if stripped[:1] in ("{", "["):
             return value.encode("utf-8")
-        try:
-            return base64.b64decode(value, validate=True)
-        except (binascii.Error, ValueError):
-            return value.encode("utf-8")
+        return None
     href = member.get("href")
     if isinstance(href, str) and href:
         return _data_uri_bytes(href)
@@ -553,6 +551,31 @@ def _feature_collection_from_results(results: Mapping[str, Any]) -> JsonObject:
         f"got output keys {sorted(results)!r}. "
         "execute_dataframe requires a feature-collection-out process."
     )
+
+
+def _feature_collection_from_output(results: Mapping[str, Any]) -> JsonObject | None:
+    """Best-effort, pure attempt to find a FeatureCollection in a results document.
+
+    Tries the declared-kind output member's JSON payload first (the
+    ``FeatureLayer`` shape published as a base64/``data:`` URI -- see
+    :func:`_output_json_bytes` -- for example ``surface.contour``'s output),
+    then falls back to :func:`_feature_collection_from_results` (the plain
+    inline-FeatureCollection vector-process shape). Returns ``None`` rather than
+    raising when neither is found, so a caller can decide what to do next (fetch
+    a live href, fall back to another kind, ...) -- and, notably, without
+    needing geopandas: this is pure selection logic only, no conversion.
+    """
+    member = _primary_output_member(results)
+    if member is not None:
+        data = _output_json_bytes(member)
+        if data is not None:
+            parsed = json.loads(data)
+            if _is_feature_collection(parsed):
+                return cast(JsonObject, parsed)
+    try:
+        return _feature_collection_from_results(results)
+    except HonuaError:
+        return None
 
 
 def _async_prefer_header(respond_async: bool) -> dict[str, str] | None:
@@ -959,27 +982,34 @@ class HonuaGeoprocessing:
             raise HonuaError("Table/Scalar output has no decodable JSON payload.")
         return json.loads(data)
 
+    def _result_feature_collection(self, results: Mapping[str, Any]) -> JsonObject:
+        """Select a results document's FeatureCollection output.
+
+        Pure selection plus, only when the pure attempt comes up empty, a live
+        ``href`` fetch through the bound client -- no geopandas needed.
+        :meth:`_result_geodataframe` is the thin geopandas-dependent conversion
+        built on top of this.
+        """
+        found = _feature_collection_from_output(results)
+        if found is not None:
+            return found
+        member = _primary_output_member(results)
+        href = member.get("href") if member is not None else None
+        if isinstance(href, str) and href and not href.startswith("data:"):
+            path, params = _href_path_and_params(href)
+            parsed = json.loads(self.client._request("GET", path, params=params).content)
+            if _is_feature_collection(parsed):
+                return cast(JsonObject, parsed)
+        raise HonuaError(
+            "Geoprocessing results document does not contain a FeatureCollection output; "
+            f"got output keys {sorted(results)!r}."
+        )
+
     def _result_geodataframe(self, results: Mapping[str, Any]) -> "gpd.GeoDataFrame":
         """Parse a ``FeatureLayer`` output to a GeoDataFrame (requires geopandas)."""
         from .geopandas import ogc_features_to_geodataframe
 
         return ogc_features_to_geodataframe(self._result_feature_collection(results))
-
-    def _result_feature_collection(self, results: Mapping[str, Any]) -> JsonObject:
-        member = _primary_output_member(results)
-        if member is not None:
-            data = _output_json_bytes(member)
-            if data is None:
-                href = member.get("href")
-                if isinstance(href, str) and href and not href.startswith("data:"):
-                    path, params = _href_path_and_params(href)
-                    data = self.client._request("GET", path, params=params).content
-            if data is not None:
-                parsed = json.loads(data)
-                if _is_feature_collection(parsed):
-                    return cast(JsonObject, parsed)
-        # Fall back to the inline-FeatureCollection selector (vector-process shape).
-        return _feature_collection_from_results(results)
 
     def consume_result(self, results: Mapping[str, Any]) -> Any:
         """Route a results document to the Python object matching its output kind.
@@ -987,7 +1017,10 @@ class HonuaGeoprocessing:
         * ``Raster`` -> :class:`xarray.DataArray` (via :meth:`result_to_xarray`).
         * ``FeatureLayer`` -> a :class:`geopandas.GeoDataFrame`.
         * ``Table`` / ``Scalar`` -> the parsed JSON value (``dict`` / ``list``).
-        * undeclared kind -> sniffed (raster, then feature collection, then JSON).
+        * undeclared kind -> sniffed, in priority order: raster, then feature
+          collection (via the pure :func:`_feature_collection_from_output`, so
+          geopandas is only touched once a FeatureCollection payload is actually
+          found), then a plain JSON value.
 
         Lets a caller consume :meth:`execute_raster_process` output without
         knowing in advance which kind a given ``process_id`` produces (xarray for
@@ -1002,20 +1035,19 @@ class HonuaGeoprocessing:
             return self._result_geodataframe(results)
         if kind in ("Table", "Scalar"):
             return self._result_json_value(results)
-        if kind is None:
-            from .raster import find_raster_output
+        if kind is not None:
+            raise HonuaError(f"Unsupported results kind {kind!r}.")
+        from .raster import find_raster_output
 
-            try:
-                find_raster_output(results)
-            except HonuaError:
-                pass
-            else:
-                return self.result_to_xarray(results)
-            try:
-                return self._result_geodataframe(results)
-            except HonuaError:
-                return self._result_json_value(results)
-        raise HonuaError(f"Unsupported results kind {kind!r}.")
+        try:
+            find_raster_output(results)
+        except HonuaError:
+            pass
+        else:
+            return self.result_to_xarray(results)
+        if _feature_collection_from_output(results) is not None:
+            return self._result_geodataframe(results)
+        return self._result_json_value(results)
 
     # -- canonical multi-step plan ----------------------------------------
 
@@ -1382,35 +1414,44 @@ class AsyncHonuaGeoprocessing:
             raise HonuaError("Table/Scalar output has no decodable JSON payload.")
         return json.loads(data)
 
+    async def _result_feature_collection(self, results: Mapping[str, Any]) -> JsonObject:
+        """Select a results document's FeatureCollection output.
+
+        Pure selection plus, only when the pure attempt comes up empty, a live
+        ``href`` fetch through the bound client -- no geopandas needed.
+        :meth:`_result_geodataframe` is the thin geopandas-dependent conversion
+        built on top of this.
+        """
+        found = _feature_collection_from_output(results)
+        if found is not None:
+            return found
+        member = _primary_output_member(results)
+        href = member.get("href") if member is not None else None
+        if isinstance(href, str) and href and not href.startswith("data:"):
+            path, params = _href_path_and_params(href)
+            response = await self.client._request("GET", path, params=params)
+            parsed = json.loads(response.content)
+            if _is_feature_collection(parsed):
+                return cast(JsonObject, parsed)
+        raise HonuaError(
+            "Geoprocessing results document does not contain a FeatureCollection output; "
+            f"got output keys {sorted(results)!r}."
+        )
+
     async def _result_geodataframe(self, results: Mapping[str, Any]) -> "gpd.GeoDataFrame":
         """Parse a ``FeatureLayer`` output to a GeoDataFrame (requires geopandas)."""
         from .geopandas import ogc_features_to_geodataframe
 
         return ogc_features_to_geodataframe(await self._result_feature_collection(results))
 
-    async def _result_feature_collection(self, results: Mapping[str, Any]) -> JsonObject:
-        member = _primary_output_member(results)
-        if member is not None:
-            data = _output_json_bytes(member)
-            if data is None:
-                href = member.get("href")
-                if isinstance(href, str) and href and not href.startswith("data:"):
-                    path, params = _href_path_and_params(href)
-                    response = await self.client._request("GET", path, params=params)
-                    data = response.content
-            if data is not None:
-                parsed = json.loads(data)
-                if _is_feature_collection(parsed):
-                    return cast(JsonObject, parsed)
-        # Fall back to the inline-FeatureCollection selector (vector-process shape).
-        return _feature_collection_from_results(results)
-
     async def consume_result(self, results: Mapping[str, Any]) -> Any:
         """Route a results document to the Python object matching its output kind.
 
         Async twin of :meth:`HonuaGeoprocessing.consume_result`: ``Raster`` ->
         :class:`xarray.DataArray`, ``FeatureLayer`` -> GeoDataFrame,
-        ``Table``/``Scalar`` -> parsed JSON, undeclared kind -> sniffed.
+        ``Table``/``Scalar`` -> parsed JSON, undeclared kind -> sniffed (raster,
+        then feature collection via the pure :func:`_feature_collection_from_output`,
+        then a plain JSON value).
         """
         kind = results_kind(results)
         if kind == "Raster":
@@ -1419,20 +1460,19 @@ class AsyncHonuaGeoprocessing:
             return await self._result_geodataframe(results)
         if kind in ("Table", "Scalar"):
             return await self._result_json_value(results)
-        if kind is None:
-            from .raster import find_raster_output
+        if kind is not None:
+            raise HonuaError(f"Unsupported results kind {kind!r}.")
+        from .raster import find_raster_output
 
-            try:
-                find_raster_output(results)
-            except HonuaError:
-                pass
-            else:
-                return await self.result_to_xarray(results)
-            try:
-                return await self._result_geodataframe(results)
-            except HonuaError:
-                return await self._result_json_value(results)
-        raise HonuaError(f"Unsupported results kind {kind!r}.")
+        try:
+            find_raster_output(results)
+        except HonuaError:
+            pass
+        else:
+            return await self.result_to_xarray(results)
+        if _feature_collection_from_output(results) is not None:
+            return await self._result_geodataframe(results)
+        return await self._result_json_value(results)
 
     # -- canonical multi-step plan ----------------------------------------
 

--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -491,6 +491,27 @@ def _primary_output_member(results: Mapping[str, Any]) -> Mapping[str, Any] | No
     return members[0] if members else None
 
 
+def _sniff_output_member(results: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Best-effort member lookup for outputs that carry no Honua ``kind`` tag.
+
+    :func:`_primary_output_member` requires a declared ``kind`` (Honua's
+    ``ArtifactKind`` metadata) and is the authoritative selector when present.
+    Some Table/Scalar outputs carry no ``kind`` at all -- just a plain OGC
+    ``value``/``href`` in the normal outputs-map shape, e.g.
+    ``{"out": {"value": {...}}}`` -- and still need to be found. This mirrors
+    the same kind-agnostic document-shape tolerance
+    :func:`_feature_collection_from_results` / ``find_raster_output`` already
+    apply: the whole document (a bare member) or the first nested member
+    carrying ``value``/``href`` is used, without requiring ``kind``.
+    """
+    if "value" in results or "href" in results:
+        return results
+    for member in results.values():
+        if isinstance(member, Mapping) and ("value" in member or "href" in member):
+            return member
+    return None
+
+
 def results_kind(results: Mapping[str, Any]) -> str | None:
     """Return the ``kind`` of a results document's primary output, if declared.
 
@@ -968,7 +989,7 @@ class HonuaGeoprocessing:
 
     def _result_json_value(self, results: Mapping[str, Any]) -> Any:
         """Parse a ``Table``/``Scalar`` output's JSON value from a results document."""
-        member = _primary_output_member(results) or results
+        member = _primary_output_member(results) or _sniff_output_member(results) or results
         data = _output_json_bytes(member)
         if data is None:
             href = member.get("href")
@@ -1399,7 +1420,7 @@ class AsyncHonuaGeoprocessing:
 
     async def _result_json_value(self, results: Mapping[str, Any]) -> Any:
         """Parse a ``Table``/``Scalar`` output's JSON value from a results document."""
-        member = _primary_output_member(results) or results
+        member = _primary_output_member(results) or _sniff_output_member(results) or results
         data = _output_json_bytes(member)
         if data is None:
             href = member.get("href")

--- a/packages/honua-sdk/honua_sdk/geoprocessing.py
+++ b/packages/honua-sdk/honua_sdk/geoprocessing.py
@@ -40,9 +40,12 @@ reuse the bound :class:`~honua_sdk.client.HonuaClient` /
 
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
 import time
+import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard, cast
@@ -59,6 +62,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 JsonObject = dict[str, Any]
 LayerReferenceKind = Literal["inlineGeoJson", "queryResult"]
+RasterReferenceKind = Literal["source", "layerId", "rasterId"]
 
 #: Canonical process id that accepts a multi-step analysis ``plan`` input.
 CANONICAL_PROCESS_ID = "honua-geoprocessing"
@@ -95,6 +99,41 @@ LAYER_SCOPE_PROCESS_IDS: frozenset[str] = frozenset(
         "conversion.feature-project",
         "generalization.simplify-layer",
         "generalization.dissolve",
+    }
+)
+
+#: Raster / surface process ids handled by the GDAL worker. Unlike the vector
+#: ids above, **none** of these are allow-listed for direct
+#: ``POST .../processes/{processId}/execution`` on the reconciled server
+#: (``ProcessMigrationEvidenceClassifier.FirstSliceAutomatedVectorProcessIds``
+#: only lists vector/geometry ids) — a direct call 404s with ``no-such-process``.
+#: The only way to invoke one is wrapped as a single ``geoprocess`` step inside
+#: the canonical ``honua-geoprocessing`` ``plan`` input; the
+#: :meth:`~HonuaGeoprocessing.submit_raster_process` /
+#: :meth:`~HonuaGeoprocessing.execute_raster_process` helpers do that wrapping
+#: transparently.
+RASTER_SCOPE_PROCESS_IDS: frozenset[str] = frozenset(
+    {
+        "surface.slope",
+        "surface.aspect",
+        "surface.hillshade",
+        "surface.contour",
+        "surface.viewshed",
+        "surface.roughness",
+        "surface.rugosity-tpi",
+        "surface.rugosity-tri",
+        "raster.clip",
+        "raster.mosaic",
+        "raster.reclassify",
+        "raster.reproject",
+        "raster.resample",
+        "raster.map-algebra",
+        "raster.spectral-index",
+        "raster.statistics",
+        "raster.histogram",
+        "raster.interpolate-idw",
+        "raster.interpolate-kriging",
+        "raster.zonal-statistics",
     }
 )
 
@@ -159,6 +198,87 @@ class LayerReference:
         if self.where:
             inputs["where"] = self.where
         return inputs
+
+
+@dataclass(frozen=True)
+class RasterReference:
+    """A reference to the raster a raster/surface GP process runs on.
+
+    A raster input reaches the GDAL worker as **one flat string parameter** in
+    the process ``inputs`` bag; exactly one carrier is populated according to
+    :attr:`kind`. Use the classmethod constructors rather than building this by
+    hand:
+
+    * :meth:`from_geotiff_bytes` -- inline GeoTIFF bytes, base64-encoded and
+      emitted as ``source`` (this is literally what the GDAL worker reads at
+      execution time).
+    * :meth:`from_layer_id` -- a catalog raster layer id, emitted as ``layerId``
+      (resolved server-side into a ``source`` before the job reaches the worker).
+    * :meth:`from_raster_id` -- a registered raster id, emitted as ``rasterId``
+      (same server-side pre-resolution as ``layerId``).
+
+    The three carriers are mutually exclusive; exactly one must be populated.
+    """
+
+    kind: RasterReferenceKind
+    source_base64: str | None = None
+    layer_id: str | None = None
+    raster_id: str | None = None
+
+    def __post_init__(self) -> None:
+        populated = [
+            name
+            for name, value in (
+                ("source_base64", self.source_base64),
+                ("layer_id", self.layer_id),
+                ("raster_id", self.raster_id),
+            )
+            if value is not None
+        ]
+        if len(populated) != 1:
+            raise ValueError(
+                "RasterReference requires exactly one of source_base64/layer_id/raster_id "
+                f"to be populated; got {populated!r}. Use the classmethod constructors."
+            )
+
+    @classmethod
+    def from_geotiff_bytes(cls, data: bytes) -> "RasterReference":
+        """Build a reference from inline GeoTIFF ``data`` (base64-encoded ``source``)."""
+        if not isinstance(data, (bytes, bytearray)):
+            raise TypeError("from_geotiff_bytes expects GeoTIFF bytes.")
+        encoded = base64.b64encode(bytes(data)).decode("ascii")
+        return cls(kind="source", source_base64=encoded)
+
+    @classmethod
+    def from_layer_id(cls, layer_id: str) -> "RasterReference":
+        """Build a reference to a catalog raster layer id (emitted as ``layerId``)."""
+        return cls(kind="layerId", layer_id=str(layer_id))
+
+    @classmethod
+    def from_raster_id(cls, raster_id: str) -> "RasterReference":
+        """Build a reference to a registered raster id (emitted as ``rasterId``)."""
+        return cls(kind="rasterId", raster_id=str(raster_id))
+
+    def to_inputs(self) -> JsonObject:
+        """Project this reference onto its single OGC Processes ``inputs`` key.
+
+        The GDAL worker reads ``source`` (inline base64 GeoTIFF); ``layerId`` /
+        ``rasterId`` are resolved into a ``source`` server-side before the job
+        reaches the worker.
+        """
+        if self.kind == "source":
+            if not self.source_base64:
+                raise ValueError("source raster reference requires base64-encoded GeoTIFF bytes.")
+            return {"source": self.source_base64}
+        if self.kind == "layerId":
+            if not self.layer_id:
+                raise ValueError("layerId raster reference requires a catalog raster layer id.")
+            return {"layerId": self.layer_id}
+        if self.kind == "rasterId":
+            if not self.raster_id:
+                raise ValueError("rasterId raster reference requires a registered raster id.")
+            return {"rasterId": self.raster_id}
+        raise ValueError(f"Unknown raster reference kind: {self.kind!r}")  # pragma: no cover
 
 
 @dataclass(frozen=True)
@@ -234,6 +354,161 @@ def _layer_inputs(reference: LayerReference, parameters: Mapping[str, Any] | Non
 def _plan_inputs(plan: Mapping[str, Any]) -> JsonObject:
     """Wrap an analysis plan into the canonical process ``inputs`` bag."""
     return {"plan": dict(plan)}
+
+
+def _zone_inputs(zones: LayerReference) -> JsonObject:
+    """Project a zone-polygon layer onto the ``zones`` raster-process input.
+
+    ``raster.zonal-statistics`` reads its zone polygons as a **base64-encoded
+    GeoJSON ``FeatureCollection``** under the flat ``zones`` parameter (confirmed
+    via ``GdalRasterZonalStatisticsJobExecutor`` ->
+    ``GdalJobInputReader.TryGetBase64Input(parameters, "zones", ...)``). This is
+    a *different* wire shape from a vector process's ``inputGeoJson`` (raw JSON
+    string), so zones are encoded here rather than via ``LayerReference.to_inputs``.
+    Layer-resolved zones (``zonesLayerId``) are deferred server-side, so only an
+    inline-GeoJSON :class:`LayerReference` is accepted.
+    """
+    if zones.kind != "inlineGeoJson" or zones.inline_geojson is None:
+        raise ValueError(
+            "zones must be an inline-GeoJSON LayerReference "
+            "(LayerReference.from_geojson(...)); layer-resolved zones are deferred server-side."
+        )
+    payload = json.dumps(zones.inline_geojson, separators=(",", ":")).encode("utf-8")
+    return {"zones": base64.b64encode(payload).decode("ascii")}
+
+
+def _raster_process_inputs(
+    raster: RasterReference,
+    zones: LayerReference | None,
+    parameters: Mapping[str, Any] | None,
+) -> JsonObject:
+    """Build the flat raster-process ``inputs`` bag (raster + zones + parameters)."""
+    inputs: JsonObject = dict(raster.to_inputs())
+    if zones is not None:
+        inputs.update(_zone_inputs(zones))
+    if parameters:
+        for key, value in parameters.items():
+            inputs[key] = value if isinstance(value, str) else _stringify(value)
+    return inputs
+
+
+def _raster_plan(process_id: str, inputs: Mapping[str, Any], plan_id: str) -> JsonObject:
+    """Wrap a raster-process invocation as a single-step canonical plan.
+
+    Raster/surface process ids 404 on direct execution, so they are submitted as
+    one ``geoprocess`` step inside the ``honua-geoprocessing`` process's ``plan``
+    input (shape confirmed against
+    ``OgcProcessesExecutionSubmissionTests``).
+    """
+    return {
+        "planId": plan_id,
+        "steps": [
+            {
+                "stepId": "s1",
+                "kind": "geoprocess",
+                "processId": process_id,
+                "inputs": dict(inputs),
+            }
+        ],
+    }
+
+
+def _default_plan_id(process_id: str) -> str:
+    """Generate a reasonable, unique ``planId`` for an auto-wrapped raster step."""
+    return f"raster-{process_id}-{uuid.uuid4().hex[:12]}"
+
+
+def _data_uri_bytes(uri: str) -> bytes | None:
+    """Decode a ``data:`` URI to bytes, or ``None`` when ``uri`` is not a data URI.
+
+    Handles both ``;base64`` and plain (percent-encoded) payloads. Honua's GDAL
+    worker publishes scalar/table/vector artifacts as
+    ``data:<content-type>;base64,<payload>`` (see ``GdalDataUri.Build``).
+    """
+    if not uri.startswith("data:"):
+        return None
+    header, _, data = uri.partition(",")
+    if ";base64" in header:
+        try:
+            return base64.b64decode(data, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise HonuaError(f"Output data URI is not valid base64: {exc}") from exc
+    return unquote(data).encode("utf-8")
+
+
+def _output_json_bytes(member: Mapping[str, Any]) -> bytes | None:
+    """Return the JSON payload bytes carried inline by an output ``member``.
+
+    Reads an inline ``value`` (data URI, raw JSON string, or base64) or a
+    ``data:`` ``href``. Returns ``None`` when the payload is only reachable via a
+    fetchable (``http(s)``) ``href`` -- the caller fetches that through the bound
+    client so base URL, auth, and retry policy apply.
+    """
+    value = member.get("value")
+    if isinstance(value, str):
+        decoded = _data_uri_bytes(value)
+        if decoded is not None:
+            return decoded
+        stripped = value.strip()
+        if stripped[:1] in ("{", "["):
+            return value.encode("utf-8")
+        try:
+            return base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError):
+            return value.encode("utf-8")
+    href = member.get("href")
+    if isinstance(href, str) and href:
+        return _data_uri_bytes(href)
+    return None
+
+
+def _output_members(results: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    """Yield candidate output members from a results document.
+
+    Handles the same shape variability the other selectors do: the document may
+    itself be a member, an outputs map keyed by output id, or an outputs map
+    whose members wrap the real payload under a ``value`` key.
+    """
+    members: list[Mapping[str, Any]] = []
+    if _looks_output_member(results):
+        members.append(results)
+    for member in results.values():
+        if isinstance(member, Mapping):
+            if _looks_output_member(member):
+                members.append(member)
+            wrapped = member.get("value")
+            if isinstance(wrapped, Mapping) and _looks_output_member(wrapped):
+                members.append(wrapped)
+    return tuple(members)
+
+
+def _looks_output_member(value: Any) -> bool:
+    """Whether ``value`` looks like an OGC results output member (carries ``kind``)."""
+    return isinstance(value, Mapping) and "kind" in value
+
+
+def _primary_output_member(results: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return the first output member carrying a ``kind`` field, if any."""
+    members = _output_members(results)
+    return members[0] if members else None
+
+
+def results_kind(results: Mapping[str, Any]) -> str | None:
+    """Return the ``kind`` of a results document's primary output, if declared.
+
+    Reads ``outputs.*.kind`` (one of Honua's ``ArtifactKind`` values --
+    ``Raster``, ``FeatureLayer``, ``Table``, ``Scalar``) from the OGC Processes
+    results document returned by ``GET /ogc/processes/jobs/{id}/results``,
+    tolerating the same document-shape variability the raster/feature selectors
+    handle (bare member, outputs map, or ``value``-wrapped member). Returns
+    ``None`` when no output declares a ``kind`` (for example a bare pass-through
+    ``FeatureCollection``), in which case consumption falls back to sniffing.
+    """
+    member = _primary_output_member(results)
+    if member is None:
+        return None
+    kind = member.get("kind")
+    return kind if isinstance(kind, str) else None
 
 
 def _is_feature_collection(value: Any) -> TypeGuard[Mapping[str, Any]]:
@@ -555,6 +830,11 @@ class HonuaGeoprocessing:
             return inline
         href = raster_href(member)
         if href:
+            # honua-server publishes rasters as a ``data:`` URI in ``href``
+            # (GdalDataUri.Build), so decode that inline rather than fetching.
+            data_uri = _data_uri_bytes(href)
+            if data_uri is not None:
+                return data_uri
             path, params = _href_path_and_params(href)
             return self.client._request("GET", path, params=params).content
         raise HonuaError("Raster output has neither an inline value nor an href to fetch.")
@@ -599,6 +879,143 @@ class HonuaGeoprocessing:
             timeout=timeout,
         )
         return self.result_to_xarray(result)
+
+    # -- raster-ref-in (surface/raster tools) -----------------------------
+
+    def submit_raster_process(
+        self,
+        process_id: str,
+        raster: RasterReference,
+        *,
+        zones: LayerReference | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        plan_id: str | None = None,
+        respond_async: bool = True,
+    ) -> GeoprocessingJob:
+        """Submit a raster/surface process and return the (pending) job.
+
+        ``raster`` is a :class:`RasterReference` (inline GeoTIFF ``source`` or a
+        server-resolved ``layerId`` / ``rasterId``); ``zones`` is an optional
+        inline-GeoJSON :class:`LayerReference` of zone polygons for
+        ``raster.zonal-statistics``; ``parameters`` carries process options (for
+        example ``{"units": "degrees"}`` for ``surface.slope``).
+
+        Because every raster/surface process id 404s on direct execution, the
+        call is transparently auto-wrapped as a single ``geoprocess`` step inside
+        the canonical ``honua-geoprocessing`` ``plan`` and submitted through the
+        existing plan machinery. Pass ``plan_id`` to override the generated id.
+        """
+        inputs = _raster_process_inputs(raster, zones, parameters)
+        plan = _raster_plan(process_id, inputs, plan_id or _default_plan_id(process_id))
+        return self.submit_plan(plan, respond_async=respond_async)
+
+    def execute_raster_process(
+        self,
+        process_id: str,
+        raster: RasterReference,
+        *,
+        zones: LayerReference | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        plan_id: str | None = None,
+        poll_interval: float = 0.5,
+        timeout: float | None = 120.0,
+        raise_on_failure: bool = True,
+    ) -> JsonObject:
+        """Run a raster/surface process to completion and return the results document.
+
+        Same ergonomics as :meth:`execute` for vector processes: submits (as an
+        auto-wrapped single-step plan), polls to a terminal state, and returns
+        the ``/results`` document. The output ``kind`` varies by tool (``Raster``
+        for most, ``FeatureLayer`` for ``surface.contour``, ``Table`` for
+        ``raster.zonal-statistics``, ``Scalar`` for
+        ``raster.statistics``/``raster.histogram``); pass the returned document to
+        :meth:`consume_result` to get the corresponding Python object without
+        knowing the kind in advance.
+        """
+        inputs = _raster_process_inputs(raster, zones, parameters)
+        plan = _raster_plan(process_id, inputs, plan_id or _default_plan_id(process_id))
+        return self.execute_plan(
+            plan,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            raise_on_failure=raise_on_failure,
+        )
+
+    # -- kind-routed result consumption -----------------------------------
+
+    def _result_json_value(self, results: Mapping[str, Any]) -> Any:
+        """Parse a ``Table``/``Scalar`` output's JSON value from a results document."""
+        member = _primary_output_member(results) or results
+        data = _output_json_bytes(member)
+        if data is None:
+            href = member.get("href")
+            if isinstance(href, str) and href and not href.startswith("data:"):
+                path, params = _href_path_and_params(href)
+                data = self.client._request("GET", path, params=params).content
+        if data is None:
+            value = member.get("value")
+            if isinstance(value, (dict, list)):
+                return value
+            raise HonuaError("Table/Scalar output has no decodable JSON payload.")
+        return json.loads(data)
+
+    def _result_geodataframe(self, results: Mapping[str, Any]) -> "gpd.GeoDataFrame":
+        """Parse a ``FeatureLayer`` output to a GeoDataFrame (requires geopandas)."""
+        from .geopandas import ogc_features_to_geodataframe
+
+        return ogc_features_to_geodataframe(self._result_feature_collection(results))
+
+    def _result_feature_collection(self, results: Mapping[str, Any]) -> JsonObject:
+        member = _primary_output_member(results)
+        if member is not None:
+            data = _output_json_bytes(member)
+            if data is None:
+                href = member.get("href")
+                if isinstance(href, str) and href and not href.startswith("data:"):
+                    path, params = _href_path_and_params(href)
+                    data = self.client._request("GET", path, params=params).content
+            if data is not None:
+                parsed = json.loads(data)
+                if _is_feature_collection(parsed):
+                    return cast(JsonObject, parsed)
+        # Fall back to the inline-FeatureCollection selector (vector-process shape).
+        return _feature_collection_from_results(results)
+
+    def consume_result(self, results: Mapping[str, Any]) -> Any:
+        """Route a results document to the Python object matching its output kind.
+
+        * ``Raster`` -> :class:`xarray.DataArray` (via :meth:`result_to_xarray`).
+        * ``FeatureLayer`` -> a :class:`geopandas.GeoDataFrame`.
+        * ``Table`` / ``Scalar`` -> the parsed JSON value (``dict`` / ``list``).
+        * undeclared kind -> sniffed (raster, then feature collection, then JSON).
+
+        Lets a caller consume :meth:`execute_raster_process` output without
+        knowing in advance which kind a given ``process_id`` produces (xarray for
+        ``surface.slope``, a GeoDataFrame for ``surface.contour``, a list-of-dicts
+        for ``raster.zonal-statistics``). Raster/feature routing requires the
+        corresponding optional extra (``raster`` / ``geopandas``).
+        """
+        kind = results_kind(results)
+        if kind == "Raster":
+            return self.result_to_xarray(results)
+        if kind == "FeatureLayer":
+            return self._result_geodataframe(results)
+        if kind in ("Table", "Scalar"):
+            return self._result_json_value(results)
+        if kind is None:
+            from .raster import find_raster_output
+
+            try:
+                find_raster_output(results)
+            except HonuaError:
+                pass
+            else:
+                return self.result_to_xarray(results)
+            try:
+                return self._result_geodataframe(results)
+            except HonuaError:
+                return self._result_json_value(results)
+        raise HonuaError(f"Unsupported results kind {kind!r}.")
 
     # -- canonical multi-step plan ----------------------------------------
 
@@ -845,6 +1262,11 @@ class AsyncHonuaGeoprocessing:
             return inline
         href = raster_href(member)
         if href:
+            # honua-server publishes rasters as a ``data:`` URI in ``href``
+            # (GdalDataUri.Build), so decode that inline rather than fetching.
+            data_uri = _data_uri_bytes(href)
+            if data_uri is not None:
+                return data_uri
             path, params = _href_path_and_params(href)
             response = await self.client._request("GET", path, params=params)
             return response.content
@@ -890,6 +1312,127 @@ class AsyncHonuaGeoprocessing:
             timeout=timeout,
         )
         return await self.result_to_xarray(result)
+
+    # -- raster-ref-in (surface/raster tools) -----------------------------
+
+    async def submit_raster_process(
+        self,
+        process_id: str,
+        raster: RasterReference,
+        *,
+        zones: LayerReference | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        plan_id: str | None = None,
+        respond_async: bool = True,
+    ) -> GeoprocessingJob:
+        """Submit a raster/surface process and return the (pending) job.
+
+        Async twin of :meth:`HonuaGeoprocessing.submit_raster_process`; the call
+        is transparently auto-wrapped as a single ``geoprocess`` step inside the
+        canonical ``honua-geoprocessing`` ``plan`` (raster ids 404 on direct
+        execution).
+        """
+        inputs = _raster_process_inputs(raster, zones, parameters)
+        plan = _raster_plan(process_id, inputs, plan_id or _default_plan_id(process_id))
+        return await self.submit_plan(plan, respond_async=respond_async)
+
+    async def execute_raster_process(
+        self,
+        process_id: str,
+        raster: RasterReference,
+        *,
+        zones: LayerReference | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        plan_id: str | None = None,
+        poll_interval: float = 0.5,
+        timeout: float | None = 120.0,
+        raise_on_failure: bool = True,
+    ) -> JsonObject:
+        """Run a raster/surface process to completion and return the results document.
+
+        Async twin of :meth:`HonuaGeoprocessing.execute_raster_process`. Pass the
+        returned document to :meth:`consume_result` to get the corresponding
+        Python object for whatever ``kind`` the tool produced.
+        """
+        inputs = _raster_process_inputs(raster, zones, parameters)
+        plan = _raster_plan(process_id, inputs, plan_id or _default_plan_id(process_id))
+        return await self.execute_plan(
+            plan,
+            poll_interval=poll_interval,
+            timeout=timeout,
+            raise_on_failure=raise_on_failure,
+        )
+
+    # -- kind-routed result consumption -----------------------------------
+
+    async def _result_json_value(self, results: Mapping[str, Any]) -> Any:
+        """Parse a ``Table``/``Scalar`` output's JSON value from a results document."""
+        member = _primary_output_member(results) or results
+        data = _output_json_bytes(member)
+        if data is None:
+            href = member.get("href")
+            if isinstance(href, str) and href and not href.startswith("data:"):
+                path, params = _href_path_and_params(href)
+                response = await self.client._request("GET", path, params=params)
+                data = response.content
+        if data is None:
+            value = member.get("value")
+            if isinstance(value, (dict, list)):
+                return value
+            raise HonuaError("Table/Scalar output has no decodable JSON payload.")
+        return json.loads(data)
+
+    async def _result_geodataframe(self, results: Mapping[str, Any]) -> "gpd.GeoDataFrame":
+        """Parse a ``FeatureLayer`` output to a GeoDataFrame (requires geopandas)."""
+        from .geopandas import ogc_features_to_geodataframe
+
+        return ogc_features_to_geodataframe(await self._result_feature_collection(results))
+
+    async def _result_feature_collection(self, results: Mapping[str, Any]) -> JsonObject:
+        member = _primary_output_member(results)
+        if member is not None:
+            data = _output_json_bytes(member)
+            if data is None:
+                href = member.get("href")
+                if isinstance(href, str) and href and not href.startswith("data:"):
+                    path, params = _href_path_and_params(href)
+                    response = await self.client._request("GET", path, params=params)
+                    data = response.content
+            if data is not None:
+                parsed = json.loads(data)
+                if _is_feature_collection(parsed):
+                    return cast(JsonObject, parsed)
+        # Fall back to the inline-FeatureCollection selector (vector-process shape).
+        return _feature_collection_from_results(results)
+
+    async def consume_result(self, results: Mapping[str, Any]) -> Any:
+        """Route a results document to the Python object matching its output kind.
+
+        Async twin of :meth:`HonuaGeoprocessing.consume_result`: ``Raster`` ->
+        :class:`xarray.DataArray`, ``FeatureLayer`` -> GeoDataFrame,
+        ``Table``/``Scalar`` -> parsed JSON, undeclared kind -> sniffed.
+        """
+        kind = results_kind(results)
+        if kind == "Raster":
+            return await self.result_to_xarray(results)
+        if kind == "FeatureLayer":
+            return await self._result_geodataframe(results)
+        if kind in ("Table", "Scalar"):
+            return await self._result_json_value(results)
+        if kind is None:
+            from .raster import find_raster_output
+
+            try:
+                find_raster_output(results)
+            except HonuaError:
+                pass
+            else:
+                return await self.result_to_xarray(results)
+            try:
+                return await self._result_geodataframe(results)
+            except HonuaError:
+                return await self._result_json_value(results)
+        raise HonuaError(f"Unsupported results kind {kind!r}.")
 
     # -- canonical multi-step plan ----------------------------------------
 

--- a/tests/test_geoprocessing_raster_input.py
+++ b/tests/test_geoprocessing_raster_input.py
@@ -33,6 +33,9 @@ from honua_sdk.geoprocessing import (
     RASTER_SCOPE_PROCESS_IDS,
     LayerReference,
     RasterReference,
+    _data_uri_bytes,
+    _feature_collection_from_output,
+    _output_json_bytes,
     results_kind,
 )
 
@@ -114,6 +117,17 @@ def test_raster_reference_from_geotiff_bytes_type_checked() -> None:
         RasterReference.from_geotiff_bytes("not-bytes")  # type: ignore[arg-type]
 
 
+def test_raster_reference_to_inputs_guards_empty_carrier() -> None:
+    # __post_init__ only checks "populated" (not None); an empty-string carrier
+    # passes that check but must still be rejected by to_inputs()'s own guard.
+    with pytest.raises(ValueError, match="source raster reference requires"):
+        RasterReference(kind="source", source_base64="").to_inputs()
+    with pytest.raises(ValueError, match="layerId raster reference requires"):
+        RasterReference(kind="layerId", layer_id="").to_inputs()
+    with pytest.raises(ValueError, match="rasterId raster reference requires"):
+        RasterReference(kind="rasterId", raster_id="").to_inputs()
+
+
 # ---------------------------------------------------------------------------
 # Plan-wrapped submission body
 # ---------------------------------------------------------------------------
@@ -177,7 +191,7 @@ def test_execute_raster_process_wraps_source_bytes() -> None:
         result = client.geoprocessing().execute_raster_process(
             "surface.slope",
             raster,
-            parameters={"units": "degrees", "zFactor": 2},
+            parameters={"units": "degrees", "zFactor": 2, "invert": False},
             plan_id="plan-x",
             poll_interval=0.0,
         )
@@ -186,9 +200,11 @@ def test_execute_raster_process_wraps_source_bytes() -> None:
     step = captured[0]["inputs"]["plan"]["steps"][0]
     assert step["processId"] == "surface.slope"
     assert step["inputs"]["source"] == base64.b64encode(b"II*\x00dem").decode("ascii")
-    # Non-string parameters are canonicalized to strings, like the vector path.
+    # Non-string parameters are canonicalized to strings, like the vector path
+    # (including the boolean true/false spelling, not Python's True/False).
     assert step["inputs"]["units"] == "degrees"
     assert step["inputs"]["zFactor"] == "2"
+    assert step["inputs"]["invert"] == "false"
 
 
 def test_execute_raster_process_with_zones_base64_geojson() -> None:
@@ -384,8 +400,197 @@ def test_consume_result_unknown_kind_sniffs_json() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Pure decode/selection helpers (no optional extra needed for any of these --
+# these are the primitives consume_result's kind-routing is built on, and are
+# exercised directly so their branches stay covered independent of whether
+# geopandas/rasterio happen to be installed).
+# ---------------------------------------------------------------------------
+
+
+def test_data_uri_bytes_non_data_uri_is_none() -> None:
+    assert _data_uri_bytes("https://example.test/x.tif") is None
+
+
+def test_data_uri_bytes_base64() -> None:
+    encoded = base64.b64encode(b"hello").decode("ascii")
+    assert _data_uri_bytes(f"data:text/plain;base64,{encoded}") == b"hello"
+
+
+def test_data_uri_bytes_plain_percent_encoded() -> None:
+    assert _data_uri_bytes("data:text/plain,hello%20world") == b"hello world"
+
+
+def test_data_uri_bytes_invalid_base64_raises() -> None:
+    with pytest.raises(HonuaError, match="not valid base64"):
+        _data_uri_bytes("data:text/plain;base64,not-base64!!!")
+
+
+def test_output_json_bytes_data_uri_value() -> None:
+    encoded = base64.b64encode(b'{"a": 1}').decode("ascii")
+    member = {"value": f"data:application/json;base64,{encoded}"}
+    assert _output_json_bytes(member) == b'{"a": 1}'
+
+
+def test_output_json_bytes_raw_json_string_value() -> None:
+    member = {"value": '{"a": 1}'}
+    assert _output_json_bytes(member) == b'{"a": 1}'
+
+
+def test_output_json_bytes_non_json_non_data_value_is_none() -> None:
+    # A string value that is neither a ``data:`` URI nor JSON-looking.
+    assert _output_json_bytes({"value": "not-json-and-not-a-data-uri"}) is None
+
+
+def test_output_json_bytes_data_uri_href() -> None:
+    encoded = base64.b64encode(b"[1, 2]").decode("ascii")
+    member = {"href": f"data:application/json;base64,{encoded}"}
+    assert _output_json_bytes(member) == b"[1, 2]"
+
+
+def test_output_json_bytes_no_value_or_href_is_none() -> None:
+    assert _output_json_bytes({"id": "x", "kind": "Scalar"}) is None
+
+
+def test_results_kind_bare_document_is_the_member() -> None:
+    # The results document itself (not an outputs map) carries ``kind``.
+    assert results_kind({"id": "x", "kind": "Scalar", "value": {"mean": 1.0}}) == "Scalar"
+
+
+def test_results_kind_value_wrapped_member() -> None:
+    # OGC ``raw``/``value``-wrapped member: the kind-bearing payload sits under
+    # the outer member's ``value`` key rather than at the top level.
+    results = {"out": {"value": {"id": "x", "kind": "Table", "href": "data:application/json;base64,e30="}}}
+    assert results_kind(results) == "Table"
+
+
+def test_feature_collection_from_output_via_kind_based_decode() -> None:
+    found = _feature_collection_from_output(_featurelayer_results())
+    assert found == _CONTOUR_FC
+
+
+def test_feature_collection_from_output_falls_back_to_inline_shape() -> None:
+    # The plain inline-FeatureCollection vector-process shape (no ``kind``).
+    inline = {"out": {"value": _CONTOUR_FC}}
+    assert _feature_collection_from_output(inline) == _CONTOUR_FC
+
+
+def test_feature_collection_from_output_bare_document_is_the_collection() -> None:
+    # The whole results document IS the (pass-through) FeatureCollection.
+    assert _feature_collection_from_output(_CONTOUR_FC) == _CONTOUR_FC
+
+
+def test_feature_collection_from_output_member_is_the_collection_directly() -> None:
+    # An outputs-map member that IS a FeatureCollection directly (not wrapped
+    # under a ``value`` key).
+    results = {"out": _CONTOUR_FC}
+    assert _feature_collection_from_output(results) == _CONTOUR_FC
+
+
+def test_feature_collection_from_output_none_when_absent() -> None:
+    assert _feature_collection_from_output(_table_results()) is None
+
+
+def test_consume_result_unsupported_kind_raises() -> None:
+    results = {"out": {"id": "x", "kind": "SomethingElse", "value": {"a": 1}}}
+    with _client() as client:
+        with pytest.raises(HonuaError, match="Unsupported results kind"):
+            client.geoprocessing().consume_result(results)
+
+
+def test_consume_result_undeclared_kind_falls_back_to_json() -> None:
+    # No ``kind`` anywhere, no raster, no FeatureCollection -- falls all the way
+    # through to the plain-JSON-value path without needing any optional extra.
+    # The document itself is the "member" here (no outputs-map nesting), same
+    # bare-document shape ``_is_feature_collection``/``find_raster_output``
+    # already tolerate.
+    encoded = base64.b64encode(json.dumps({"answer": 42}).encode("utf-8")).decode("ascii")
+    results = {"value": f"data:application/json;base64,{encoded}"}
+    with _client() as client:
+        assert client.geoprocessing().consume_result(results) == {"answer": 42}
+
+
+def _fetch_client(payload: bytes, expected_path: str) -> HonuaClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == expected_path
+        return httpx.Response(200, content=payload, headers={"content-type": "application/json"})
+
+    return HonuaClient("http://example.test", transport=httpx.MockTransport(handler))
+
+
+def test_result_json_value_fetches_live_href() -> None:
+    # A Table/Scalar member with no inline value/data-uri href, only a live
+    # fetchable href -- exercises the (extras-independent) fetch fallback.
+    payload = json.dumps({"mean": 5.0}).encode("utf-8")
+    results = {"stats": {"id": "x", "kind": "Scalar", "href": "https://example.test/artifacts/stats.json"}}
+    with _fetch_client(payload, "/artifacts/stats.json") as client:
+        assert client.geoprocessing()._result_json_value(results) == {"mean": 5.0}
+
+
+def test_result_json_value_raw_dict_value() -> None:
+    results = {"stats": {"id": "x", "kind": "Scalar", "value": {"mean": 5.0}}}
+    with _client() as client:
+        assert client.geoprocessing()._result_json_value(results) == {"mean": 5.0}
+
+
+def test_result_json_value_raises_when_no_decodable_payload() -> None:
+    results = {"stats": {"id": "x", "kind": "Scalar"}}
+    with _client() as client:
+        with pytest.raises(HonuaError, match="no decodable JSON payload"):
+            client.geoprocessing()._result_json_value(results)
+
+
+def test_result_feature_collection_resolves_via_pure_decode() -> None:
+    # _result_feature_collection needs no client I/O (and no geopandas) when the
+    # pure _feature_collection_from_output decode already finds the payload --
+    # this is what lets _result_geodataframe stay a thin geopandas-only wrapper.
+    with _client() as client:
+        assert client.geoprocessing()._result_feature_collection(_featurelayer_results()) == _CONTOUR_FC
+
+
+def test_result_feature_collection_fetches_live_href() -> None:
+    payload = json.dumps(_CONTOUR_FC).encode("utf-8")
+    results = {"contour": {"id": "x", "kind": "FeatureLayer", "href": "https://example.test/artifacts/c.geojson"}}
+    with _fetch_client(payload, "/artifacts/c.geojson") as client:
+        assert client.geoprocessing()._result_feature_collection(results) == _CONTOUR_FC
+
+
+def test_result_feature_collection_raises_when_absent() -> None:
+    with _client() as client:
+        with pytest.raises(HonuaError, match="does not contain a FeatureCollection"):
+            client.geoprocessing()._result_feature_collection(_table_results())
+
+
+# ---------------------------------------------------------------------------
 # Async parity
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_async_submit_raster_process_wraps_into_canonical_plan() -> None:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        captured.append(json.loads(request.content))
+        return httpx.Response(201, json=_status("job-1", "accepted"))
+
+    raster = RasterReference.from_layer_id("dem-1")
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        await client.geoprocessing().submit_raster_process(
+            "surface.slope", raster, parameters={"units": "degrees"}, plan_id="plan-slope"
+        )
+
+    assert captured[0]["inputs"]["plan"] == {
+        "planId": "plan-slope",
+        "steps": [
+            {
+                "stepId": "s1",
+                "kind": "geoprocess",
+                "processId": "surface.slope",
+                "inputs": {"layerId": "dem-1", "units": "degrees"},
+            }
+        ],
+    }
 
 
 @pytest.mark.anyio
@@ -433,3 +638,99 @@ async def test_async_consume_result_featurelayer() -> None:
 
     assert len(gdf) == 1
     assert list(gdf["elev"]) == [100]
+
+
+@pytest.mark.anyio
+async def test_async_consume_result_unsupported_kind_raises() -> None:
+    results = {"out": {"id": "x", "kind": "SomethingElse", "value": {"a": 1}}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(HonuaError, match="Unsupported results kind"):
+            await client.geoprocessing().consume_result(results)
+
+
+@pytest.mark.anyio
+async def test_async_consume_result_undeclared_kind_falls_back_to_json() -> None:
+    encoded = base64.b64encode(json.dumps({"answer": 42}).encode("utf-8")).decode("ascii")
+    results = {"value": f"data:application/json;base64,{encoded}"}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        assert await client.geoprocessing().consume_result(results) == {"answer": 42}
+
+
+@pytest.mark.anyio
+async def test_async_result_json_value_fetches_live_href() -> None:
+    payload = json.dumps({"mean": 5.0}).encode("utf-8")
+    results = {"stats": {"id": "x", "kind": "Scalar", "href": "https://example.test/artifacts/stats.json"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/artifacts/stats.json"
+        return httpx.Response(200, content=payload, headers={"content-type": "application/json"})
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        value = await client.geoprocessing()._result_json_value(results)
+    assert value == {"mean": 5.0}
+
+
+@pytest.mark.anyio
+async def test_async_result_json_value_raw_dict_value() -> None:
+    results = {"stats": {"id": "x", "kind": "Scalar", "value": {"mean": 5.0}}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        value = await client.geoprocessing()._result_json_value(results)
+    assert value == {"mean": 5.0}
+
+
+@pytest.mark.anyio
+async def test_async_result_json_value_raises_when_no_decodable_payload() -> None:
+    results = {"stats": {"id": "x", "kind": "Scalar"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(HonuaError, match="no decodable JSON payload"):
+            await client.geoprocessing()._result_json_value(results)
+
+
+@pytest.mark.anyio
+async def test_async_result_feature_collection_resolves_via_pure_decode() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        found = await client.geoprocessing()._result_feature_collection(_featurelayer_results())
+    assert found == _CONTOUR_FC
+
+
+@pytest.mark.anyio
+async def test_async_result_feature_collection_fetches_live_href() -> None:
+    payload = json.dumps(_CONTOUR_FC).encode("utf-8")
+    results = {"contour": {"id": "x", "kind": "FeatureLayer", "href": "https://example.test/artifacts/c.geojson"}}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/artifacts/c.geojson"
+        return httpx.Response(200, content=payload, headers={"content-type": "application/geo+json"})
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        found = await client.geoprocessing()._result_feature_collection(results)
+    assert found == _CONTOUR_FC
+
+
+@pytest.mark.anyio
+async def test_async_result_feature_collection_raises_when_absent() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(HonuaError, match="does not contain a FeatureCollection"):
+            await client.geoprocessing()._result_feature_collection(_table_results())

--- a/tests/test_geoprocessing_raster_input.py
+++ b/tests/test_geoprocessing_raster_input.py
@@ -509,6 +509,25 @@ def test_consume_result_undeclared_kind_falls_back_to_json() -> None:
         assert client.geoprocessing().consume_result(results) == {"answer": 42}
 
 
+def test_consume_result_undeclared_kind_nested_value_wrapper_sniffed() -> None:
+    # Regression test (codex review, PR #173): a plain OGC results document in
+    # the normal outputs-map shape -- {"out": {"value": {...}}} -- with no
+    # Honua ArtifactKind ``kind`` tag anywhere. _primary_output_member() finds
+    # nothing (no "kind"), so the JSON sniff must still descend into the
+    # nested per-output "out" member's "value" instead of only checking the
+    # root results map -- otherwise a Table/Scalar output with no ArtifactKind
+    # metadata raises HonuaError instead of being sniffed successfully.
+    results = {"out": {"value": {"mean": 5.0}}}
+    with _client() as client:
+        assert client.geoprocessing().consume_result(results) == {"mean": 5.0}
+
+
+def test_result_json_value_sniffs_nested_value_wrapper_without_kind() -> None:
+    results = {"out": {"value": {"mean": 5.0}}}
+    with _client() as client:
+        assert client.geoprocessing()._result_json_value(results) == {"mean": 5.0}
+
+
 def _fetch_client(payload: bytes, expected_path: str) -> HonuaClient:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == expected_path
@@ -662,6 +681,29 @@ async def test_async_consume_result_undeclared_kind_falls_back_to_json() -> None
 
     async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
         assert await client.geoprocessing().consume_result(results) == {"answer": 42}
+
+
+@pytest.mark.anyio
+async def test_async_consume_result_undeclared_kind_nested_value_wrapper_sniffed() -> None:
+    # Regression test (codex review, PR #173) -- async twin.
+    results = {"out": {"value": {"mean": 5.0}}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        assert await client.geoprocessing().consume_result(results) == {"mean": 5.0}
+
+
+@pytest.mark.anyio
+async def test_async_result_json_value_sniffs_nested_value_wrapper_without_kind() -> None:
+    results = {"out": {"value": {"mean": 5.0}}}
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        assert await client.geoprocessing()._result_json_value(results) == {"mean": 5.0}
 
 
 @pytest.mark.anyio

--- a/tests/test_geoprocessing_raster_input.py
+++ b/tests/test_geoprocessing_raster_input.py
@@ -1,0 +1,435 @@
+"""Tests for raster/surface process *input* wiring on the geoprocessing clients.
+
+Covers:
+
+* :class:`RasterReference` construction / ``to_inputs`` / mutual-exclusivity,
+* the exact plan-wrapped execution body ``submit_raster_process`` /
+  ``execute_raster_process`` send (raster ids 404 on direct execution, so they
+  are auto-wrapped as a single ``geoprocess`` step inside the canonical
+  ``honua-geoprocessing`` ``plan`` -- shape mirrors the real
+  ``OgcProcessesExecutionSubmissionTests`` fixture),
+* ``results_kind`` + kind-routed ``consume_result`` for all four
+  ``ArtifactKind`` values (``Raster`` / ``FeatureLayer`` / ``Table`` / ``Scalar``)
+  using representative result-document shapes.
+
+Transport is mocked with :class:`httpx.MockTransport` (no live server). The
+raster-conversion path additionally needs the optional ``raster`` extra and is
+skipped via :func:`pytest.importorskip` when it is absent.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from honua_sdk import AsyncHonuaClient, HonuaClient
+from honua_sdk.errors import HonuaError
+from honua_sdk.geoprocessing import (
+    CANONICAL_PROCESS_ID,
+    RASTER_SCOPE_PROCESS_IDS,
+    LayerReference,
+    RasterReference,
+    results_kind,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _status(job_id: str, status: str) -> dict[str, Any]:
+    return {
+        "jobID": job_id,
+        "status": status,
+        "processID": CANONICAL_PROCESS_ID,
+        "type": "process",
+    }
+
+
+def _tiny_geotiff() -> bytes:
+    pytest.importorskip("rasterio")
+    import numpy as np
+    from rasterio.io import MemoryFile
+    from rasterio.transform import from_origin
+
+    array = np.arange(12, dtype="float32").reshape(1, 3, 4)
+    profile = {
+        "driver": "GTiff",
+        "height": 3,
+        "width": 4,
+        "count": 1,
+        "dtype": "float32",
+        "crs": "EPSG:4326",
+        "transform": from_origin(0, 3, 1, 1),
+    }
+    with MemoryFile() as memfile:
+        with memfile.open(**profile) as dataset:
+            dataset.write(array)
+        return bytes(memfile.read())
+
+
+# ---------------------------------------------------------------------------
+# RasterReference
+# ---------------------------------------------------------------------------
+
+
+def test_raster_scope_ids_are_the_nineteen_plus_zonal() -> None:
+    assert "surface.slope" in RASTER_SCOPE_PROCESS_IDS
+    assert "raster.zonal-statistics" in RASTER_SCOPE_PROCESS_IDS
+    assert len(RASTER_SCOPE_PROCESS_IDS) == 20  # 8 surface + 12 raster ids
+    # Raster ids are disjoint from the direct-execution vector allowlist.
+    from honua_sdk.geoprocessing import LAYER_SCOPE_PROCESS_IDS
+
+    assert RASTER_SCOPE_PROCESS_IDS.isdisjoint(LAYER_SCOPE_PROCESS_IDS)
+
+
+def test_raster_reference_from_geotiff_bytes() -> None:
+    ref = RasterReference.from_geotiff_bytes(b"II*\x00fake")
+    assert ref.kind == "source"
+    assert ref.to_inputs() == {"source": base64.b64encode(b"II*\x00fake").decode("ascii")}
+
+
+def test_raster_reference_from_layer_id() -> None:
+    assert RasterReference.from_layer_id("dem-1").to_inputs() == {"layerId": "dem-1"}
+
+
+def test_raster_reference_from_raster_id() -> None:
+    assert RasterReference.from_raster_id("r-42").to_inputs() == {"rasterId": "r-42"}
+
+
+def test_raster_reference_requires_exactly_one_carrier() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        RasterReference(kind="source", source_base64="AA==", layer_id="dem-1")
+    with pytest.raises(ValueError, match="exactly one"):
+        RasterReference(kind="source")
+
+
+def test_raster_reference_from_geotiff_bytes_type_checked() -> None:
+    with pytest.raises(TypeError):
+        RasterReference.from_geotiff_bytes("not-bytes")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Plan-wrapped submission body
+# ---------------------------------------------------------------------------
+
+
+def _capture_execution() -> tuple[list[dict[str, Any]], "httpx.MockTransport"]:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST":
+            assert path == f"/ogc/processes/processes/{CANONICAL_PROCESS_ID}/execution"
+            captured.append(json.loads(request.content))
+            return httpx.Response(201, json=_status("job-1", "accepted"))
+        if path == "/ogc/processes/jobs/job-1":
+            return httpx.Response(200, json=_status("job-1", "successful"))
+        if path == "/ogc/processes/jobs/job-1/results":
+            return httpx.Response(200, json={})
+        raise AssertionError(f"unexpected {path}")
+
+    return captured, httpx.MockTransport(handler)
+
+
+def test_submit_raster_process_wraps_into_canonical_plan() -> None:
+    captured, transport = _capture_execution()
+    raster = RasterReference.from_layer_id("dem-1")
+
+    with HonuaClient("http://example.test", transport=transport) as client:
+        client.geoprocessing().submit_raster_process(
+            "surface.slope",
+            raster,
+            parameters={"units": "degrees"},
+            plan_id="plan-slope",
+        )
+
+    assert captured == [
+        {
+            "inputs": {
+                "plan": {
+                    "planId": "plan-slope",
+                    "steps": [
+                        {
+                            "stepId": "s1",
+                            "kind": "geoprocess",
+                            "processId": "surface.slope",
+                            "inputs": {"layerId": "dem-1", "units": "degrees"},
+                        }
+                    ],
+                }
+            },
+            "response": "document",
+        }
+    ]
+
+
+def test_execute_raster_process_wraps_source_bytes() -> None:
+    captured, transport = _capture_execution()
+    raster = RasterReference.from_geotiff_bytes(b"II*\x00dem")
+
+    with HonuaClient("http://example.test", transport=transport) as client:
+        result = client.geoprocessing().execute_raster_process(
+            "surface.slope",
+            raster,
+            parameters={"units": "degrees", "zFactor": 2},
+            plan_id="plan-x",
+            poll_interval=0.0,
+        )
+
+    assert result == {}
+    step = captured[0]["inputs"]["plan"]["steps"][0]
+    assert step["processId"] == "surface.slope"
+    assert step["inputs"]["source"] == base64.b64encode(b"II*\x00dem").decode("ascii")
+    # Non-string parameters are canonicalized to strings, like the vector path.
+    assert step["inputs"]["units"] == "degrees"
+    assert step["inputs"]["zFactor"] == "2"
+
+
+def test_execute_raster_process_with_zones_base64_geojson() -> None:
+    captured, transport = _capture_execution()
+    raster = RasterReference.from_layer_id("dem-1")
+    zones_fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "properties": {"id": "z0"}, "geometry": {"type": "Polygon", "coordinates": []}}
+        ],
+    }
+    zones = LayerReference.from_geojson(zones_fc)
+
+    with HonuaClient("http://example.test", transport=transport) as client:
+        client.geoprocessing().execute_raster_process(
+            "raster.zonal-statistics",
+            raster,
+            zones=zones,
+            parameters={"statistics": "mean,count", "band": 1},
+            plan_id="plan-zonal",
+            poll_interval=0.0,
+        )
+
+    inputs = captured[0]["inputs"]["plan"]["steps"][0]["inputs"]
+    assert inputs["layerId"] == "dem-1"
+    # zones ride as a *base64-encoded* GeoJSON FeatureCollection under ``zones``.
+    decoded = json.loads(base64.b64decode(inputs["zones"]).decode("utf-8"))
+    assert decoded == zones_fc
+    assert inputs["statistics"] == "mean,count"
+    assert inputs["band"] == "1"
+
+
+def test_zones_must_be_inline_geojson() -> None:
+    _, transport = _capture_execution()
+    raster = RasterReference.from_layer_id("dem-1")
+    zones = LayerReference.from_query_result("qr-1")
+
+    with HonuaClient("http://example.test", transport=transport) as client:
+        with pytest.raises(ValueError, match="inline-GeoJSON"):
+            client.geoprocessing().execute_raster_process(
+                "raster.zonal-statistics", raster, zones=zones, poll_interval=0.0
+            )
+
+
+def test_default_plan_id_is_generated_and_unique() -> None:
+    captured, transport = _capture_execution()
+    raster = RasterReference.from_layer_id("dem-1")
+
+    with HonuaClient("http://example.test", transport=transport) as client:
+        client.geoprocessing().submit_raster_process("surface.aspect", raster)
+
+    plan_id = captured[0]["inputs"]["plan"]["planId"]
+    assert plan_id.startswith("raster-surface.aspect-")
+
+
+# ---------------------------------------------------------------------------
+# results_kind + kind-routed consumption
+# ---------------------------------------------------------------------------
+
+
+def _raster_results() -> dict[str, Any]:
+    encoded = base64.b64encode(_tiny_geotiff()).decode("ascii")
+    return {
+        "slope": {
+            "id": "artifact-slope",
+            "kind": "Raster",
+            "title": "Slope",
+            "href": f"data:image/tiff; application=geotiff;base64,{encoded}",
+            "type": "image/tiff; application=geotiff",
+        }
+    }
+
+
+_CONTOUR_FC = {
+    "type": "FeatureCollection",
+    "features": [
+        {"type": "Feature", "properties": {"elev": 100}, "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]}}
+    ],
+}
+
+
+def _featurelayer_results() -> dict[str, Any]:
+    encoded = base64.b64encode(json.dumps(_CONTOUR_FC).encode("utf-8")).decode("ascii")
+    return {
+        "contour": {
+            "id": "artifact-contour",
+            "kind": "FeatureLayer",
+            "title": "Contour vector",
+            "href": f"data:application/geo+json;base64,{encoded}",
+            "type": "application/geo+json",
+        }
+    }
+
+
+_ZONAL_TABLE = {
+    "kind": "raster.zonal-statistics",
+    "band": 1,
+    "statistics": ["mean", "count"],
+    "zones": [
+        {"zoneIndex": 0, "zoneId": "0", "mean": 12.5, "count": 40},
+        {"zoneIndex": 1, "zoneId": "1", "mean": 7.0, "count": 12},
+    ],
+}
+
+
+def _table_results() -> dict[str, Any]:
+    encoded = base64.b64encode(json.dumps(_ZONAL_TABLE).encode("utf-8")).decode("ascii")
+    return {
+        "zonalStatistics": {
+            "id": "artifact-zonal",
+            "kind": "Table",
+            "title": "Zonal statistics",
+            "href": f"data:application/json;base64,{encoded}",
+            "type": "application/json",
+        }
+    }
+
+
+_SCALAR = {"kind": "raster.statistics", "band": 1, "mean": 3.5, "min": 0.0, "max": 11.0}
+
+
+def _scalar_results() -> dict[str, Any]:
+    encoded = base64.b64encode(json.dumps(_SCALAR).encode("utf-8")).decode("ascii")
+    return {
+        "statistics": {
+            "id": "artifact-stats",
+            "kind": "Scalar",
+            "title": "Statistics",
+            "href": f"data:application/json;base64,{encoded}",
+            "type": "application/json",
+        }
+    }
+
+
+def test_results_kind_for_each_artifact_kind() -> None:
+    assert results_kind(_raster_results()) == "Raster"
+    assert results_kind(_featurelayer_results()) == "FeatureLayer"
+    assert results_kind(_table_results()) == "Table"
+    assert results_kind(_scalar_results()) == "Scalar"
+    # A bare pass-through FeatureCollection declares no kind.
+    assert results_kind({"type": "FeatureCollection", "features": []}) is None
+
+
+def _client() -> HonuaClient:
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    return HonuaClient("http://example.test", transport=httpx.MockTransport(handler))
+
+
+def test_consume_result_table_returns_json() -> None:
+    with _client() as client:
+        value = client.geoprocessing().consume_result(_table_results())
+    assert value == _ZONAL_TABLE
+    assert value["zones"][0]["mean"] == 12.5
+
+
+def test_consume_result_scalar_returns_json() -> None:
+    with _client() as client:
+        value = client.geoprocessing().consume_result(_scalar_results())
+    assert value == _SCALAR
+
+
+def test_consume_result_featurelayer_returns_geodataframe() -> None:
+    pytest.importorskip("geopandas")
+    with _client() as client:
+        gdf = client.geoprocessing().consume_result(_featurelayer_results())
+    assert len(gdf) == 1
+    assert list(gdf["elev"]) == [100]
+
+
+def test_consume_result_raster_returns_xarray() -> None:
+    pytest.importorskip("rioxarray")
+    with _client() as client:
+        array = client.geoprocessing().consume_result(_raster_results())
+    assert array.shape == (1, 3, 4)
+    assert float(array.sum()) == pytest.approx(66.0)
+
+
+def test_result_raster_bytes_decodes_data_uri_href() -> None:
+    pytest.importorskip("rasterio")
+    with _client() as client:
+        data = client.geoprocessing().result_raster_bytes(_raster_results())
+    assert data == _tiny_geotiff()
+
+
+def test_consume_result_unknown_kind_sniffs_json() -> None:
+    # A member with a kind the SDK does not special-case, but a JSON payload.
+    encoded = base64.b64encode(json.dumps({"answer": 42}).encode("utf-8")).decode("ascii")
+    results = {"out": {"id": "x", "kind": "Table", "href": f"data:application/json;base64,{encoded}"}}
+    with _client() as client:
+        assert client.geoprocessing().consume_result(results) == {"answer": 42}
+
+
+# ---------------------------------------------------------------------------
+# Async parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_async_execute_raster_process_wraps_plan() -> None:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST":
+            captured.append(json.loads(request.content))
+            return httpx.Response(201, json=_status("job-a", "accepted"))
+        if path == "/ogc/processes/jobs/job-a":
+            return httpx.Response(200, json=_status("job-a", "successful"))
+        if path == "/ogc/processes/jobs/job-a/results":
+            return httpx.Response(200, json=_scalar_results())
+        raise AssertionError(f"unexpected {path}")
+
+    raster = RasterReference.from_raster_id("r-1")
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gp = client.geoprocessing()
+        result = await gp.execute_raster_process(
+            "raster.statistics", raster, plan_id="plan-a", poll_interval=0.0
+        )
+        value = await gp.consume_result(result)
+
+    step = captured[0]["inputs"]["plan"]["steps"][0]
+    assert step == {
+        "stepId": "s1",
+        "kind": "geoprocess",
+        "processId": "raster.statistics",
+        "inputs": {"rasterId": "r-1"},
+    }
+    assert value == _SCALAR
+
+
+@pytest.mark.anyio
+async def test_async_consume_result_featurelayer() -> None:
+    pytest.importorskip("geopandas")
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - no fetch expected
+        raise AssertionError(f"unexpected fetch {request.url}")
+
+    async with AsyncHonuaClient("http://example.test", transport=httpx.MockTransport(handler)) as client:
+        gdf = await client.geoprocessing().consume_result(_featurelayer_results())
+
+    assert len(gdf) == 1
+    assert list(gdf["elev"]) == [100]


### PR DESCRIPTION
## What

Adds first-class support for submitting a **raster as an input** to an OGC API Processes geoprocessing job. Previously `geoprocessing.py` could only consume raster *output*; there was no way to send a raster *in*, nor any awareness that raster/surface process ids need special routing.

### New public surface (`honua_sdk.geoprocessing`)

- **`RasterReference`** — frozen dataclass mirroring `LayerReference`:
  - `from_geotiff_bytes(data)` → base64 `source` (what the GDAL worker reads at execution)
  - `from_layer_id(layer_id)` → `layerId` (server pre-resolved)
  - `from_raster_id(raster_id)` → `rasterId` (server pre-resolved)
  - exactly-one-carrier validation, `to_inputs()` projecting to the single flat param.
- **`RASTER_SCOPE_PROCESS_IDS`** — the 20 raster/surface ids (8 `surface.*` + 12 `raster.*`), disjoint from `LAYER_SCOPE_PROCESS_IDS`.
- **`submit_raster_process` / `execute_raster_process`** (sync + async) — accept `process_id`, a `RasterReference`, optional `zones: LayerReference` (for `raster.zonal-statistics`), and `parameters`. Because every raster id **404s on direct execution**, the call is **transparently auto-wrapped** as a single `geoprocess` step inside the canonical `honua-geoprocessing` `plan` and submitted through the existing `submit_plan`/`execute_plan` machinery. Callers never see the plan wrapping.
- **`results_kind(results)`** + **`consume_result(results)`** — route by `ArtifactKind`: `Raster` → xarray, `FeatureLayer` → GeoDataFrame, `Table`/`Scalar` → parsed JSON. A caller can consume `execute_raster_process(...)` output without knowing the kind a given process produces.

### Ground-truth wire shapes honored

- Raster input = one flat string param (`source`/`layerId`/`rasterId`), mutually exclusive.
- `zones` = **base64-encoded GeoJSON FeatureCollection** under the flat `zones` param (matches `GdalRasterZonalStatisticsJobExecutor` → `TryGetBase64Input`), which is a *different* shape from a vector process's `inputGeoJson` — so zones are encoded here rather than via `LayerReference.to_inputs()`.
- Plan-wrap shape matches the real `OgcProcessesExecutionSubmissionTests` fixture: `{"inputs":{"plan":{"planId":..,"steps":[{"stepId":"s1","kind":"geoprocess","processId":..,"inputs":{..}}]}}}`.
- honua-server publishes raster/table/scalar/feature-layer artifacts as `data:` URIs (`GdalDataUri.Build`). `result_raster_bytes` now **decodes a `data:` URI `href` inline** instead of trying to HTTP-fetch it, and `consume_result` decodes the `data:` JSON payloads for Table/Scalar/FeatureLayer.

## Tests

- New `tests/test_geoprocessing_raster_input.py`: `RasterReference.to_inputs()` for all three kinds + mutual-exclusivity; the **exact** plan-wrapped JSON body captured from a mocked transport; `zones` base64 encoding; `results_kind` and `consume_result` for all four `ArtifactKind`s using representative result documents; sync + async parity.
- Full suite: **1390 passed, 1 skipped**.
- `ruff` and `mypy` clean on the changed module.

## Live-Docker verification (partial — honest)

Brought up the seeded `honua-server` client-compat compose stack (nightly-aot image) locally and exercised the real OGC Processes surface with API-key auth:

- **Vector plan execution works end-to-end** (a `geometry.buffer` plan step goes `accepted` → `successful`), confirming the in-process job pipeline.
- **Both `surface.slope` and `raster.zonal-statistics` submissions pass server-side catalog validation and enqueue** (status `accepted`) — a real confirmation that the SDK's plan-wrapped submission shape, `processId` routing, base64 `source` raster input, and base64 `zones` input are all accepted by the live server.
- **Raster/surface jobs could not be driven to completion**: this honua image ships **no GDAL worker**, so raster jobs sit at `accepted` indefinitely (vector jobs complete; raster jobs never leave the queue). I did **not** get real xarray/Table output back from a live raster job, so I am not claiming that. Executing raster/surface tools live would require deploying the `Honua.Worker.Gdal` worker, which is out of scope here. The Raster→xarray, FeatureLayer→GeoDataFrame, and Table/Scalar→JSON consumption paths are covered by unit tests against the documented real result-document shapes.

Do not merge — two other PRs depend on this landing first; a reviewer will merge after review.