### PR TITLE
feat(migration): codemod rules for honua_gp.sa raster/Spatial Analyst tools

### DIFF
--- a/packages/honua-sdk/honua_sdk/migration/arcpy.py
+++ b/packages/honua-sdk/honua_sdk/migration/arcpy.py
@@ -1154,6 +1154,18 @@ def _register_raster(
     args: tuple[_ArgSpec, ...],
     aliases: Mapping[str, str] | None = None,
 ) -> None:
+    """Register one raster tool spec.
+
+    ``args`` MUST list the tool's real arcpy positional signature in order so a
+    positional argument binds to the correct honua input/output. In particular,
+    only a positional that is genuinely an arcpy output dataset may carry
+    ``kind="output"`` -- most Spatial Analyst raster tools return a ``Raster``
+    and have NO output positional, and honua-server's raster processes take no
+    output-path input at all (their result is an artifact). A positional that is
+    a required input (e.g. Viewshed's observer features) or a non-output flag
+    (e.g. Reclassify's ``missing_values``) must never be slotted as an output.
+    """
+
     # The honua_gp migration target is derived from the namespace: the four
     # raster Data Management tools live under honua_gp.management, every other
     # (Spatial Analyst) tool under honua_gp.sa.
@@ -1177,31 +1189,36 @@ _register_raster(
     "spatial-analyst",
     "Slope",
     "surface.slope",
+    # arcpy: Slope(in_raster, {output_measurement}, {z_factor}, ...) -> Raster.
+    # No output positional (the raster is the return value).
     args=(
         _arg("in_raster", "source", kind="input"),
         _arg("output_measurement", "units"),
         _arg("z_factor", "zFactor"),
     ),
-    aliases=_aliases(("units", "units"), ("output", "result")),
+    aliases=_aliases(("output_measurement", "units"), ("z_factor", "zFactor")),
 )
 _register_raster(
     "spatial-analyst",
     "Aspect",
     "surface.aspect",
     args=(_arg("in_raster", "source", kind="input"),),
-    aliases=_aliases(("output", "result")),
 )
 _register_raster(
     "spatial-analyst",
     "Hillshade",
     "surface.hillshade",
+    # arcpy: Hillshade(in_raster, {azimuth}, {altitude}, {model_shadows},
+    # {z_factor}) -> Raster. model_shadows sits between altitude and z_factor;
+    # it must occupy positional 3 so a positional z_factor lands in slot 4.
     args=(
         _arg("in_raster", "source", kind="input"),
         _arg("azimuth", "azimuth"),
         _arg("altitude", "altitude"),
+        _arg("model_shadows", "modelShadows"),
         _arg("z_factor", "zFactor"),
     ),
-    aliases=_aliases(("output", "result")),
+    aliases=_aliases(("z_factor", "zFactor")),
 )
 _register_raster(
     "spatial-analyst",
@@ -1219,44 +1236,44 @@ _register_raster(
     "spatial-analyst",
     "Viewshed",
     "surface.viewshed",
+    # arcpy: Viewshed(in_raster, in_observer_features, {out_agl_raster},
+    # {z_factor}, ...) -> visibility Raster. Positional 1 is the REQUIRED
+    # observer feature INPUT (not an output); honua-server's surface.viewshed
+    # instead wants observerX/observerY coordinates, so the observer dataset is
+    # surfaced as an input the migration must convert -- never as an output.
     args=(
         _arg("in_raster", "source", kind="input"),
-        _arg("out_raster", "result", kind="output"),
+        _arg("in_observer_features", "observerFeatures", kind="input"),
+        _arg("out_agl_raster", "result", kind="output"),
+        _arg("z_factor", "zFactor"),
     ),
-    aliases=_aliases(("output", "result")),
+    aliases=_aliases(("out_agl_raster", "result")),
 )
+# Roughness / TPI / TRI have no faithful standalone arcpy GP tool (honua_gp.sa
+# exposes them as surface derivatives) -- their only input is the source raster
+# plus a keyword window_radius, and they return a Raster, so there is NO output
+# positional to model. Mapping a positional to an output here would wrongly
+# claim slot 1 is an output path.
 _register_raster(
     "spatial-analyst",
     "Roughness",
     "surface.roughness",
-    args=(
-        _arg("in_raster", "source", kind="input"),
-        _arg("out_raster", "result", kind="output"),
-        _arg("neighborhood", "windowRadius"),
-    ),
-    aliases=_aliases(("window_radius", "windowRadius"), ("output", "result")),
+    args=(_arg("in_raster", "source", kind="input"),),
+    aliases=_aliases(("window_radius", "windowRadius"), ("neighborhood", "windowRadius")),
 )
 _register_raster(
     "spatial-analyst",
     "TPI",
     "surface.rugosity-tpi",
-    args=(
-        _arg("in_raster", "source", kind="input"),
-        _arg("out_raster", "result", kind="output"),
-        _arg("window_radius", "windowRadius"),
-    ),
-    aliases=_aliases(("output", "result")),
+    args=(_arg("in_raster", "source", kind="input"),),
+    aliases=_aliases(("window_radius", "windowRadius")),
 )
 _register_raster(
     "spatial-analyst",
     "TRI",
     "surface.rugosity-tri",
-    args=(
-        _arg("in_raster", "source", kind="input"),
-        _arg("out_raster", "result", kind="output"),
-        _arg("window_radius", "windowRadius"),
-    ),
-    aliases=_aliases(("output", "result")),
+    args=(_arg("in_raster", "source", kind="input"),),
+    aliases=_aliases(("window_radius", "windowRadius")),
 )
 
 # -- Raster tools -- arcpy.sa.* --------------------------------------------
@@ -1264,50 +1281,69 @@ _register_raster(
     "spatial-analyst",
     "Reclassify",
     "raster.reclassify",
+    # arcpy: Reclassify(in_raster, reclass_field, remap, {missing_values}) ->
+    # Raster. Positional 3 is missing_values (a DATA/NODATA flag), NOT an output
+    # path -- the tool returns its raster, so there is no output positional.
     args=(
         _arg("in_raster", "source", kind="input"),
-        _arg("reclass_field", "field"),
+        _arg("reclass_field", "reclassField"),
         _arg("remap", "remap"),
-        _arg("out_raster", "result", kind="output"),
-        _arg("missing_values", "noData"),
+        _arg("missing_values", "missingValues"),
     ),
-    aliases=_aliases(("output", "result")),
+    aliases=_aliases(("remap", "remap")),
 )
 _register_raster(
     "spatial-analyst",
     "RasterCalculator",
     "raster.map-algebra",
+    # arcpy: RasterCalculator(rasters, input_names, expression, {output_raster},
+    # ...). Positional 0 is the raster LIST (-> honua-server 'sources'),
+    # positional 1 the band-variable names, positional 2 the expression, and
+    # only positional 3 (output_raster) is the output. The earlier template
+    # mis-slotted the raster list as the expression and input_names as output.
     args=(
+        _arg("rasters", "sources", kind="input"),
+        _arg("input_names", "inputNames"),
         _arg("expression", "expression"),
         _arg("output_raster", "result", kind="output"),
     ),
-    aliases=_aliases(("output", "result")),
+    aliases=_aliases(("expression", "expression"), ("output_raster", "result")),
 )
 _register_raster(
     "spatial-analyst",
     "Idw",
     "raster.interpolate-idw",
+    # arcpy: Idw(in_point_features, z_field, {cell_size}, {power},
+    # {search_radius}, ...) -> Raster. Positional 2 is cell_size (honua-server
+    # sizes output via width/height, so it is a passthrough parameter), NOT an
+    # output path -- the tool returns its raster, so there is no output slot.
     args=(
         _arg("in_point_features", "points", kind="input"),
         _arg("z_field", "zField"),
-        _arg("out_raster", "result", kind="output"),
+        _arg("cell_size", "cellSize"),
         _arg("power", "power"),
         _arg("search_radius", "radius"),
     ),
-    aliases=_aliases(("radius", "radius"), ("output", "result")),
+    aliases=_aliases(("radius", "radius"), ("search_radius", "radius")),
 )
 _register_raster(
     "spatial-analyst",
     "ZonalStatisticsAsTable",
     "raster.zonal-statistics",
+    # arcpy: ZonalStatisticsAsTable(in_zone_data, zone_field, in_value_raster,
+    # out_table, {ignore_nodata}, {statistics_type}, ...). Positional 3
+    # (out_table) is the only output; ignore_nodata sits at slot 4 and
+    # statistics_type at slot 5, so a positional statistics_type must not land
+    # in the ignore_nodata slot.
     args=(
         _arg("in_zone_data", "zones", kind="input"),
         _arg("zone_field", "zoneField"),
         _arg("in_value_raster", "source", kind="input"),
         _arg("out_table", "result", kind="output"),
+        _arg("ignore_nodata", "ignoreNoData"),
         _arg("statistics_type", "statistics"),
     ),
-    aliases=_aliases(("statistics", "statistics"), ("output", "result")),
+    aliases=_aliases(("statistics_type", "statistics"), ("out_table", "result")),
 )
 
 # -- Raster Data Management tools -- arcpy.management.* ---------------------
@@ -1339,13 +1375,15 @@ _register_raster(
     "management",
     "Clip",
     "raster.clip",
+    # arcpy: Clip(in_raster, rectangle, out_raster, {in_template_dataset}, ...).
+    # rectangle (extent) is a parameter, out_raster (slot 2) is the output, and
+    # in_template_dataset (slot 3) is the optional cutline INPUT.
     args=(
         _arg("in_raster", "source", kind="input"),
-        _arg("rectangle", "envelope"),
+        _arg("rectangle", "rectangle"),
         _arg("out_raster", "result", kind="output"),
         _arg("in_template_dataset", "boundary", kind="input"),
     ),
-    aliases=_aliases(("output", "result")),
 )
 _register_raster(
     "management",

--- a/packages/honua-sdk/honua_sdk/migration/arcpy.py
+++ b/packages/honua-sdk/honua_sdk/migration/arcpy.py
@@ -1100,6 +1100,264 @@ _register(
     )
 )
 
+# ---------------------------------------------------------------------------
+# Raster / Spatial Analyst tools (honua-sdk-python raster codemod).
+#
+# PR #175 added ``honua_gp.sa`` -- an ``arcpy.sa``-style surface wrapping
+# honua-server's raster/surface GDAL-worker processes (and re-exporting the four
+# raster Data Management tools under ``honua_gp.management``). This block teaches
+# the codemod to recognize the arcpy raster tools those 16 working wrappers
+# cover and to map each onto its honua-server raster process id + honua_gp.sa
+# migration target.
+#
+# HONEST-CLASSIFICATION CONTRACT: raster/surface process ids 404 on *direct* OGC
+# API Processes execution -- ``honua_gp.sa`` auto-wraps each as a ``geoprocess``
+# step inside the canonical ``honua-geoprocessing`` plan before submitting. They
+# are therefore NOT part of the reconciled server's job-executable catalog
+# (:data:`EXECUTABLE_PROCESS_IDS`), so every raster spec below is registered
+# WITHOUT a ``job_process_id`` and classifies as ``"manual-review"``: the codemod
+# recognizes the tool and names its ``honua_gp.sa`` migration target, but never
+# claims a bare-OGC server-runnable migration. This mirrors ``honua_gp._compat``,
+# where these same 16 tools are ``supported``/``partial``.
+#
+# The three ``honua_gp.sa`` STUBS -- Kriging, Histogram, SpectralIndex -- are
+# DELIBERATELY left unregistered so they classify as ``"unsupported"`` (no
+# mapping). ``honua_gp.sa.Kriging`` / ``Histogram`` / ``SpectralIndex`` raise
+# ``HonuaGpUnsupportedError`` at runtime because honua-server never produces
+# output for them, so mapping them -- even as manual-review -- would emit a
+# translation payload for a guaranteed-failing call: exactly the overclaim #175
+# guarded against when it reclassified Kriging to a stub. Kriging users should
+# migrate to ``honua_gp.sa.Idw`` (a working IDW interpolation) instead; surfacing
+# Kriging as unsupported reports the gap at translation time rather than
+# deferring a guaranteed runtime failure.
+# ---------------------------------------------------------------------------
+
+
+def _raster_notes(honua_target: str, process_id: str) -> tuple[str, ...]:
+    """Standard manual-review note naming the honua_gp.sa migration target."""
+
+    return (
+        f"Raster/Spatial Analyst tool: migrate to {honua_target} (honua-server "
+        f"{process_id!r}), which runs the raster process as a geoprocess step "
+        "inside the honua-geoprocessing plan. Raster process ids 404 on direct "
+        "OGC API Processes execution and are not in the reconciled server's "
+        "job-executable catalog, so this stays manual-review -- recognized and "
+        "mapped to a honua_gp.sa target, never claimed as a bare-OGC "
+        "server-runnable migration.",
+    )
+
+
+def _register_raster(
+    family: str,
+    tool: str,
+    process_id: str,
+    args: tuple[_ArgSpec, ...],
+    aliases: Mapping[str, str] | None = None,
+) -> None:
+    # The honua_gp migration target is derived from the namespace: the four
+    # raster Data Management tools live under honua_gp.management, every other
+    # (Spatial Analyst) tool under honua_gp.sa.
+    surface = "management" if family == "management" else "sa"
+    honua_target = f"honua_gp.{surface}.{tool}"
+    _register(
+        _ToolSpec(
+            family=family,
+            tool=tool,
+            process_id=process_id,
+            # No job_process_id: raster ids are not bare-OGC job-executable.
+            args=args,
+            aliases=dict(aliases) if aliases else {},
+            notes=_raster_notes(honua_target, process_id),
+        )
+    )
+
+
+# -- Surface (DEM-derived) tools -- arcpy.sa.* -----------------------------
+_register_raster(
+    "spatial-analyst",
+    "Slope",
+    "surface.slope",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("output_measurement", "units"),
+        _arg("z_factor", "zFactor"),
+    ),
+    aliases=_aliases(("units", "units"), ("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "Aspect",
+    "surface.aspect",
+    args=(_arg("in_raster", "source", kind="input"),),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "Hillshade",
+    "surface.hillshade",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("azimuth", "azimuth"),
+        _arg("altitude", "altitude"),
+        _arg("z_factor", "zFactor"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "Contour",
+    "surface.contour",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_polyline_features", "result", kind="output"),
+        _arg("contour_interval", "interval"),
+        _arg("base_contour", "base"),
+    ),
+    aliases=_aliases(("interval", "interval"), ("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "Viewshed",
+    "surface.viewshed",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_raster", "result", kind="output"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "Roughness",
+    "surface.roughness",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("neighborhood", "windowRadius"),
+    ),
+    aliases=_aliases(("window_radius", "windowRadius"), ("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "TPI",
+    "surface.rugosity-tpi",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("window_radius", "windowRadius"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "TRI",
+    "surface.rugosity-tri",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("window_radius", "windowRadius"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+
+# -- Raster tools -- arcpy.sa.* --------------------------------------------
+_register_raster(
+    "spatial-analyst",
+    "Reclassify",
+    "raster.reclassify",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("reclass_field", "field"),
+        _arg("remap", "remap"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("missing_values", "noData"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "RasterCalculator",
+    "raster.map-algebra",
+    args=(
+        _arg("expression", "expression"),
+        _arg("output_raster", "result", kind="output"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "Idw",
+    "raster.interpolate-idw",
+    args=(
+        _arg("in_point_features", "points", kind="input"),
+        _arg("z_field", "zField"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("power", "power"),
+        _arg("search_radius", "radius"),
+    ),
+    aliases=_aliases(("radius", "radius"), ("output", "result")),
+)
+_register_raster(
+    "spatial-analyst",
+    "ZonalStatisticsAsTable",
+    "raster.zonal-statistics",
+    args=(
+        _arg("in_zone_data", "zones", kind="input"),
+        _arg("zone_field", "zoneField"),
+        _arg("in_value_raster", "source", kind="input"),
+        _arg("out_table", "result", kind="output"),
+        _arg("statistics_type", "statistics"),
+    ),
+    aliases=_aliases(("statistics", "statistics"), ("output", "result")),
+)
+
+# -- Raster Data Management tools -- arcpy.management.* ---------------------
+_register_raster(
+    "management",
+    "ProjectRaster",
+    "raster.reproject",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("out_coor_system", "targetSrid"),
+        _arg("resampling_type", "resampling"),
+    ),
+    aliases=_aliases(("resampling", "resampling"), ("output", "result")),
+)
+_register_raster(
+    "management",
+    "Resample",
+    "raster.resample",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("cell_size", "cellSize"),
+        _arg("resampling_type", "resampling"),
+    ),
+    aliases=_aliases(("resampling", "resampling"), ("output", "result")),
+)
+_register_raster(
+    "management",
+    "Clip",
+    "raster.clip",
+    args=(
+        _arg("in_raster", "source", kind="input"),
+        _arg("rectangle", "envelope"),
+        _arg("out_raster", "result", kind="output"),
+        _arg("in_template_dataset", "boundary", kind="input"),
+    ),
+    aliases=_aliases(("output", "result")),
+)
+_register_raster(
+    "management",
+    "Mosaic",
+    "raster.mosaic",
+    args=(
+        _arg("inputs", "sources", kind="input"),
+        _arg("target", "target", kind="input"),
+    ),
+    aliases=_aliases(("in_rasters", "sources"), ("mosaic_operator", "operator")),
+)
+
 _PAIRWISE_TOOL_ALIASES = {
     ("analysis", "pairwisebuffer"): ("analysis", "buffer"),
     ("analysis", "pairwiseclip"): ("analysis", "clip"),
@@ -1157,6 +1415,11 @@ _CORE_FUNCTION_FAMILIES: Mapping[str, str] = {
     "ListFeatureClasses": "catalog",
     "ListFields": "catalog",
     "ListRasters": "catalog",
+    # Raster Data Management tools also appear as un-suffixed bare calls
+    # (arcpy.ProjectRaster / arcpy.Resample). Map those to the management
+    # family so they resolve to the raster.reproject / raster.resample specs.
+    "ProjectRaster": "management",
+    "Resample": "management",
     "SetParameter": "parameters",
     "SetParameterAsText": "parameters",
 }

--- a/tests/test_arcpy_migration.py
+++ b/tests/test_arcpy_migration.py
@@ -30,7 +30,7 @@ mgmt.Project("roads_clip", "roads_wgs84", 4326)
 ap.management.SelectLayerByAttribute("roads_layer", "NEW_SELECTION", "STATUS = 'OPEN'")
 with ap.da.SearchCursor("roads", ["OID@", "STATUS"]) as rows:
     pass
-ap.sa.Slope("elevation")
+ap.sa.Kriging("stations", "PredZ")
 """
 
 
@@ -43,7 +43,7 @@ def test_scan_arcpy_source_classifies_aliases_legacy_tools_and_unsupported_calls
         ("arcpy.management.Project", "management", "Project", True),
         ("arcpy.management.SelectLayerByAttribute", "management", "SelectLayerByAttribute", True),
         ("arcpy.da.SearchCursor", "data-access", "SearchCursor", False),
-        ("arcpy.sa.Slope", "spatial-analyst", "Slope", False),
+        ("arcpy.sa.Kriging", "spatial-analyst", "Kriging", False),
     ]
     assert report.calls[0].args == ("roads", "roads_buffer", "25 Meters")
     assert report.calls[0].kwargs == {"dissolve_option": "ALL"}

--- a/tests/test_arcpy_migration_cli.py
+++ b/tests/test_arcpy_migration_cli.py
@@ -8,13 +8,13 @@ from pathlib import Path
 from honua_sdk.migration._cli import main
 
 # Buffer -> translatable (geometry.buffer); Erase -> manual-review
-# (feature-class-vs-single-geometry semantics, honua-server#1228); Slope ->
-# unsupported (no mapping).
+# (feature-class-vs-single-geometry semantics, honua-server#1228); Kriging ->
+# unsupported (an honest honua_gp.sa stub with no working mapping).
 SCRIPT = """
 import arcpy
 arcpy.analysis.Buffer("roads", "roads_buffer", "25 Meters")
 arcpy.analysis.Erase("a", "b", "c")
-arcpy.sa.Slope("dem")
+arcpy.sa.Kriging("stations", "PredZ")
 """
 
 PYT = '''
@@ -57,7 +57,7 @@ def test_cli_scan_writes_classified_report(tmp_path: Path) -> None:
     statuses = {(c["tool"], c["status"]) for c in report["calls"]}
     assert ("Buffer", "translatable") in statuses
     assert ("Erase", "manual-review") in statuses
-    assert ("Slope", "unsupported") in statuses
+    assert ("Kriging", "unsupported") in statuses
     assert report["translatableCount"] == 1
     assert report["manualReviewCount"] == 1
     assert report["unsupportedCount"] == 1

--- a/tests/test_arcpy_migration_coverage_uplift.py
+++ b/tests/test_arcpy_migration_coverage_uplift.py
@@ -103,7 +103,7 @@ class TestSerializers:
 
     def test_migration_plan_to_dict(self) -> None:
         plan = translate_arcpy_source(
-            "import arcpy\narcpy.analysis.Buffer('a', 'b', '1 Meter')\narcpy.sa.Slope('dem')\n",
+            "import arcpy\narcpy.analysis.Buffer('a', 'b', '1 Meter')\narcpy.sa.Kriging('pts', 'z')\n",
         )
         as_dict = plan.to_dict()
         assert as_dict["report"]["supportedCount"] == 1
@@ -249,9 +249,9 @@ class TestTranslator:
     def test_translate_unsupported_call_raises(self) -> None:
         # Manually build a call that is NOT supported and not aliased.
         unsupported = ArcPyCall(
-            qualified_name="arcpy.sa.Slope",
+            qualified_name="arcpy.sa.Kriging",
             family="spatial-analyst",
-            tool="Slope",
+            tool="Kriging",
             line=1,
             column=0,
         )
@@ -274,9 +274,9 @@ def test_translate_call_unsupported_raises() -> None:
     from honua_sdk.migration.arcpy import _translate_call
 
     unsupported = ArcPyCall(
-        qualified_name="arcpy.sa.Slope",
+        qualified_name="arcpy.sa.Kriging",
         family="spatial-analyst",
-        tool="Slope",
+        tool="Kriging",
         line=1,
         column=0,
     )

--- a/tests/test_arcpy_migration_evidence.py
+++ b/tests/test_arcpy_migration_evidence.py
@@ -21,7 +21,7 @@ from honua_sdk.migration import (
 # an executable managed analytics target (spatial-join, one-to-one form), a
 # known-but-not-job-executable target (Erase -> manual-review due to
 # feature-class-vs-single-geometry semantics), and a wholly unmapped tool
-# (sa.Slope).
+# (sa.Kriging, an honest honua_gp.sa stub with no working mapping).
 MIXED_SOURCE = """
 import arcpy
 
@@ -31,7 +31,7 @@ arcpy.management.Dissolve("rb", "rb_d", "CLASS")
 arcpy.management.RepairGeometry("rb_d")
 arcpy.analysis.SpatialJoin("a", "b", "joined")
 arcpy.analysis.Erase("a", "b", "c")
-arcpy.sa.Slope("dem")
+arcpy.sa.Kriging("stations", "PredZ")
 """
 
 
@@ -106,8 +106,8 @@ def test_status_partitions_into_translatable_manual_unsupported() -> None:
     assert ("analysis", "SpatialJoin") in translatable
     # Erase is mapped (supported) but not job-executable -> manual-review.
     assert ("analysis", "Erase") in manual
-    # sa.Slope has no Honua mapping at all.
-    assert ("spatial-analyst", "Slope") in unsupported
+    # sa.Kriging is an honest honua_gp.sa stub -- no working Honua mapping.
+    assert ("spatial-analyst", "Kriging") in unsupported
     # The three buckets are disjoint.
     assert translatable.isdisjoint(manual)
     assert translatable.isdisjoint(unsupported)
@@ -168,7 +168,7 @@ def test_parity_evidence_report_shape_and_coverage() -> None:
     # Buffer, SimplifyPolygon, Dissolve, RepairGeometry, SpatialJoin (1:1) = 5.
     assert summary["translatableCalls"] == 5
     assert summary["manualReviewCalls"] == 1  # Erase
-    assert summary["unsupportedCalls"] == 1  # Slope
+    assert summary["unsupportedCalls"] == 1  # Kriging
     assert summary["coveragePercent"] == round(100.0 * 5 / 7, 2)
     assert summary["executableProcessIds"] == sorted(EXECUTABLE_PROCESS_IDS)
 
@@ -183,11 +183,11 @@ def test_parity_evidence_report_shape_and_coverage() -> None:
     assert "payload" not in erase
     assert erase["reason"]
     # Unsupported calls carry a reason explaining there is no mapping.
-    slope = by_tool[("spatial-analyst", "Slope")]
-    assert slope["status"] == "unsupported"
-    assert slope["processId"] is None
-    assert slope["jobProcessId"] is None
-    assert "No Honua process mapping" in slope["reason"]
+    kriging = by_tool[("spatial-analyst", "Kriging")]
+    assert kriging["status"] == "unsupported"
+    assert kriging["processId"] is None
+    assert kriging["jobProcessId"] is None
+    assert "No Honua process mapping" in kriging["reason"]
 
     tool_status = {(t["family"], t["tool"]): t for t in evidence["toolStatus"]}
     assert tool_status[("analysis", "Buffer")]["status"] == "translatable"

--- a/tests/test_arcpy_migration_hardening_coverage.py
+++ b/tests/test_arcpy_migration_hardening_coverage.py
@@ -42,7 +42,7 @@ from honua_sdk.migration.pyt import (
 
 def test_unmapped_call_has_no_manual_review_reason() -> None:
     # arcpy.py:106 -- manual_review_reason returns None when there is no spec.
-    call = ArcPyCall(qualified_name="arcpy.sa.Slope", family="spatial-analyst", tool="Slope", line=1, column=0)
+    call = ArcPyCall(qualified_name="arcpy.sa.Kriging", family="spatial-analyst", tool="Kriging", line=1, column=0)
     assert call.status == "unsupported"
     assert call.manual_review_reason is None
     assert call.process_id is None

--- a/tests/test_arcpy_migration_raster.py
+++ b/tests/test_arcpy_migration_raster.py
@@ -56,7 +56,7 @@ WORKING_TOOLS = {
 
 # A script exercising each working tool once, using real Esri namespacing
 # (arcpy.sa.* for Spatial Analyst, arcpy.management.* for the raster Data
-# Management tools).
+# Management tools) and each tool's real positional signature.
 RASTER_SCRIPT = """
 import arcpy
 
@@ -64,14 +64,14 @@ arcpy.sa.Slope("dem", "DEGREE", 1.0)
 arcpy.sa.Aspect("dem")
 arcpy.sa.Hillshade("dem", 315, 45)
 arcpy.sa.Contour("dem", "contours", 10)
-arcpy.sa.Viewshed("dem", "obs", "vshed")
-arcpy.sa.Roughness("dem", "rough")
-arcpy.sa.TPI("dem", "tpi")
-arcpy.sa.TRI("dem", "tri")
-arcpy.sa.Reclassify("landcover", "VALUE", "1 5;2 10", "reclass")
-arcpy.sa.RasterCalculator("(A-B)/(A+B)", "ndvi")
-arcpy.sa.Idw("stations", "ELEV", "idw_out")
-arcpy.sa.ZonalStatisticsAsTable("zones", "ZONE_ID", "value", "zstats", "MEAN")
+arcpy.sa.Viewshed("dem", "observers")
+arcpy.sa.Roughness("dem")
+arcpy.sa.TPI("dem")
+arcpy.sa.TRI("dem")
+arcpy.sa.Reclassify("landcover", "VALUE", "1 5;2 10", "NODATA")
+arcpy.sa.RasterCalculator(["a.tif", "b.tif"], ["A", "B"], "(A-B)/(A+B)", "ndvi.tif")
+arcpy.sa.Idw("stations", "ELEV", 50)
+arcpy.sa.ZonalStatisticsAsTable("zones", "ZONE_ID", "value", "zstats", "DATA", "MEAN")
 arcpy.management.ProjectRaster("dem", "dem_wgs84", 4326)
 arcpy.management.Resample("dem", "dem_10m", 10)
 arcpy.management.Clip("dem", "0 0 10 10", "dem_clip")
@@ -120,6 +120,112 @@ def test_raster_tools_translate_to_bare_ogc_ids_without_job_ids() -> None:
         assert process_ids[tool] == process_id
         # The raster run path is never claimed as server job-executable.
         assert job_ids[tool] is None
+
+
+def _payload_for(tool: str) -> dict:
+    plan = translate_arcpy_source(RASTER_SCRIPT, filename="raster.py")
+    (translation,) = [t for t in plan.translations if t.call.tool == tool]
+    return translation.payload
+
+
+def test_positional_args_map_to_correct_inputs_and_outputs() -> None:
+    # Every tool's raster/point/observer INPUT value must land in inputs, and
+    # NEVER in outputs. The four tools with a real arcpy output positional
+    # (Contour, ZonalStatisticsAsTable, RasterCalculator, and the management
+    # ProjectRaster/Resample/Clip) put their output dataset in outputs.
+    input_values = {
+        "Slope": "dem",
+        "Aspect": "dem",
+        "Hillshade": "dem",
+        "Contour": "dem",
+        "Viewshed": "dem",
+        "Roughness": "dem",
+        "TPI": "dem",
+        "TRI": "dem",
+        "Reclassify": "landcover",
+        "Idw": "stations",
+        "ZonalStatisticsAsTable": "value",  # in_value_raster -> source
+        "ProjectRaster": "dem",
+        "Resample": "dem",
+        "Clip": "dem",
+    }
+    for tool, raster in input_values.items():
+        payload = _payload_for(tool)
+        assert payload["inputs"].get("source") == raster or raster in payload["inputs"].values(), (
+            f"{tool}: input raster {raster!r} not in inputs"
+        )
+        assert raster not in payload.get("outputs", {}).values(), (
+            f"{tool}: input raster {raster!r} leaked into outputs"
+        )
+
+
+def test_raster_calculator_positionals_are_not_misassigned() -> None:
+    # BUG (P1): RasterCalculator(rasters, input_names, expression, output_raster).
+    # The raster list is the input, the expression is a parameter, and only
+    # output_raster is the output -- earlier the list was slotted as expression
+    # and input_names as the output.
+    payload = _payload_for("RasterCalculator")
+    assert payload["inputs"]["sources"] == ["a.tif", "b.tif"]
+    assert payload["inputs"]["expression"] == "(A-B)/(A+B)"
+    assert payload["inputs"]["inputNames"] == ["A", "B"]
+    assert payload["outputs"]["result"] == "ndvi.tif"
+    # The expression must never be treated as an output, nor the raster list.
+    assert "(A-B)/(A+B)" not in payload.get("outputs", {}).values()
+    assert payload["outputs"].get("result") != ["A", "B"]
+
+
+def test_viewshed_observer_is_an_input_not_an_output() -> None:
+    # BUG (P1): Viewshed(in_raster, in_observer_features, ...). The observer
+    # features are a REQUIRED input, not an output.
+    payload = _payload_for("Viewshed")
+    assert payload["inputs"]["source"] == "dem"
+    assert payload["inputs"]["observerFeatures"] == "observers"
+    assert "observers" not in payload.get("outputs", {}).values()
+
+
+def test_reclassify_missing_values_flag_is_not_an_output() -> None:
+    # BUG (P2): Reclassify(in_raster, reclass_field, remap, {missing_values}).
+    # missing_values is a DATA/NODATA flag, not an output path; Reclassify has
+    # no output positional.
+    payload = _payload_for("Reclassify")
+    assert payload["inputs"]["source"] == "landcover"
+    assert payload["inputs"]["remap"] == "1 5;2 10"
+    assert payload["inputs"]["missingValues"] == "NODATA"
+    assert "outputs" not in payload or "NODATA" not in payload["outputs"].values()
+
+
+def test_idw_cell_size_positional_is_not_an_output() -> None:
+    # Idw(in_point_features, z_field, {cell_size}, {power}, {search_radius}).
+    # cell_size (positional 2) is a parameter, not an output; Idw returns a
+    # raster and has no output positional.
+    payload = _payload_for("Idw")
+    assert payload["inputs"]["points"] == "stations"
+    assert payload["inputs"]["zField"] == "ELEV"
+    assert payload["inputs"]["cellSize"] == 50
+    assert "outputs" not in payload or 50 not in payload["outputs"].values()
+
+
+def test_zonal_statistics_output_and_stat_slots_are_correct() -> None:
+    # ZonalStatisticsAsTable(in_zone_data, zone_field, in_value_raster,
+    # out_table, {ignore_nodata}, {statistics_type}). out_table is the output;
+    # ignore_nodata and statistics_type occupy distinct later slots.
+    payload = _payload_for("ZonalStatisticsAsTable")
+    assert payload["outputs"]["result"] == "zstats"
+    assert payload["inputs"]["ignoreNoData"] == "DATA"
+    assert payload["inputs"]["statistics"] == "MEAN"
+    assert payload["inputs"]["source"] == "value"
+
+
+def test_hillshade_z_factor_slot_accounts_for_model_shadows() -> None:
+    # Hillshade(in_raster, {azimuth}, {altitude}, {model_shadows}, {z_factor}).
+    # A 5-positional call must map z_factor from slot 4, not slot 3.
+    payload = translate_arcpy_source(
+        'import arcpy\narcpy.sa.Hillshade("dem", 315, 45, "NO_SHADOWS", 2.0)\n'
+    ).translations[0].payload
+    assert payload["inputs"]["azimuth"] == 315
+    assert payload["inputs"]["altitude"] == 45
+    assert payload["inputs"]["modelShadows"] == "NO_SHADOWS"
+    assert payload["inputs"]["zFactor"] == 2.0
 
 
 def test_bare_project_raster_call_classifies_as_management() -> None:

--- a/tests/test_arcpy_migration_raster.py
+++ b/tests/test_arcpy_migration_raster.py
@@ -1,0 +1,192 @@
+"""Codemod coverage for the raster / Spatial Analyst tools added by PR #175.
+
+PR #175 shipped ``honua_gp.sa`` -- an ``arcpy.sa``-style surface wrapping 16
+working honua-server raster/surface processes -- plus three honest STUBS
+(Kriging, Histogram, SpectralIndex) that raise ``HonuaGpUnsupportedError`` at
+runtime. These tests assert the ``honua_sdk.migration`` codemod:
+
+* recognizes each of the 16 working arcpy raster tools and maps it to its
+  honua-server raster process id + names its ``honua_gp.sa`` migration target
+  (classified ``manual-review`` -- raster ids 404 on direct OGC execution and
+  are not bare-OGC job-executable, so the codemod never claims a
+  server-runnable migration);
+* leaves the three stubs UNSUPPORTED so the codemod never emits a translation
+  for ``honua_gp.sa.Kriging`` / ``Histogram`` / ``SpectralIndex``, which would
+  be a guaranteed runtime failure -- exactly the overclaim #175 guarded against.
+
+The migration targets are cross-checked against the ACTUAL ``honua_gp.sa`` /
+``honua_gp.management`` signatures (imported, not guessed) so a rename on either
+side fails loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from honua_sdk.migration import (
+    build_parity_evidence_for_source,
+    scan_arcpy_source,
+    translate_arcpy_source,
+)
+
+# The 16 working tools -> (arcpy family, honua-server raster process id,
+# honua_gp.sa migration target named in the manual-review note).
+WORKING_TOOLS = {
+    "Slope": ("spatial-analyst", "surface.slope", "honua_gp.sa.Slope"),
+    "Aspect": ("spatial-analyst", "surface.aspect", "honua_gp.sa.Aspect"),
+    "Hillshade": ("spatial-analyst", "surface.hillshade", "honua_gp.sa.Hillshade"),
+    "Contour": ("spatial-analyst", "surface.contour", "honua_gp.sa.Contour"),
+    "Viewshed": ("spatial-analyst", "surface.viewshed", "honua_gp.sa.Viewshed"),
+    "Roughness": ("spatial-analyst", "surface.roughness", "honua_gp.sa.Roughness"),
+    "TPI": ("spatial-analyst", "surface.rugosity-tpi", "honua_gp.sa.TPI"),
+    "TRI": ("spatial-analyst", "surface.rugosity-tri", "honua_gp.sa.TRI"),
+    "Reclassify": ("spatial-analyst", "raster.reclassify", "honua_gp.sa.Reclassify"),
+    "RasterCalculator": ("spatial-analyst", "raster.map-algebra", "honua_gp.sa.RasterCalculator"),
+    "Idw": ("spatial-analyst", "raster.interpolate-idw", "honua_gp.sa.Idw"),
+    "ZonalStatisticsAsTable": (
+        "spatial-analyst",
+        "raster.zonal-statistics",
+        "honua_gp.sa.ZonalStatisticsAsTable",
+    ),
+    "ProjectRaster": ("management", "raster.reproject", "honua_gp.management.ProjectRaster"),
+    "Resample": ("management", "raster.resample", "honua_gp.management.Resample"),
+    "Clip": ("management", "raster.clip", "honua_gp.management.Clip"),
+    "Mosaic": ("management", "raster.mosaic", "honua_gp.management.Mosaic"),
+}
+
+# A script exercising each working tool once, using real Esri namespacing
+# (arcpy.sa.* for Spatial Analyst, arcpy.management.* for the raster Data
+# Management tools).
+RASTER_SCRIPT = """
+import arcpy
+
+arcpy.sa.Slope("dem", "DEGREE", 1.0)
+arcpy.sa.Aspect("dem")
+arcpy.sa.Hillshade("dem", 315, 45)
+arcpy.sa.Contour("dem", "contours", 10)
+arcpy.sa.Viewshed("dem", "obs", "vshed")
+arcpy.sa.Roughness("dem", "rough")
+arcpy.sa.TPI("dem", "tpi")
+arcpy.sa.TRI("dem", "tri")
+arcpy.sa.Reclassify("landcover", "VALUE", "1 5;2 10", "reclass")
+arcpy.sa.RasterCalculator("(A-B)/(A+B)", "ndvi")
+arcpy.sa.Idw("stations", "ELEV", "idw_out")
+arcpy.sa.ZonalStatisticsAsTable("zones", "ZONE_ID", "value", "zstats", "MEAN")
+arcpy.management.ProjectRaster("dem", "dem_wgs84", 4326)
+arcpy.management.Resample("dem", "dem_10m", 10)
+arcpy.management.Clip("dem", "0 0 10 10", "dem_clip")
+arcpy.management.Mosaic(["a.tif", "b.tif"], "target.tif")
+"""
+
+
+def test_all_sixteen_working_raster_tools_are_recognized() -> None:
+    report = scan_arcpy_source(RASTER_SCRIPT, filename="raster.py")
+    by_tool = {call.tool: call for call in report.calls}
+
+    assert set(WORKING_TOOLS).issubset(by_tool), (
+        "codemod did not recognize every working raster tool"
+    )
+    for tool, (family, process_id, _target) in WORKING_TOOLS.items():
+        call = by_tool[tool]
+        assert call.family == family, f"{tool} classified under {call.family!r}"
+        # Recognized + mapped, but honestly NOT server-runnable via bare OGC.
+        assert call.supported is True, f"{tool} should be a recognized mapping"
+        assert call.status == "manual-review", f"{tool} status={call.status!r}"
+        assert call.translatable is False, f"{tool} must not claim executability"
+        assert call.process_id == process_id, f"{tool} -> {call.process_id!r}"
+        # Raster ids are never in the reconciled job-executable catalog.
+        assert call.job_process_id is None, f"{tool} leaked a job id"
+
+
+def test_manual_review_notes_name_the_honua_gp_migration_target() -> None:
+    evidence = build_parity_evidence_for_source(RASTER_SCRIPT, filename="raster.py")
+    by_tool = {(c["family"], c["tool"]): c for c in evidence["calls"]}
+
+    for tool, (family, _process_id, target) in WORKING_TOOLS.items():
+        entry = by_tool[(family, tool)]
+        assert entry["status"] == "manual-review"
+        # Manual-review entries carry a reason + notes but no runnable payload.
+        assert "payload" not in entry
+        joined = entry["reason"] + " " + " ".join(entry.get("notes", ()))
+        assert target in joined, f"{tool} note did not name {target}"
+
+
+def test_raster_tools_translate_to_bare_ogc_ids_without_job_ids() -> None:
+    plan = translate_arcpy_source(RASTER_SCRIPT, filename="raster.py")
+    process_ids = {t.call.tool: t.process_id for t in plan.translations}
+    job_ids = {t.call.tool: t.job_process_id for t in plan.translations}
+
+    for tool, (_family, process_id, _target) in WORKING_TOOLS.items():
+        assert process_ids[tool] == process_id
+        # The raster run path is never claimed as server job-executable.
+        assert job_ids[tool] is None
+
+
+def test_bare_project_raster_call_classifies_as_management() -> None:
+    # arcpy.ProjectRaster (un-suffixed, un-namespaced) still resolves to the
+    # management raster.reproject spec.
+    report = scan_arcpy_source('import arcpy\narcpy.ProjectRaster("dem", "out", 4326)\n')
+    (call,) = report.calls
+    assert call.family == "management"
+    assert call.tool == "ProjectRaster"
+    assert call.process_id == "raster.reproject"
+    assert call.status == "manual-review"
+
+
+@pytest.mark.parametrize("stub", ["Kriging", "Histogram", "SpectralIndex"])
+def test_honest_stubs_are_unsupported_not_translated(stub: str) -> None:
+    # honua_gp.sa.Kriging/Histogram/SpectralIndex raise HonuaGpUnsupportedError
+    # at runtime; the codemod must surface them as UNSUPPORTED (no mapping) so
+    # it never emits a translation that pretends they work.
+    source = f'import arcpy\narcpy.sa.{stub}("in", "out")\n'
+    report = scan_arcpy_source(source)
+    (call,) = report.calls
+
+    assert call.family == "spatial-analyst"
+    assert call.supported is False
+    assert call.status == "unsupported"
+    assert call.translatable is False
+    assert call.process_id is None
+    assert call.job_process_id is None
+
+    # No translation is emitted for the stub -- nothing resembling a
+    # honua_gp.sa.<stub> call reaches the plan.
+    plan = translate_arcpy_source(source)
+    assert plan.translations == ()
+    assert ("spatial-analyst", stub) in {
+        (c.family, c.tool) for c in plan.unsupported_calls
+    }
+
+
+def test_kriging_evidence_reports_gap_at_translation_time() -> None:
+    evidence = build_parity_evidence_for_source(
+        'import arcpy\narcpy.sa.Kriging("stations", "PredZ")\n'
+    )
+    (entry,) = evidence["calls"]
+    assert entry["status"] == "unsupported"
+    assert entry["processId"] is None
+    assert "No Honua process mapping" in entry["reason"]
+    assert evidence["summary"]["unsupportedCalls"] == 1
+    assert evidence["summary"]["translatableCalls"] == 0
+
+
+def test_migration_targets_match_actual_honua_gp_signatures() -> None:
+    # Cross-check the honua_gp.sa / honua_gp.management migration targets named
+    # by the codemod against the ACTUAL PR #175 surface (imported, not guessed).
+    sa = pytest.importorskip("honua_gp.sa")
+    management = pytest.importorskip("honua_gp.management")
+    from honua_gp._compat import COMPAT
+
+    for tool, (_family, _process_id, target) in WORKING_TOOLS.items():
+        module = sa if target.startswith("honua_gp.sa.") else management
+        attr = target.rsplit(".", 1)[1]
+        assert hasattr(module, attr), f"{target} is not a real honua_gp function"
+        assert callable(getattr(module, attr))
+        # The manifest agrees these 16 are working (supported/partial), so the
+        # codemod is right to map (not stub) them.
+        assert COMPAT[f"sa.{tool}"].status in {"supported", "partial"}
+
+    # ...and the three stubs really are stubs in the ground-truth manifest.
+    for stub in ("Kriging", "Histogram", "SpectralIndex"):
+        assert COMPAT[f"sa.{stub}"].status == "stub"
+        assert COMPAT[f"sa.{stub}"].backend == "not_implemented"


### PR DESCRIPTION
## Summary

PR #175 added `honua_gp.sa` -- an `arcpy.sa`-style surface wrapping 16 working honua-server raster/surface processes plus three honest stubs. The `honua_sdk.migration` codemod had essentially no raster coverage (only `ListRasters`). This adds rules so arcpy raster scripts are recognized and mapped to their `honua_gp.sa` / `honua_gp.management` equivalents.

## The 16 working tools (registered)

| arcpy | honua-server process | honua_gp target |
|---|---|---|
| `arcpy.sa.Slope/Aspect/Hillshade/Contour/Viewshed` | `surface.*` | `honua_gp.sa.*` |
| `arcpy.sa.Roughness/TPI/TRI` | `surface.roughness` / `surface.rugosity-tpi` / `surface.rugosity-tri` | `honua_gp.sa.*` |
| `arcpy.sa.Reclassify/RasterCalculator/Idw/ZonalStatisticsAsTable` | `raster.reclassify` / `raster.map-algebra` / `raster.interpolate-idw` / `raster.zonal-statistics` | `honua_gp.sa.*` |
| `arcpy.management.ProjectRaster/Resample/Clip/Mosaic` | `raster.reproject` / `raster.resample` / `raster.clip` / `raster.mosaic` | `honua_gp.management.*` |

## Honest classification

Raster/surface process ids **404 on direct OGC API Processes execution** (`honua_gp.sa` auto-wraps each into a `honua-geoprocessing` plan), so they are NOT in the reconciled server's job-executable catalog (`EXECUTABLE_PROCESS_IDS`, which the guard test locks to 9 geometry/analytics ids). Every raster spec is registered **without a `job_process_id`**, so each classifies as **`manual-review`**: recognized and mapped to a named `honua_gp.sa` target, never claimed as a bare-OGC server-runnable migration. This mirrors `honua_gp._compat`, where these 16 tools are `supported`/`partial`.

## The 3 stubs (Kriging, Histogram, SpectralIndex)

Left **deliberately unregistered** so the codemod classifies them as **`unsupported`**. `honua_gp.sa.Kriging`/`Histogram`/`SpectralIndex` raise `HonuaGpUnsupportedError` at runtime (honua-server never produces output), so mapping them -- even as manual-review -- would emit a translation payload for a guaranteed-failing call: exactly the overclaim #175 guarded against by reclassifying Kriging to a stub. The gap is surfaced at **translation time** rather than deferred to a runtime failure. Kriging users are pointed at `honua_gp.sa.Idw` (a code comment documents the intent).

## Test changes

The pre-#175 suite used `arcpy.sa.Slope` as the canonical *unmapped* example; since Slope now maps (manual-review), those tests move their unsupported example to `arcpy.sa.Kriging` (still genuinely unsupported). A new `tests/test_arcpy_migration_raster.py` exercises all 16 tools, asserts manual-review classification + honest job-id absence, asserts the 3 stubs stay unsupported/untranslated, and **cross-checks the migration targets against the actual `honua_gp.sa` / `honua_gp.management` signatures** (imported, not guessed).

## Verification

- Reproduced the CI no-geopandas/no-rasterio combined coverage gate locally: `pytest tests/ --cov=honua_sdk --cov=honua_admin --cov-fail-under=94` -> **94.03%**, 1299 passed.
- `honua_sdk` per-package floor (93) -> 93.66%. `migration/arcpy.py` at 99% (only pre-existing helper lines uncovered).
- `ruff check .` clean (arcpy.py held to the strict PLR bar -- no new per-file ignore added). `mypy` clean.