### PR TITLE
feat: add sanitized doctor diagnostics (#171)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Canonical public contract bytes are SHA-pinned and must never be rewritten by
+# platform checkout defaults.
+packages/honua-sdk/honua_sdk/schemas/** text eol=lf

--- a/docs/diagnostic-bundles.md
+++ b/docs/diagnostic-bundles.md
@@ -1,0 +1,98 @@
+# Sanitized diagnostic bundles
+
+`honua doctor` creates a local, bounded support artifact without uploading it.
+The artifact conforms to the canonical
+[`diagnostic-bundle.v1` schema](https://honua.io/schemas/diagnostic-bundle.v1.json),
+vendored byte-for-byte in the installed SDK and pinned to:
+
+- support source commit `0c990fbe8f519a00a57e26dab21cbb8f80d559ea`;
+- 6,494 bytes; and
+- SHA-256 `4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9`.
+
+The matching public provenance record is
+[`diagnostic-bundle.v1.provenance.json`](https://honua.io/schemas/diagnostic-bundle.v1.provenance.json).
+The support-owned valid/invalid conformance corpus is also shipped with the
+package and exercised in CI so validator behavior cannot drift from intake.
+
+## Emit and review
+
+Capture the final failing exchange in a local JSON file. This input may contain
+raw values because the command reads it only into memory:
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "url": "https://server.example/rest/services/roads/FeatureServer/0/query?token=secret",
+    "headers": { "authorization": "Bearer secret" }
+  },
+  "response": {
+    "status": 500,
+    "mediaType": "application/problem+json",
+    "headers": { "content-type": "application/problem+json" },
+    "body": { "error": "failed", "apiKey": "secret" }
+  }
+}
+```
+
+Choose the classification and both consent values explicitly:
+
+```bash
+honua doctor \
+  --exchange ./failure.json \
+  --classification customer-data \
+  --redaction-acknowledged true \
+  --share-with-support false \
+  --output ./diagnostic-bundle.json
+```
+
+Add `--base-url https://server.example/honua` to attempt one anonymous,
+credential-free capability read. Probe failure produces a minimal sanitized
+envelope and does not remove the supplied failure, which remains the final
+envelope.
+
+The command validates the complete bundle against the pinned v1 constraints
+before atomic output and writes owner-only permissions where supported. Stdout
+contains only a machine-readable result summary (SDK/runtime context, schema
+pin, envelope count, and upload state), never the artifact path or traffic.
+`sdkContext` is not written into the artifact because the canonical v1 schema
+forbids extension fields.
+
+Review the JSON locally. If it is appropriate to share, rerun with
+`--share-with-support true` and submit the reviewed file through the support
+intake workflow. The CLI itself never uploads.
+
+## Privacy boundary
+
+The Python emitter deliberately persists no body preview. Request and response
+bodies are hashed in memory, then discarded; the artifact retains only original
+byte size, SHA-256, and flags recording that the content was removed. It also:
+
+- removes URL origin, user information, path parameters, and query values;
+- drops Authorization, Proxy-Authorization, Cookie, Set-Cookie, API keys,
+  signatures, tokens, and every non-allowlisted header;
+- omits absent optional fields rather than serializing `null`;
+- rejects credential-shaped bundle IDs and consent identities;
+- caps input at 30 MiB, each body at the schema's 25 MiB maximum, capability
+  responses at 256 KiB, envelopes at 50, and headers at 32; and
+- never writes raw request/response bytes, configured API keys, cookies, or
+  customer body values to stdout, stderr, artifacts, telemetry, or snapshots.
+
+## Read-only replay
+
+Replay the final sanitized read envelope against a separately configured server:
+
+```bash
+honua doctor \
+  --replay ./diagnostic-bundle.json \
+  --base-url https://server.example \
+  --output ./diagnostic-replay.json
+```
+
+Replay validates and safety-checks the entire source artifact before network
+access. It sends no captured headers, bodies, credentials, or query values,
+disables redirects, and allows exactly one bounded `GET` or `HEAD`. Mutation,
+subscription, traversal, placeholder paths, request bodies, unsafe headers,
+credential-shaped previews, malformed bundles, changed verifiable hashes,
+timeouts, and over-budget responses fail closed. A successful replay creates a
+new sanitized v1 bundle and never modifies the source.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Authentication: auth.md
       - Compatibility: compatibility.md
       - Troubleshooting: troubleshooting.md
+      - Diagnostic bundles: diagnostic-bundles.md
   - Examples: examples.md
   - Deep dives:
       - Retries and timeouts: retries-and-timeouts.md

--- a/packages/honua-sdk/README.md
+++ b/packages/honua-sdk/README.md
@@ -20,6 +20,8 @@ the full documentation index, install matrix, and release notes.
   call via `honua_sdk.geopandas`.
 - Optional `grpc` extra unlocks streaming feature queries through
   `honua_sdk.grpc.HonuaGrpcClient` / `HonuaGrpcAsyncClient`.
+- `honua doctor` emits a schema-pinned, sanitized local diagnostic bundle for
+  support review without uploading raw traffic or credentials.
 
 ## Install
 
@@ -88,6 +90,7 @@ accepted and normalized through `honua_sdk.normalize_protocol(...)`.
 - [Authentication](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/auth.md)
 - [Geospatial ETL demo](https://github.com/honua-io/honua-sdk-python/blob/trunk/examples/geospatial_etl/README.md)
 - [Troubleshooting](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/troubleshooting.md)
+- [Sanitized diagnostic bundles](https://github.com/honua-io/honua-sdk-python/blob/trunk/docs/diagnostic-bundles.md)
 - [Monorepo README](https://github.com/honua-io/honua-sdk-python) -- install matrix, package overview, and release notes
 
 ## License

--- a/packages/honua-sdk/honua_sdk/cli.py
+++ b/packages/honua-sdk/honua_sdk/cli.py
@@ -22,6 +22,10 @@ Commands
     ``style apply``; the bytes are written to ``--out`` (or stdout). It relies
     on :meth:`HonuaClient.export_map`.
 
+``honua doctor``
+    Emit or read-only replay a canonical, sanitized diagnostic bundle for local
+    support review. It never uploads or persists raw HTTP traffic.
+
 The base URL is read from ``--base-url`` or the ``HONUA_BASE_URL`` environment
 variable; an optional API key from ``--api-key`` or ``HONUA_API_KEY``.
 """
@@ -29,14 +33,27 @@ variable; an optional API key from ``--api-key`` or ``HONUA_API_KEY``.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
+import platform
 import sys
-from collections.abc import Sequence
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from . import __version__
 from .client import HonuaClient
+from .diagnostics import (
+    DIAGNOSTIC_SCHEMA_SHA256,
+    DIAGNOSTIC_SCHEMA_URL,
+    DiagnosticError,
+    assert_diagnostic_bundle,
+    create_diagnostic_bundle,
+    probe_capabilities,
+    replay_diagnostic_bundle,
+)
 from .errors import HonuaError
 
 if TYPE_CHECKING:
@@ -44,6 +61,11 @@ if TYPE_CHECKING:
 
 _ENV_BASE_URL = "HONUA_BASE_URL"
 _ENV_API_KEY = "HONUA_API_KEY"
+_MAX_DIAGNOSTIC_INPUT_BYTES = 30 * 1024 * 1024
+
+
+class _DoctorCliError(ValueError):
+    """Safe command error whose message contains no captured input."""
 
 
 def _resolve_base_url(args: argparse.Namespace) -> str:
@@ -150,6 +172,159 @@ def _cmd_style_apply(args: argparse.Namespace, out: Any) -> int:
     return 0
 
 
+def _cmd_doctor(args: argparse.Namespace, out: Any) -> int:
+    if args.replay:
+        if args.exchange:
+            raise _DoctorCliError("doctor accepts either --replay or --exchange, not both")
+        base_url = args.base_url or os.environ.get(_ENV_BASE_URL)
+        if not base_url:
+            raise _DoctorCliError("doctor replay requires --base-url or HONUA_BASE_URL")
+        source_bundle = _read_diagnostic_json(args.replay)
+        assert_diagnostic_bundle(source_bundle)
+        replayed = replay_diagnostic_bundle(source_bundle, base_url, timeout=args.timeout)
+        _write_diagnostic_bundle_safe(args.output, replayed)
+        _emit_doctor_result(out, replayed, outcome="replayed", capability_probe="not-applicable")
+        return 0
+
+    if args.classification is None or args.redaction_acknowledged is None or args.share_with_support is None:
+        raise _DoctorCliError("doctor emission requires classification and both explicit consent values")
+    exchanges: list[dict[str, Any]] = []
+    base_url = args.base_url or os.environ.get(_ENV_BASE_URL)
+    if base_url:
+        exchanges.append(probe_capabilities(base_url, timeout=args.timeout))
+    if args.exchange:
+        exchanges.append(_captured_exchange(_read_diagnostic_json(args.exchange)))
+    if not exchanges:
+        raise _DoctorCliError("doctor requires --base-url/HONUA_BASE_URL or --exchange")
+
+    bundle = create_diagnostic_bundle(
+        content_classification=args.classification,
+        redaction_acknowledged=_explicit_bool(args.redaction_acknowledged),
+        share_with_support=_explicit_bool(args.share_with_support),
+        exchanges=exchanges,
+        bundle_id=args.bundle_id,
+        granted_by=args.granted_by,
+    )
+    _write_diagnostic_bundle_safe(args.output, bundle)
+    _emit_doctor_result(
+        out,
+        bundle,
+        outcome="emitted",
+        capability_probe="attempted" if base_url else "not-configured",
+    )
+    return 0
+
+
+def _emit_doctor_result(
+    out: Any,
+    bundle: Mapping[str, Any],
+    *,
+    outcome: str,
+    capability_probe: str,
+) -> None:
+    result = {
+        "format": "honua.doctor-result.v1",
+        "outcome": outcome,
+        "outputWritten": True,
+        "envelopeCount": len(bundle["envelopes"]),
+        "capabilityProbe": capability_probe,
+        "runtime": {"python": platform.python_version(), "platform": sys.platform},
+        "sdk": {"package": "honua-sdk", "version": __version__},
+        "schema": DIAGNOSTIC_SCHEMA_URL,
+        "schemaSha256": DIAGNOSTIC_SCHEMA_SHA256,
+        "uploaded": False,
+    }
+    _emit_json(result, out)
+
+
+def _read_diagnostic_json(path: str) -> object:
+    try:
+        source = Path(path)
+        size = source.stat().st_size
+        if not source.is_file() or size > _MAX_DIAGNOSTIC_INPUT_BYTES:
+            raise _DoctorCliError("diagnostic input is not a regular file or exceeds 30 MiB")
+        with source.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except _DoctorCliError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise _DoctorCliError("diagnostic input could not be read as JSON") from exc
+
+
+def _captured_exchange(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise _DoctorCliError("captured exchange must be a JSON object")
+    request = value.get("request")
+    response = value.get("response")
+    if not isinstance(request, dict):
+        raise _DoctorCliError("captured exchange requires a request object")
+    method = request.get("method")
+    url = request.get("url")
+    if not isinstance(method, str) or not isinstance(url, str):
+        raise _DoctorCliError("captured exchange requires request.method and request.url strings")
+    exchange: dict[str, Any] = {"method": method, "url": url}
+    if "headers" in request:
+        exchange["requestHeaders"] = request["headers"]
+    if "body" in request:
+        exchange["requestBody"] = request["body"]
+    if response is not None:
+        _copy_captured_response(response, exchange)
+    for name in ("correlationId", "traceId", "capturedAt"):
+        if name in value:
+            exchange[name] = value[name]
+    return exchange
+
+
+def _copy_captured_response(value: object, exchange: dict[str, Any]) -> None:
+    if not isinstance(value, dict):
+        raise _DoctorCliError("captured response must be a JSON object")
+    status = value.get("statusCode", value.get("status"))
+    if status is not None:
+        exchange["statusCode"] = status
+    for source_name, target_name in (
+        ("mediaType", "mediaType"),
+        ("headers", "responseHeaders"),
+        ("body", "responseBody"),
+    ):
+        if source_name in value:
+            exchange[target_name] = value[source_name]
+
+
+def _write_diagnostic_bundle(path: str, bundle: object) -> None:
+    assert_diagnostic_bundle(bundle)
+    serialized = json.dumps(bundle, indent=2, sort_keys=True) + "\n"
+    assert_diagnostic_bundle(json.loads(serialized))
+    destination = Path(path).resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent, text=True)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            with contextlib.suppress(AttributeError, OSError):
+                os.fchmod(handle.fileno(), 0o600)
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        with contextlib.suppress(OSError):
+            destination.chmod(0o600)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+def _write_diagnostic_bundle_safe(path: str, bundle: object) -> None:
+    try:
+        _write_diagnostic_bundle(path, bundle)
+    except OSError as exc:
+        raise _DoctorCliError("diagnostic output could not be written safely") from exc
+
+
+def _explicit_bool(value: str) -> bool:
+    if value not in {"true", "false"}:
+        raise _DoctorCliError("doctor consent values must be explicitly true or false")
+    return value == "true"
+
+
 def _add_common_connection_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--base-url",
@@ -224,6 +399,28 @@ def build_parser() -> argparse.ArgumentParser:
     style_apply.set_defaults(func=_cmd_style_apply)
     style.set_defaults(func=_dispatch_style)
 
+    # honua doctor
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="Write a local sanitized diagnostic-bundle.v1 support artifact.",
+        description="Write a local sanitized diagnostic-bundle.v1 support artifact; the command never uploads.",
+    )
+    doctor.add_argument("--base-url", default=None, help=f"Anonymous capability probe URL (or {_ENV_BASE_URL}).")
+    doctor.add_argument("--exchange", default=None, help="Captured failing exchange JSON read only in memory.")
+    doctor.add_argument("--replay", default=None, help="Validated bundle to replay as one anonymous GET/HEAD.")
+    doctor.add_argument(
+        "--classification",
+        required=False,
+        choices=("unknown", "public", "internal", "customer-data", "secret-suspected"),
+    )
+    doctor.add_argument("--redaction-acknowledged", required=False, choices=("true", "false"))
+    doctor.add_argument("--share-with-support", required=False, choices=("true", "false"))
+    doctor.add_argument("--granted-by", default=None)
+    doctor.add_argument("--bundle-id", default=None)
+    doctor.add_argument("--timeout", type=float, default=10.0)
+    doctor.add_argument("--output", required=True, help="Destination JSON file. The command never uploads.")
+    doctor.set_defaults(func=_cmd_doctor)
+
     return parser
 
 
@@ -247,6 +444,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise
     except HonuaError as exc:
         sys.stderr.write(f"error: {exc}\n")
+        return 1
+    except (DiagnosticError, _DoctorCliError):
+        sys.stderr.write("error: doctor refused unsafe or invalid diagnostic input\n")
         return 1
     return int(result)
 

--- a/packages/honua-sdk/honua_sdk/diagnostics.py
+++ b/packages/honua-sdk/honua_sdk/diagnostics.py
@@ -1,0 +1,691 @@
+"""Sanitized support diagnostics for the :command:`honua doctor` workflow.
+
+The wire artifact is intentionally narrower than runtime SDK context. It emits
+only the canonical ``diagnostic-bundle.v1`` fields and never persists raw HTTP
+traffic. Bodies are hashed in memory and replaced with bounded metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, cast
+from urllib.parse import parse_qsl, unquote, urlsplit, urlunsplit
+
+import httpx
+
+DIAGNOSTIC_SCHEMA_URL = "https://honua.io/schemas/diagnostic-bundle.v1.json"
+DIAGNOSTIC_SCHEMA_SHA256 = "4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9"
+DIAGNOSTIC_SCHEMA_BYTES = 6494
+
+_MAX_BODY_BYTES = 25 * 1024 * 1024
+_MAX_PROBE_BYTES = 256 * 1024
+_MAX_ENVELOPES = 50
+_MAX_HEADERS = 32
+_MAX_PATH_LENGTH = 2048
+_CLASSIFICATIONS = frozenset({"unknown", "public", "internal", "customer-data", "secret-suspected"})
+_BUNDLE_KEYS = frozenset({"schemaVersion", "bundleId", "contentClassification", "consent", "envelopes"})
+_CONSENT_KEYS = frozenset({"redactionAcknowledged", "shareWithSupport", "grantedBy"})
+_ENVELOPE_KEYS = frozenset(
+    {
+        "method",
+        "normalizedPath",
+        "statusCode",
+        "mediaType",
+        "correlationId",
+        "traceId",
+        "capturedAt",
+        "requestHeaders",
+        "responseHeaders",
+        "requestBody",
+        "responseBody",
+    }
+)
+_BODY_KEYS = frozenset({"preview", "contentSha256", "originalByteSize", "redactionApplied", "truncated"})
+_SAFE_HEADER_NAMES = {
+    "accept": "Accept",
+    "content-length": "Content-Length",
+    "content-type": "Content-Type",
+    "retry-after": "Retry-After",
+    "server": "Server",
+    "traceparent": "Traceparent",
+    "x-correlation-id": "X-Correlation-Id",
+    "x-honua-version": "X-Honua-Version",
+    "x-request-id": "X-Request-Id",
+}
+_SAFE_PATH_SEGMENTS = frozenset(
+    {
+        "api",
+        "v1",
+        "rest",
+        "services",
+        "FeatureServer",
+        "MapServer",
+        "query",
+        "healthz",
+        "ready",
+        "ogc",
+        "collections",
+        "items",
+        "conformance",
+    }
+)
+_SAFE_QUERY_NAMES = frozenset({"f", "format", "limit", "offset", "page", "status"})
+_SECRET_PATTERN = re.compile(
+    r"(?i)(?:bearer\s+|basic\s+|password\s*[=:]|secret\s*[=:]|token\s*[=:]|api[-_]?key\s*[=:]"
+    r"|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
+    r"|[^\s/@]+@[^\s/@]+\.[^\s/@]+)"
+)
+
+
+class DiagnosticError(ValueError):
+    """Base class for safe diagnostic validation and sanitization failures."""
+
+
+class DiagnosticSafetyError(DiagnosticError):
+    """Raised before output or network effects when diagnostic input is unsafe."""
+
+
+class DiagnosticValidationError(DiagnosticError):
+    """Raised when a bundle does not conform to the pinned v1 contract."""
+
+    def __init__(self, errors: Sequence[str]) -> None:
+        super().__init__("Diagnostic bundle failed pinned-schema validation.")
+        self.errors = tuple(errors)
+
+
+def validate_diagnostic_bundle(value: object) -> tuple[str, ...]:
+    """Validate *value* against the pinned canonical v1 wire constraints."""
+    errors: list[str] = []
+    if not isinstance(value, dict):
+        return ("$: expected type 'object'",)
+    _unexpected(value, _BUNDLE_KEYS, "$", errors)
+    _required(value, ("schemaVersion", "contentClassification", "consent", "envelopes"), "$", errors)
+    _string(value, "schemaVersion", "$", errors, maximum=3, constant="1.0")
+    _string(value, "bundleId", "$", errors, maximum=64)
+    classification = _string(value, "contentClassification", "$", errors, maximum=32)
+    if classification is not None and classification not in _CLASSIFICATIONS:
+        errors.append("$.contentClassification: value is not in the canonical enum")
+    _validate_consent(value.get("consent"), errors)
+    envelopes = value.get("envelopes")
+    if not isinstance(envelopes, list):
+        if "envelopes" in value:
+            errors.append("$.envelopes: expected type 'array'")
+    else:
+        if not envelopes:
+            errors.append("$.envelopes: contains fewer than minimum 1 item")
+        if len(envelopes) > _MAX_ENVELOPES:
+            errors.append("$.envelopes: contains more than maximum 50 items")
+        for index, envelope in enumerate(envelopes):
+            _validate_envelope(envelope, index, errors)
+    return tuple(errors)
+
+
+def assert_diagnostic_bundle(value: object) -> None:
+    """Raise :class:`DiagnosticValidationError` unless *value* is canonical v1."""
+    errors = validate_diagnostic_bundle(value)
+    if errors:
+        raise DiagnosticValidationError(errors)
+
+
+def create_diagnostic_bundle(
+    *,
+    content_classification: str,
+    redaction_acknowledged: bool,
+    share_with_support: bool,
+    exchanges: Sequence[Mapping[str, Any]],
+    bundle_id: str | None = None,
+    granted_by: str | None = None,
+) -> dict[str, Any]:
+    """Create and validate a canonical bundle from raw in-memory exchanges."""
+    if content_classification not in _CLASSIFICATIONS:
+        raise DiagnosticSafetyError("Content classification is not supported by diagnostic-bundle.v1.")
+    if not isinstance(redaction_acknowledged, bool) or not isinstance(share_with_support, bool):
+        raise DiagnosticSafetyError("Both diagnostic consent values must be explicit booleans.")
+    if not exchanges:
+        raise DiagnosticSafetyError("At least one diagnostic exchange is required.")
+    if len(exchanges) > _MAX_ENVELOPES:
+        raise DiagnosticSafetyError("Diagnostic bundles cannot contain more than 50 exchanges.")
+
+    consent: dict[str, Any] = {
+        "redactionAcknowledged": redaction_acknowledged,
+        "shareWithSupport": share_with_support,
+    }
+    if granted_by is not None:
+        consent["grantedBy"] = _safe_metadata(granted_by, "grantedBy", 256)
+    bundle: dict[str, Any] = {
+        "schemaVersion": "1.0",
+        "contentClassification": content_classification,
+        "consent": consent,
+        "envelopes": [sanitize_exchange(exchange) for exchange in exchanges],
+    }
+    if bundle_id is not None:
+        bundle["bundleId"] = _safe_metadata(bundle_id, "bundleId", 64)
+    assert_diagnostic_bundle(bundle)
+    return bundle
+
+
+def sanitize_exchange(exchange: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert one raw in-memory exchange to a canonical sanitized envelope."""
+    method = exchange.get("method")
+    url = exchange.get("url")
+    if not isinstance(method, str) or not method.strip():
+        raise DiagnosticSafetyError("Diagnostic exchange requires a request method string.")
+    if not isinstance(url, str) or not url.strip():
+        raise DiagnosticSafetyError("Diagnostic exchange requires a request URL string.")
+
+    envelope: dict[str, Any] = {
+        "method": method.strip().upper()[:16],
+        "normalizedPath": normalize_diagnostic_path(url),
+    }
+    _copy_optional_integer(exchange, envelope, "statusCode", minimum=100, maximum=599)
+    _copy_optional_safe_string(exchange, envelope, "mediaType", maximum=256)
+    _copy_optional_safe_string(exchange, envelope, "correlationId", maximum=200)
+    _copy_optional_safe_string(exchange, envelope, "traceId", maximum=200)
+    _copy_optional_safe_string(exchange, envelope, "capturedAt", maximum=40)
+    for source_name, output_name in (
+        ("requestHeaders", "requestHeaders"),
+        ("responseHeaders", "responseHeaders"),
+    ):
+        if source_name in exchange:
+            headers = sanitize_headers(exchange[source_name])
+            if headers:
+                envelope[output_name] = headers
+    for source_name, output_name in (("requestBody", "requestBody"), ("responseBody", "responseBody")):
+        if source_name in exchange:
+            envelope[output_name] = sanitize_body(exchange[source_name])
+
+    assert_diagnostic_bundle(
+        {
+            "schemaVersion": "1.0",
+            "contentClassification": "unknown",
+            "consent": {"redactionAcknowledged": True, "shareWithSupport": False},
+            "envelopes": [envelope],
+        }
+    )
+    return envelope
+
+
+def sanitize_headers(value: object) -> list[dict[str, str]]:
+    """Return only allowlisted, non-secret headers from a raw mapping."""
+    if value is None:
+        return []
+    if not isinstance(value, Mapping):
+        raise DiagnosticSafetyError("Diagnostic headers must be a JSON object.")
+    sanitized: list[dict[str, str]] = []
+    for raw_name, raw_value in value.items():
+        if not isinstance(raw_name, str):
+            continue
+        canonical_name = _SAFE_HEADER_NAMES.get(raw_name.strip().lower())
+        if canonical_name is None:
+            continue
+        header_value = _header_value(raw_value)
+        if header_value is None or _SECRET_PATTERN.search(header_value):
+            continue
+        if "\r" in header_value or "\n" in header_value:
+            continue
+        sanitized.append({"name": canonical_name, "value": header_value[:2048]})
+    return sorted(sanitized, key=lambda header: header["name"].lower())
+
+
+def sanitize_body(value: object) -> dict[str, Any]:
+    """Hash raw body bytes in memory and persist metadata only, never a preview."""
+    raw = _body_bytes(value)
+    size = len(raw)
+    if size > _MAX_BODY_BYTES:
+        raise DiagnosticSafetyError("Diagnostic body exceeds the canonical 25 MiB limit.")
+    suppressed = size > 0
+    return {
+        "contentSha256": hashlib.sha256(raw).hexdigest(),
+        "originalByteSize": size,
+        "redactionApplied": suppressed,
+        "truncated": suppressed,
+    }
+
+
+def normalize_diagnostic_path(raw_url: str) -> str:
+    """Remove origin/userinfo and placeholder path parameters and query values."""
+    candidate = raw_url.strip()
+    parsed = urlsplit(candidate if "://" in candidate else f"https://diagnostic.invalid/{candidate.lstrip('/')}")
+    decoded_path = unquote(parsed.path)
+    segments: list[str] = []
+    for raw_segment in decoded_path.split("/"):
+        if not raw_segment:
+            continue
+        segment = unquote(raw_segment)
+        if segment in {".", ".."} or "\x00" in segment or "\\" in segment:
+            raise DiagnosticSafetyError("Diagnostic URL contains an unsafe path segment.")
+        segments.append(segment if segment in _SAFE_PATH_SEGMENTS else "{value}")
+    normalized = "/" + "/".join(segments)
+    query_names = sorted(
+        {
+            name
+            for name, _ in parse_qsl(parsed.query, keep_blank_values=True)
+            if name in _SAFE_QUERY_NAMES and not _SECRET_PATTERN.search(name)
+        }
+    )
+    if query_names:
+        normalized += "?" + "&".join(f"{name}={{value}}" for name in query_names)
+    if len(normalized) > _MAX_PATH_LENGTH:
+        raise DiagnosticSafetyError("Normalized diagnostic path exceeds the canonical limit.")
+    return normalized
+
+
+def safe_probe_base_url(raw_url: str) -> str:
+    """Validate an anonymous probe/replay origin and return it without credentials."""
+    parsed = urlsplit(raw_url.strip())
+    local_http = parsed.scheme == "http" and (parsed.hostname or "").lower() in {
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    }
+    if (parsed.scheme != "https" and not local_http) or parsed.username or parsed.password:
+        raise DiagnosticSafetyError("Doctor base URL must be credential-free HTTPS or localhost HTTP.")
+    if parsed.query or parsed.fragment or not parsed.hostname:
+        raise DiagnosticSafetyError("Doctor base URL must not contain query, fragment, or missing host.")
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def probe_capabilities(
+    base_url: str,
+    *,
+    timeout: float = 10.0,
+    transport: httpx.BaseTransport | None = None,
+) -> dict[str, Any]:
+    """Perform one bounded anonymous capability read and return raw in-memory input."""
+    safe_base = safe_probe_base_url(base_url)
+    target = f"{safe_base}/api/v1/services?limit=1"
+    captured_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    try:
+        with (
+            httpx.Client(
+                timeout=max(0.001, min(timeout, 30.0)),
+                follow_redirects=False,
+                trust_env=False,
+                transport=transport,
+            ) as client,
+            client.stream(
+                "GET",
+                target,
+                headers={"Accept": "application/json, application/problem+json"},
+            ) as response,
+        ):
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes():
+                total += len(chunk)
+                if total > _MAX_PROBE_BYTES:
+                    raise DiagnosticSafetyError("Capability probe response exceeds 256 KiB.")
+                chunks.append(chunk)
+            raw_body = b"".join(chunks)
+            return {
+                "method": "GET",
+                "url": target,
+                "statusCode": response.status_code,
+                "mediaType": response.headers.get("content-type"),
+                "correlationId": response.headers.get("x-correlation-id") or response.headers.get("x-request-id"),
+                "traceId": response.headers.get("traceparent"),
+                "capturedAt": captured_at,
+                "responseHeaders": dict(response.headers),
+                "responseBody": raw_body,
+            }
+    except DiagnosticSafetyError:
+        raise
+    except (httpx.HTTPError, OSError):
+        return {"method": "GET", "url": target, "capturedAt": captured_at}
+
+
+def replay_diagnostic_bundle(
+    bundle: object,
+    base_url: str,
+    *,
+    timeout: float = 10.0,
+    transport: httpx.BaseTransport | None = None,
+) -> dict[str, Any]:
+    """Replay one sanitized read envelope anonymously and return a new bundle."""
+    assert_diagnostic_bundle(bundle)
+    validated = cast(dict[str, Any], bundle)
+    _assert_replay_artifact_safe(validated)
+    envelopes = cast(list[dict[str, Any]], validated["envelopes"])
+    envelope = envelopes[-1]
+    method = cast(str, envelope["method"])
+    normalized_path = cast(str, envelope["normalizedPath"])
+    if method.upper() not in {"GET", "HEAD"}:
+        raise DiagnosticSafetyError("Replay permits only one GET or HEAD request.")
+    replay_path = _safe_replay_path(normalized_path)
+    target = _join_replay_target(safe_probe_base_url(base_url), replay_path)
+    captured_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    try:
+        with (
+            httpx.Client(
+                timeout=max(0.001, min(timeout, 30.0)),
+                follow_redirects=False,
+                trust_env=False,
+                transport=transport,
+            ) as client,
+            client.stream(
+                method.upper(),
+                target,
+                headers={"Accept": "application/json, application/problem+json"},
+            ) as response,
+        ):
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes():
+                total += len(chunk)
+                if total > _MAX_PROBE_BYTES:
+                    raise DiagnosticSafetyError("Replay response exceeds 256 KiB.")
+                chunks.append(chunk)
+            exchange = {
+                "method": method.upper(),
+                "url": target,
+                "statusCode": response.status_code,
+                "mediaType": response.headers.get("content-type"),
+                "correlationId": response.headers.get("x-correlation-id") or response.headers.get("x-request-id"),
+                "traceId": response.headers.get("traceparent"),
+                "capturedAt": captured_at,
+                "responseHeaders": dict(response.headers),
+                "responseBody": b"".join(chunks),
+            }
+    except DiagnosticSafetyError:
+        raise
+    except (httpx.HTTPError, OSError) as exc:
+        raise DiagnosticSafetyError("Replay request failed without producing an artifact.") from exc
+
+    consent = cast(dict[str, Any], validated["consent"])
+    return create_diagnostic_bundle(
+        content_classification=cast(str, validated["contentClassification"]),
+        redaction_acknowledged=bool(consent["redactionAcknowledged"]),
+        share_with_support=bool(consent["shareWithSupport"]),
+        exchanges=[exchange],
+        granted_by=consent.get("grantedBy") if isinstance(consent.get("grantedBy"), str) else None,
+    )
+
+
+def _assert_replay_artifact_safe(bundle: Mapping[str, Any]) -> None:
+    bundle_id = bundle.get("bundleId")
+    if isinstance(bundle_id, str):
+        _safe_metadata(bundle_id, "bundleId", 64)
+    consent = bundle.get("consent")
+    if isinstance(consent, dict) and isinstance(consent.get("grantedBy"), str):
+        _safe_metadata(consent["grantedBy"], "grantedBy", 256)
+    envelopes = cast(list[dict[str, Any]], bundle["envelopes"])
+    for envelope in envelopes:
+        if "requestBody" in envelope:
+            raise DiagnosticSafetyError("Replay refuses artifacts containing request bodies.")
+        for header_group in ("requestHeaders", "responseHeaders"):
+            headers = envelope.get(header_group)
+            if headers is None:
+                continue
+            for header in cast(list[dict[str, Any]], headers):
+                name = header.get("name")
+                value = header.get("value")
+                if (
+                    not isinstance(name, str)
+                    or name.lower() not in _SAFE_HEADER_NAMES
+                    or not isinstance(value, str)
+                    or _SECRET_PATTERN.search(value)
+                ):
+                    raise DiagnosticSafetyError("Replay artifact contains unsafe headers.")
+        for body_name in ("responseBody",):
+            body = envelope.get(body_name)
+            if isinstance(body, dict):
+                _verify_body_metadata(body)
+
+
+def _verify_body_metadata(body: Mapping[str, Any]) -> None:
+    preview = body.get("preview")
+    content_hash = body.get("contentSha256")
+    redacted = body.get("redactionApplied")
+    truncated = body.get("truncated")
+    if isinstance(preview, str) and _SECRET_PATTERN.search(preview):
+        raise DiagnosticSafetyError("Replay artifact contains credential-shaped body content.")
+    if (
+        isinstance(preview, str)
+        and isinstance(content_hash, str)
+        and redacted is False
+        and truncated is False
+        and hashlib.sha256(preview.encode()).hexdigest() != content_hash
+    ):
+        raise DiagnosticSafetyError("Replay artifact body hash does not match its unredacted preview.")
+
+
+def _safe_replay_path(normalized_path: str) -> str:
+    raw_path = normalized_path.split("?", 1)[0]
+    decoded = unquote(unquote(raw_path))
+    segments = [segment for segment in decoded.split("/") if segment]
+    lowered_segments = {segment.lower() for segment in segments}
+    if (
+        not decoded.startswith("/")
+        or "{" in decoded
+        or "}" in decoded
+        or "%" in normalized_path
+        or "//" in decoded
+        or "\\" in decoded
+        or "\x00" in decoded
+        or any(segment in {".", ".."} for segment in decoded.split("/"))
+        or any(segment not in _SAFE_PATH_SEGMENTS for segment in segments)
+        or lowered_segments.intersection({"subscribe", "subscriptions", "stream", "watch", "events"})
+    ):
+        raise DiagnosticSafetyError("Replay path is unsafe, parameterized, or subscription-shaped.")
+    return decoded
+
+
+def _join_replay_target(base_url: str, replay_path: str) -> str:
+    parsed = urlsplit(base_url)
+    prefix = parsed.path.rstrip("/")
+    path = replay_path if prefix and replay_path.startswith(f"{prefix}/") else f"{prefix}{replay_path}"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _validate_consent(value: object, errors: list[str]) -> None:
+    if not isinstance(value, dict):
+        errors.append("$.consent: expected type 'object'")
+        return
+    _unexpected(value, _CONSENT_KEYS, "$.consent", errors)
+    _required(value, ("redactionAcknowledged", "shareWithSupport"), "$.consent", errors)
+    _boolean(value, "redactionAcknowledged", "$.consent", errors)
+    _boolean(value, "shareWithSupport", "$.consent", errors)
+    _string(value, "grantedBy", "$.consent", errors, maximum=256)
+
+
+def _validate_envelope(value: object, index: int, errors: list[str]) -> None:
+    path = f"$.envelopes[{index}]"
+    if not isinstance(value, dict):
+        errors.append(f"{path}: expected type 'object'")
+        return
+    _unexpected(value, _ENVELOPE_KEYS, path, errors)
+    _required(value, ("method", "normalizedPath"), path, errors)
+    _string(value, "method", path, errors, maximum=16)
+    _string(value, "normalizedPath", path, errors, maximum=2048)
+    _integer(value, "statusCode", path, errors, minimum=100, maximum=599)
+    for name, maximum in (
+        ("mediaType", 256),
+        ("correlationId", 200),
+        ("traceId", 200),
+        ("capturedAt", 40),
+    ):
+        _string(value, name, path, errors, maximum=maximum)
+    for name in ("requestHeaders", "responseHeaders"):
+        _validate_headers(value, name, path, errors)
+    for name in ("requestBody", "responseBody"):
+        _validate_body(value, name, path, errors)
+
+
+def _validate_headers(value: Mapping[str, object], name: str, parent: str, errors: list[str]) -> None:
+    if name not in value:
+        return
+    headers = value[name]
+    path = f"{parent}.{name}"
+    if not isinstance(headers, list):
+        errors.append(f"{path}: expected type 'array'")
+        return
+    if len(headers) > _MAX_HEADERS:
+        errors.append(f"{path}: contains more than maximum 32 items")
+    for index, header in enumerate(headers):
+        header_path = f"{path}[{index}]"
+        if not isinstance(header, dict):
+            errors.append(f"{header_path}: expected type 'object'")
+            continue
+        _unexpected(header, frozenset({"name", "value"}), header_path, errors)
+        _required(header, ("name", "value"), header_path, errors)
+        _string(header, "name", header_path, errors, maximum=128)
+        _string(header, "value", header_path, errors, maximum=2048)
+
+
+def _validate_body(value: Mapping[str, object], name: str, parent: str, errors: list[str]) -> None:
+    if name not in value:
+        return
+    body = value[name]
+    path = f"{parent}.{name}"
+    if not isinstance(body, dict):
+        errors.append(f"{path}: expected type 'object'")
+        return
+    _unexpected(body, _BODY_KEYS, path, errors)
+    _required(body, ("originalByteSize", "redactionApplied", "truncated"), path, errors)
+    _string(body, "preview", path, errors, maximum=8192)
+    _string(body, "contentSha256", path, errors, maximum=64)
+    _integer(body, "originalByteSize", path, errors, minimum=0, maximum=_MAX_BODY_BYTES)
+    _boolean(body, "redactionApplied", path, errors)
+    _boolean(body, "truncated", path, errors)
+
+
+def _required(value: Mapping[str, object], names: Sequence[str], path: str, errors: list[str]) -> None:
+    for name in names:
+        if name not in value:
+            errors.append(f"{path}: missing required property '{name}'")
+
+
+def _unexpected(value: Mapping[str, object], allowed: frozenset[str], path: str, errors: list[str]) -> None:
+    for name in value:
+        if name not in allowed:
+            errors.append(f"{path}: unexpected property '{name}'")
+
+
+def _string(
+    value: Mapping[str, object],
+    name: str,
+    parent: str,
+    errors: list[str],
+    *,
+    maximum: int,
+    constant: str | None = None,
+) -> str | None:
+    if name not in value:
+        return None
+    item = value[name]
+    path = f"{parent}.{name}"
+    if not isinstance(item, str):
+        errors.append(f"{path}: expected type 'string'")
+        return None
+    if len(item) > maximum:
+        errors.append(f"{path}: exceeds maximum length {maximum}")
+    if constant is not None and item != constant:
+        errors.append(f"{path}: value must equal the constant '{constant}'")
+    return item
+
+
+def _integer(
+    value: Mapping[str, object],
+    name: str,
+    parent: str,
+    errors: list[str],
+    *,
+    minimum: int,
+    maximum: int,
+) -> None:
+    if name not in value:
+        return
+    item = value[name]
+    path = f"{parent}.{name}"
+    if not isinstance(item, int) or isinstance(item, bool):
+        errors.append(f"{path}: expected type 'integer'")
+        return
+    if item < minimum:
+        errors.append(f"{path}: is below minimum {minimum}")
+    if item > maximum:
+        errors.append(f"{path}: exceeds maximum {maximum}")
+
+
+def _boolean(value: Mapping[str, object], name: str, parent: str, errors: list[str]) -> None:
+    if name in value and not isinstance(value[name], bool):
+        errors.append(f"{parent}.{name}: expected type 'boolean'")
+
+
+def _copy_optional_integer(
+    source: Mapping[str, Any],
+    target: dict[str, Any],
+    name: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> None:
+    if name not in source or source[name] is None:
+        return
+    value = source[name]
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum or value > maximum:
+        raise DiagnosticSafetyError(f"Diagnostic {name} is outside the canonical range.")
+    target[name] = value
+
+
+def _copy_optional_safe_string(source: Mapping[str, Any], target: dict[str, Any], name: str, *, maximum: int) -> None:
+    if name not in source or source[name] is None:
+        return
+    value = source[name]
+    if not isinstance(value, str):
+        raise DiagnosticSafetyError(f"Diagnostic {name} must be a string when present.")
+    if value and not _SECRET_PATTERN.search(value) and "\r" not in value and "\n" not in value:
+        target[name] = value[:maximum]
+
+
+def _safe_metadata(value: str, field: str, maximum: int) -> str:
+    normalized = value.strip()
+    if not normalized or len(normalized) > maximum or _SECRET_PATTERN.search(normalized):
+        raise DiagnosticSafetyError(f"Diagnostic {field} is empty, over-budget, or credential-shaped.")
+    return normalized
+
+
+def _header_value(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        strings = [item for item in value if isinstance(item, str)]
+        if len(strings) == len(value):
+            return ", ".join(strings)
+    return None
+
+
+def _body_bytes(value: object) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode()
+    try:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    except (TypeError, ValueError) as exc:
+        raise DiagnosticSafetyError("Diagnostic body is not JSON-serializable.") from exc
+
+
+__all__ = [
+    "DIAGNOSTIC_SCHEMA_BYTES",
+    "DIAGNOSTIC_SCHEMA_SHA256",
+    "DIAGNOSTIC_SCHEMA_URL",
+    "DiagnosticError",
+    "DiagnosticSafetyError",
+    "DiagnosticValidationError",
+    "assert_diagnostic_bundle",
+    "create_diagnostic_bundle",
+    "normalize_diagnostic_path",
+    "probe_capabilities",
+    "replay_diagnostic_bundle",
+    "safe_probe_base_url",
+    "sanitize_body",
+    "sanitize_exchange",
+    "sanitize_headers",
+    "validate_diagnostic_bundle",
+]

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/additional-property.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/additional-property.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready",
+      "rawResponse": "raw response bytes are forbidden"
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/missing-consent.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/missing-consent.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready"
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/optional-null.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/optional-null.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "bundleId": null,
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready"
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/status-out-of-range.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/status-out-of-range.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready",
+      "statusCode": 600
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/wrong-version.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/invalid/wrong-version.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "2.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/healthz/ready"
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/manifest.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/manifest.json
@@ -1,0 +1,48 @@
+{
+  "suiteVersion": "1.0",
+  "schemaId": "https://honua.io/schemas/diagnostic-bundle.v1.json",
+  "schemaVersion": "1.0",
+  "schemaSha256": "4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9",
+  "cases": [
+    {
+      "id": "minimal-valid",
+      "path": "valid/minimal.json",
+      "valid": true
+    },
+    {
+      "id": "sanitized-exchange-valid",
+      "path": "valid/sanitized-exchange.json",
+      "valid": true
+    },
+    {
+      "id": "missing-consent-invalid",
+      "path": "invalid/missing-consent.json",
+      "valid": false,
+      "expectedErrorContains": "missing required property 'consent'"
+    },
+    {
+      "id": "wrong-version-invalid",
+      "path": "invalid/wrong-version.json",
+      "valid": false,
+      "expectedErrorContains": "value must equal the constant"
+    },
+    {
+      "id": "additional-property-invalid",
+      "path": "invalid/additional-property.json",
+      "valid": false,
+      "expectedErrorContains": "unexpected property 'rawResponse'"
+    },
+    {
+      "id": "optional-null-invalid",
+      "path": "invalid/optional-null.json",
+      "valid": false,
+      "expectedErrorContains": "expected type 'string'"
+    },
+    {
+      "id": "status-out-of-range-invalid",
+      "path": "invalid/status-out-of-range.json",
+      "valid": false,
+      "expectedErrorContains": "exceeds maximum 599"
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/valid/minimal.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/valid/minimal.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0",
+  "contentClassification": "internal",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true
+  },
+  "envelopes": [
+    {
+      "method": "GET",
+      "normalizedPath": "/rest/services/{service}/FeatureServer/{layer}/query"
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/valid/sanitized-exchange.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.conformance/valid/sanitized-exchange.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "1.0",
+  "bundleId": "doctor-01J00000000000000000000000",
+  "contentClassification": "customer-data",
+  "consent": {
+    "redactionAcknowledged": true,
+    "shareWithSupport": true,
+    "grantedBy": "customer-operator"
+  },
+  "envelopes": [
+    {
+      "method": "POST",
+      "normalizedPath": "/api/v1/tickets/{ticketId}/diagnostics",
+      "statusCode": 400,
+      "mediaType": "application/problem+json",
+      "correlationId": "corr-redacted-01",
+      "traceId": "0123456789abcdef0123456789abcdef",
+      "capturedAt": "2026-07-11T12:00:00Z",
+      "requestHeaders": [
+        {
+          "name": "Content-Type",
+          "value": "application/json"
+        }
+      ],
+      "responseHeaders": [
+        {
+          "name": "Content-Type",
+          "value": "application/problem+json"
+        }
+      ],
+      "requestBody": {
+        "preview": "{\"query\":\"[REDACTED]\"}",
+        "contentSha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        "originalByteSize": 128,
+        "redactionApplied": true,
+        "truncated": false
+      },
+      "responseBody": {
+        "preview": "{\"error\":\"validation failed\"}",
+        "contentSha256": "1111111111111111111111111111111111111111111111111111111111111111",
+        "originalByteSize": 38,
+        "redactionApplied": false,
+        "truncated": false
+      }
+    }
+  ]
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://honua.io/schemas/diagnostic-bundle.v1.json",
+  "title": "Honua Sanitized Diagnostic Bundle (v1)",
+  "description": "Canonical, sanitized evidence contract for SDK/client interop tickets (honua-support#41). A diagnostic bundle NEVER carries raw request/response bytes. Each captured HTTP exchange is a sanitized envelope: HTTP method, a normalized path (path parameters and query values placeholdered), status code, media type, correlation/trace ids, an allowlist of safe headers ONLY, and redacted + truncated body previews. For each body, the ORIGINAL byte size and a content hash are recorded alongside a redaction-applied flag so integrity is verifiable without the bytes. The bundle carries explicit content-classification and consent fields. Intake VALIDATES submissions against this schema and enforces every string-length, array-count, and body-size bound below; violations are rejected with a 400. This is the canonical artifact SDK emitters and the console must conform to.",
+  "type": "object",
+  "required": ["schemaVersion", "contentClassification", "consent", "envelopes"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "description": "Contract version. Bump only on breaking changes; additive fields keep v1.",
+      "type": "string",
+      "const": "1.0"
+    },
+    "bundleId": {
+      "description": "Optional client-assigned id for the bundle. The server assigns its own id on intake.",
+      "type": "string",
+      "maxLength": 64
+    },
+    "contentClassification": {
+      "description": "Declared sensitivity of the captured content, after client-side redaction.",
+      "type": "string",
+      "enum": ["unknown", "public", "internal", "customer-data", "secret-suspected"]
+    },
+    "consent": {
+      "description": "Explicit consent to share the sanitized bundle with Honua support.",
+      "type": "object",
+      "required": ["redactionAcknowledged", "shareWithSupport"],
+      "additionalProperties": false,
+      "properties": {
+        "redactionAcknowledged": {
+          "description": "The submitter acknowledges the bundle was redacted and carries no raw secrets.",
+          "type": "boolean"
+        },
+        "shareWithSupport": {
+          "description": "The submitter consents to sharing the sanitized bundle with Honua support.",
+          "type": "boolean"
+        },
+        "grantedBy": {
+          "description": "Optional identity of the human/automation that granted consent.",
+          "type": "string",
+          "maxLength": 256
+        }
+      }
+    },
+    "envelopes": {
+      "description": "Sanitized HTTP exchanges. At least one; capped to bound bundle size.",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "required": ["method", "normalizedPath"],
+        "additionalProperties": false,
+        "properties": {
+          "method": {
+            "description": "HTTP method (e.g. GET, POST).",
+            "type": "string",
+            "maxLength": 16
+          },
+          "normalizedPath": {
+            "description": "Request path with path parameters and query values placeholdered (e.g. /api/v1/tickets/{id}?status={value}).",
+            "type": "string",
+            "maxLength": 2048
+          },
+          "statusCode": {
+            "description": "HTTP status code, when the exchange produced a response.",
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 599
+          },
+          "mediaType": {
+            "description": "Response media type (e.g. application/json).",
+            "type": "string",
+            "maxLength": 256
+          },
+          "correlationId": {
+            "description": "Correlation id linking the exchange to server logs.",
+            "type": "string",
+            "maxLength": 200
+          },
+          "traceId": {
+            "description": "Distributed-trace id for the exchange.",
+            "type": "string",
+            "maxLength": 200
+          },
+          "capturedAt": {
+            "description": "When the exchange was captured (ISO-8601).",
+            "type": "string",
+            "maxLength": 40
+          },
+          "requestHeaders": {
+            "description": "Allowlisted, non-secret request headers ONLY. Authorization, Cookie, and any header not on the server allowlist are never present.",
+            "type": "array",
+            "maxItems": 32,
+            "items": { "$ref": "#/$defs/header" }
+          },
+          "responseHeaders": {
+            "description": "Allowlisted, non-secret response headers ONLY. Set-Cookie and any header not on the server allowlist are never present.",
+            "type": "array",
+            "maxItems": 32,
+            "items": { "$ref": "#/$defs/header" }
+          },
+          "requestBody": { "$ref": "#/$defs/bodyPreview" },
+          "responseBody": { "$ref": "#/$defs/bodyPreview" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "header": {
+      "type": "object",
+      "required": ["name", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "maxLength": 128 },
+        "value": { "type": "string", "maxLength": 2048 }
+      }
+    },
+    "bodyPreview": {
+      "description": "A redacted, truncated preview of a body plus integrity metadata for the ORIGINAL bytes. The raw bytes are never included.",
+      "type": "object",
+      "required": ["originalByteSize", "redactionApplied", "truncated"],
+      "additionalProperties": false,
+      "properties": {
+        "preview": {
+          "description": "Redacted, truncated text preview of the body.",
+          "type": "string",
+          "maxLength": 8192
+        },
+        "contentSha256": {
+          "description": "Lowercase hex SHA-256 of the ORIGINAL (pre-redaction) body bytes.",
+          "type": "string",
+          "maxLength": 64
+        },
+        "originalByteSize": {
+          "description": "Size in bytes of the ORIGINAL body before truncation/redaction.",
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 26214400
+        },
+        "redactionApplied": {
+          "description": "True when redaction removed content from the preview.",
+          "type": "boolean"
+        },
+        "truncated": {
+          "description": "True when the preview is shorter than the original body.",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.provenance.json
+++ b/packages/honua-sdk/honua_sdk/schemas/diagnostic-bundle.v1.provenance.json
@@ -1,0 +1,9 @@
+{
+  "schema": "honua.public-schema-provenance.v1",
+  "sourceRepository": "honua-io/honua-support",
+  "sourcePath": "schemas/diagnostic-bundle.v1.json",
+  "sourceCommit": "0c990fbe8f519a00a57e26dab21cbb8f80d559ea",
+  "sha256": "4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9",
+  "bytes": 6494,
+  "canonicalUrl": "https://honua.io/schemas/diagnostic-bundle.v1.json"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ ignore = []
 # (PLC0415): the pure-dict ``__geo_interface__`` path needs no third-party dep.
 "packages/honua-sdk/honua_sdk/models/_geometry.py" = ["PLC0415"]
 "packages/honua-sdk/honua_sdk/_http.py" = ["PLR2004"]
+"packages/honua-sdk/honua_sdk/diagnostics.py" = ["PLR0912", "PLR0913"]
 "packages/honua-sdk/honua_sdk/_query.py" = ["PLR0913", "PLR2004"]
 # models/_query.py: Result.to_geodataframe lazily imports the geopandas bridge
 # so geopandas stays an optional dependency (PLC0415).

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,485 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from honua_sdk import diagnostics
+
+
+SCHEMA_DIRECTORY = Path(diagnostics.__file__).parent / "schemas"
+
+
+def test_canonical_schema_and_provenance_are_byte_pinned() -> None:
+    schema = (SCHEMA_DIRECTORY / "diagnostic-bundle.v1.json").read_bytes()
+    provenance = json.loads((SCHEMA_DIRECTORY / "diagnostic-bundle.v1.provenance.json").read_text())
+
+    assert len(schema) == diagnostics.DIAGNOSTIC_SCHEMA_BYTES == provenance["bytes"]
+    assert hashlib.sha256(schema).hexdigest() == diagnostics.DIAGNOSTIC_SCHEMA_SHA256 == provenance["sha256"]
+    assert provenance["canonicalUrl"] == diagnostics.DIAGNOSTIC_SCHEMA_URL
+    assert provenance["sourceCommit"] == "0c990fbe8f519a00a57e26dab21cbb8f80d559ea"
+
+
+def test_merged_conformance_corpus_matches_validator() -> None:
+    corpus = SCHEMA_DIRECTORY / "diagnostic-bundle.v1.conformance"
+    manifest = json.loads((corpus / "manifest.json").read_text())
+    assert manifest["schemaSha256"] == diagnostics.DIAGNOSTIC_SCHEMA_SHA256
+
+    for case in manifest["cases"]:
+        payload = json.loads((corpus / case["path"]).read_text())
+        errors = diagnostics.validate_diagnostic_bundle(payload)
+        assert (not errors) is case["valid"], f"{case['id']}: {errors}"
+        if not case["valid"]:
+            assert case["expectedErrorContains"] in "\n".join(errors)
+
+
+def test_validator_rejects_every_bounded_wire_shape_violation() -> None:
+    base = _minimal_bundle({"method": "GET", "normalizedPath": "/healthz/ready"})
+    invalid_values: list[object] = [
+        None,
+        {**base, "unknown": True},
+        {**base, "contentClassification": "not-a-classification"},
+        {**base, "consent": None},
+        {**base, "consent": {"redactionAcknowledged": True}},
+        {**base, "consent": {"redactionAcknowledged": "yes", "shareWithSupport": False}},
+        {**base, "consent": {"redactionAcknowledged": True, "shareWithSupport": False, "extra": True}},
+        {**base, "envelopes": "not-an-array"},
+        {**base, "envelopes": []},
+        {**base, "envelopes": [base["envelopes"][0]] * 51},
+        {**base, "envelopes": [None]},
+        _minimal_bundle({"normalizedPath": "/healthz/ready"}),
+        _minimal_bundle({"method": None, "normalizedPath": "/healthz/ready"}),
+        _minimal_bundle({"method": "G" * 17, "normalizedPath": "/healthz/ready"}),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "statusCode": True}),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "statusCode": 99}),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "mediaType": "x" * 257}),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "requestHeaders": "bad"}),
+        _minimal_bundle(
+            {"method": "GET", "normalizedPath": "/x", "requestHeaders": [{"name": "x", "value": "y"}] * 33}
+        ),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "requestHeaders": [None]}),
+        _minimal_bundle(
+            {"method": "GET", "normalizedPath": "/x", "requestHeaders": [{"name": "x", "value": "y", "x": 1}]}
+        ),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "requestHeaders": [{"name": "x"}]}),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/x", "responseBody": "bad"}),
+        _minimal_bundle(
+            {
+                "method": "GET",
+                "normalizedPath": "/x",
+                "responseBody": {"originalByteSize": 0, "redactionApplied": False, "truncated": False, "extra": 1},
+            }
+        ),
+        _minimal_bundle(
+            {"method": "GET", "normalizedPath": "/x", "responseBody": {"redactionApplied": False, "truncated": False}}
+        ),
+        _minimal_bundle(
+            {
+                "method": "GET",
+                "normalizedPath": "/x",
+                "responseBody": {"originalByteSize": -1, "redactionApplied": "no", "truncated": False},
+            }
+        ),
+    ]
+
+    for value in invalid_values:
+        assert diagnostics.validate_diagnostic_bundle(value), value
+        with pytest.raises(diagnostics.DiagnosticValidationError):
+            diagnostics.assert_diagnostic_bundle(value)
+
+
+def test_create_bundle_rejects_invalid_required_inputs_and_accepts_safe_identity() -> None:
+    exchange = {"method": "GET", "url": "https://example.test/healthz/ready"}
+    invalid_calls = [
+        {
+            "content_classification": "invalid",
+            "redaction_acknowledged": True,
+            "share_with_support": False,
+            "exchanges": [exchange],
+        },
+        {
+            "content_classification": "internal",
+            "redaction_acknowledged": "yes",
+            "share_with_support": False,
+            "exchanges": [exchange],
+        },
+        {
+            "content_classification": "internal",
+            "redaction_acknowledged": True,
+            "share_with_support": False,
+            "exchanges": [],
+        },
+        {
+            "content_classification": "internal",
+            "redaction_acknowledged": True,
+            "share_with_support": False,
+            "exchanges": [exchange] * 51,
+        },
+    ]
+    for arguments in invalid_calls:
+        with pytest.raises(diagnostics.DiagnosticSafetyError):
+            diagnostics.create_diagnostic_bundle(**arguments)  # type: ignore[arg-type]
+
+    bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        granted_by="safe-automation",
+        exchanges=[exchange],
+    )
+    assert bundle["consent"]["grantedBy"] == "safe-automation"
+
+
+def test_emitter_omits_absent_optional_fields_and_validates() -> None:
+    bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        exchanges=[{"method": "GET", "url": "https://example.test/healthz/ready"}],
+    )
+
+    diagnostics.assert_diagnostic_bundle(bundle)
+    assert "bundleId" not in bundle
+    assert "grantedBy" not in bundle["consent"]
+    envelope = bundle["envelopes"][0]
+    assert envelope == {"method": "GET", "normalizedPath": "/healthz/ready"}
+    assert all(value is not None for value in _walk_values(bundle))
+
+
+def test_emitter_never_serializes_raw_headers_urls_or_bodies() -> None:
+    secret = "super-secret-token-value"
+    request_body = f'{{"apiKey":"{secret}","query":"customer parcel 42"}}'
+    bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="secret-suspected",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        bundle_id="doctor-safe-1",
+        exchanges=[
+            {
+                "method": "POST",
+                "url": f"https://user:{secret}@example.test/rest/services/private/FeatureServer/42/query?token={secret}&f=json",
+                "statusCode": 500,
+                "mediaType": "application/problem+json",
+                "requestHeaders": {
+                    "Authorization": f"Bearer {secret}",
+                    "Cookie": f"session={secret}",
+                    "X-API-Key": secret,
+                    "Content-Type": "application/json",
+                    "X-Request-Id": "request-safe-1",
+                    "X-Internal-Debug": secret,
+                },
+                "responseHeaders": {"Set-Cookie": secret, "Content-Type": "application/problem+json"},
+                "requestBody": request_body,
+                "responseBody": {"password": secret, "error": "failed"},
+            }
+        ],
+    )
+
+    serialized = json.dumps(bundle)
+    assert secret not in serialized
+    assert "customer parcel" not in serialized
+    assert "Authorization" not in serialized
+    assert "Cookie" not in serialized
+    assert "X-API-Key" not in serialized
+    assert "X-Internal-Debug" not in serialized
+    assert "private" not in serialized
+    envelope = bundle["envelopes"][0]
+    assert envelope["normalizedPath"] == "/rest/services/{value}/FeatureServer/{value}/query?f={value}"
+    assert envelope["requestHeaders"] == [
+        {"name": "Content-Type", "value": "application/json"},
+        {"name": "X-Request-Id", "value": "request-safe-1"},
+    ]
+    assert envelope["responseHeaders"] == [{"name": "Content-Type", "value": "application/problem+json"}]
+    assert envelope["requestBody"] == {
+        "contentSha256": hashlib.sha256(request_body.encode()).hexdigest(),
+        "originalByteSize": len(request_body.encode()),
+        "redactionApplied": True,
+        "truncated": True,
+    }
+    assert "preview" not in envelope["requestBody"]
+
+
+def test_unsafe_metadata_fails_before_bundle_creation() -> None:
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.create_diagnostic_bundle(
+            content_classification="internal",
+            redaction_acknowledged=True,
+            share_with_support=False,
+            bundle_id="Bearer should-not-survive",
+            exchanges=[{"method": "GET", "url": "https://example.test/healthz/ready"}],
+        )
+
+
+def test_sanitizer_rejects_bad_shapes_and_handles_header_sequences_and_empty_body() -> None:
+    for exchange in ({"url": "https://example.test"}, {"method": "GET"}):
+        with pytest.raises(diagnostics.DiagnosticSafetyError):
+            diagnostics.sanitize_exchange(exchange)
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.sanitize_headers("not-a-mapping")
+    assert diagnostics.sanitize_headers(None) == []
+    headers = diagnostics.sanitize_headers(
+        {
+            42: "ignored",
+            "Accept": ["application/json", "application/problem+json"],
+            "Content-Type": ["valid", 42],
+            "X-Request-Id": "bad\r\nheader",
+        }
+    )
+    assert headers == [{"name": "Accept", "value": "application/json, application/problem+json"}]
+    assert diagnostics.sanitize_body(b"") == {
+        "contentSha256": hashlib.sha256(b"").hexdigest(),
+        "originalByteSize": 0,
+        "redactionApplied": False,
+        "truncated": False,
+    }
+    assert diagnostics.sanitize_body(bytearray(b"x"))["originalByteSize"] == 1
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.sanitize_body({"not-json": object()})
+
+
+def test_sanitizer_rejects_unsafe_and_overlong_paths_and_optional_types() -> None:
+    for path in ("/safe/../secret", "/safe/%252e%252e/secret", "/safe\\secret"):
+        with pytest.raises(diagnostics.DiagnosticSafetyError):
+            diagnostics.normalize_diagnostic_path(path)
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.normalize_diagnostic_path("/" + "/".join(f"segment-{index}" for index in range(500)))
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.sanitize_exchange({"method": "GET", "url": "/healthz/ready", "statusCode": 600})
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.sanitize_exchange({"method": "GET", "url": "/healthz/ready", "mediaType": 42})
+
+
+def test_probe_is_anonymous_bounded_and_preserves_base_path() -> None:
+    secret = "probe-response-secret"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/honua/api/v1/services"
+        assert dict(request.url.params) == {"limit": "1"}
+        assert "authorization" not in request.headers
+        assert "x-api-key" not in request.headers
+        return httpx.Response(
+            503,
+            headers={"Content-Type": "application/problem+json", "X-Correlation-Id": "corr-1"},
+            content=f'{{"token":"{secret}"}}',
+        )
+
+    probe = diagnostics.probe_capabilities(
+        "https://example.test/honua",
+        transport=httpx.MockTransport(handler),
+    )
+    bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        exchanges=[probe],
+    )
+
+    assert secret not in json.dumps(bundle)
+    envelope = bundle["envelopes"][0]
+    assert envelope["statusCode"] == 503
+    assert envelope["correlationId"] == "corr-1"
+    assert envelope["normalizedPath"] == "/{value}/api/v1/services?limit={value}"
+
+
+def test_probe_failure_returns_structured_minimal_envelope() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("contains sensitive network details", request=request)
+
+    probe = diagnostics.probe_capabilities(
+        "https://example.test",
+        transport=httpx.MockTransport(handler),
+    )
+    envelope = diagnostics.sanitize_exchange(probe)
+
+    assert envelope["method"] == "GET"
+    assert envelope["normalizedPath"] == "/api/v1/services?limit={value}"
+    assert "statusCode" not in envelope
+    assert "sensitive" not in json.dumps(envelope)
+
+
+def test_probe_over_budget_fails_closed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * (256 * 1024 + 1), request=request)
+
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.probe_capabilities("https://example.test", transport=httpx.MockTransport(handler))
+
+
+def test_body_over_canonical_budget_fails_closed() -> None:
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.sanitize_body(b"x" * (25 * 1024 * 1024 + 1))
+
+
+def test_unsafe_probe_origins_are_rejected() -> None:
+    for value in (
+        "http://example.test",
+        "https://user:password@example.test",
+        "https://example.test?token=secret",
+        "file:///tmp/server",
+    ):
+        with pytest.raises(diagnostics.DiagnosticSafetyError):
+            diagnostics.safe_probe_base_url(value)
+
+
+def test_replay_performs_one_anonymous_read_and_returns_new_sanitized_bundle() -> None:
+    bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        bundle_id="doctor-replay-safe",
+        granted_by="safe-automation",
+        exchanges=[{"method": "GET", "url": "https://source.test/healthz/ready"}],
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, headers={"Content-Type": "application/json"}, content=b'{"ready":true}')
+
+    replayed = diagnostics.replay_diagnostic_bundle(
+        bundle,
+        "https://target.test/honua",
+        transport=httpx.MockTransport(handler),
+    )
+
+    diagnostics.assert_diagnostic_bundle(replayed)
+    assert len(requests) == 1
+    assert requests[0].method == "GET"
+    assert requests[0].url.path == "/honua/healthz/ready"
+    assert not requests[0].url.query
+    assert "authorization" not in requests[0].headers
+    assert "x-api-key" not in requests[0].headers
+    assert b'"ready":true' not in json.dumps(replayed).encode()
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_replay_refuses_mutations_before_network(method: str) -> None:
+    bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        exchanges=[{"method": method, "url": "https://source.test/api/v1/services"}],
+    )
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200)
+
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.replay_diagnostic_bundle(
+            bundle,
+            "https://target.test",
+            transport=httpx.MockTransport(handler),
+        )
+    assert called is False
+
+
+def test_replay_refuses_placeholder_unsafe_header_and_hash_drift_before_network() -> None:
+    unsafe_bundles = [
+        _minimal_bundle({"method": "GET", "normalizedPath": "/rest/services/{value}/FeatureServer"}),
+        _minimal_bundle({"method": "GET", "normalizedPath": "/admin/delete-all"}),
+        _minimal_bundle(
+            {
+                "method": "GET",
+                "normalizedPath": "/healthz/ready",
+                "requestHeaders": [{"name": "Authorization", "value": "Bearer credential"}],
+            }
+        ),
+        _minimal_bundle(
+            {
+                "method": "GET",
+                "normalizedPath": "/healthz/ready",
+                "responseBody": {
+                    "preview": "safe-looking",
+                    "contentSha256": "0" * 64,
+                    "originalByteSize": 12,
+                    "redactionApplied": False,
+                    "truncated": False,
+                },
+            }
+        ),
+    ]
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200)
+
+    for bundle in unsafe_bundles:
+        diagnostics.assert_diagnostic_bundle(bundle)
+        with pytest.raises(diagnostics.DiagnosticSafetyError):
+            diagnostics.replay_diagnostic_bundle(
+                bundle,
+                "https://target.test",
+                transport=httpx.MockTransport(handler),
+            )
+    assert called is False
+
+
+def test_replay_refuses_request_body_secret_preview_network_failure_and_over_budget() -> None:
+    unsafe = [
+        _minimal_bundle(
+            {
+                "method": "GET",
+                "normalizedPath": "/healthz/ready",
+                "requestBody": {"originalByteSize": 0, "redactionApplied": False, "truncated": False},
+            }
+        ),
+        _minimal_bundle(
+            {
+                "method": "GET",
+                "normalizedPath": "/healthz/ready",
+                "responseBody": {
+                    "preview": "Bearer credential",
+                    "originalByteSize": 17,
+                    "redactionApplied": True,
+                    "truncated": True,
+                },
+            }
+        ),
+    ]
+    for bundle in unsafe:
+        with pytest.raises(diagnostics.DiagnosticSafetyError):
+            diagnostics.replay_diagnostic_bundle(
+                bundle, "https://target.test", transport=httpx.MockTransport(lambda _: httpx.Response(200))
+            )
+
+    safe = _minimal_bundle({"method": "GET", "normalizedPath": "/healthz/ready"})
+
+    def failed(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network detail", request=request)
+
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.replay_diagnostic_bundle(safe, "https://target.test", transport=httpx.MockTransport(failed))
+    with pytest.raises(diagnostics.DiagnosticSafetyError):
+        diagnostics.replay_diagnostic_bundle(
+            safe,
+            "https://target.test",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, content=b"x" * (256 * 1024 + 1), request=request)
+            ),
+        )
+
+
+def _walk_values(value: object) -> list[object]:
+    if isinstance(value, dict):
+        return [item for nested in value.values() for item in _walk_values(nested)]
+    if isinstance(value, list):
+        return [item for nested in value for item in _walk_values(nested)]
+    return [value]
+
+
+def _minimal_bundle(envelope: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schemaVersion": "1.0",
+        "contentClassification": "internal",
+        "consent": {"redactionAcknowledged": True, "shareWithSupport": False},
+        "envelopes": [envelope],
+    }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,11 +17,13 @@ SCHEMA_DIRECTORY = Path(diagnostics.__file__).parent / "schemas"
 def test_canonical_schema_and_provenance_are_byte_pinned() -> None:
     schema = (SCHEMA_DIRECTORY / "diagnostic-bundle.v1.json").read_bytes()
     provenance = json.loads((SCHEMA_DIRECTORY / "diagnostic-bundle.v1.provenance.json").read_text())
+    attributes = (Path(__file__).parents[1] / ".gitattributes").read_text()
 
     assert len(schema) == diagnostics.DIAGNOSTIC_SCHEMA_BYTES == provenance["bytes"]
     assert hashlib.sha256(schema).hexdigest() == diagnostics.DIAGNOSTIC_SCHEMA_SHA256 == provenance["sha256"]
     assert provenance["canonicalUrl"] == diagnostics.DIAGNOSTIC_SCHEMA_URL
     assert provenance["sourceCommit"] == "0c990fbe8f519a00a57e26dab21cbb8f80d559ea"
+    assert "packages/honua-sdk/honua_sdk/schemas/** text eol=lf" in attributes
 
 
 def test_merged_conformance_corpus_matches_validator() -> None:

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import json
+import io
+import stat
+from pathlib import Path
+import pytest
+
+from honua_sdk import cli, diagnostics
+
+
+def test_doctor_emits_valid_sanitized_bundle_and_machine_summary(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret = "cli-super-secret-token"
+    capture = tmp_path / "failure.json"
+    capture.write_text(
+        json.dumps(
+            {
+                "request": {
+                    "method": "POST",
+                    "url": f"https://example.test/rest/services/private/FeatureServer/7/query?token={secret}",
+                    "headers": {"Authorization": f"Bearer {secret}", "Content-Type": "application/json"},
+                    "body": {"password": secret, "query": "customer data"},
+                },
+                "response": {
+                    "status": 500,
+                    "mediaType": "application/problem+json",
+                    "headers": {"Set-Cookie": secret, "Content-Type": "application/problem+json"},
+                    "body": {"error": secret},
+                },
+            }
+        )
+    )
+    output = tmp_path / "bundle.json"
+
+    result = cli.main(
+        [
+            "doctor",
+            "--exchange",
+            str(capture),
+            "--classification",
+            "customer-data",
+            "--redaction-acknowledged",
+            "true",
+            "--share-with-support",
+            "false",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    bundle = json.loads(output.read_text())
+    diagnostics.assert_diagnostic_bundle(bundle)
+    assert secret not in output.read_text()
+    assert "customer data" not in output.read_text()
+    assert all(value is not None for value in _walk_values(bundle))
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["outcome"] == "emitted"
+    assert summary["schemaSha256"] == diagnostics.DIAGNOSTIC_SCHEMA_SHA256
+    assert summary["uploaded"] is False
+    assert str(output) not in json.dumps(summary)
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+
+
+def test_doctor_probe_failure_keeps_supplied_failure_last(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        cli,
+        "probe_capabilities",
+        lambda _base_url, *, timeout: {"method": "GET", "url": "https://example.test/api/v1/services?limit=1"},
+    )
+    capture = tmp_path / "failure.json"
+    capture.write_text(
+        json.dumps(
+            {
+                "request": {"method": "GET", "url": "https://example.test/healthz/ready"},
+                "response": {"status": 503},
+            }
+        )
+    )
+    output = tmp_path / "bundle.json"
+
+    result = cli.main(
+        [
+            "doctor",
+            "--base-url",
+            "https://example.test",
+            "--exchange",
+            str(capture),
+            "--classification",
+            "internal",
+            "--redaction-acknowledged",
+            "true",
+            "--share-with-support",
+            "false",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    envelopes = json.loads(output.read_text())["envelopes"]
+    assert len(envelopes) == 2
+    assert envelopes[-1]["normalizedPath"] == "/healthz/ready"
+    assert envelopes[-1]["statusCode"] == 503
+
+
+def test_doctor_invalid_metadata_writes_no_artifact_and_leaks_no_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret = "Bearer secret-metadata-value"
+    capture = tmp_path / "failure.json"
+    capture.write_text(json.dumps({"request": {"method": "GET", "url": "https://example.test/healthz/ready"}}))
+    output = tmp_path / "bundle.json"
+
+    result = cli.main(
+        [
+            "doctor",
+            "--exchange",
+            str(capture),
+            "--classification",
+            "internal",
+            "--redaction-acknowledged",
+            "true",
+            "--share-with-support",
+            "false",
+            "--bundle-id",
+            secret,
+            "--output",
+            str(output),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert not output.exists()
+    assert secret not in captured.out
+    assert secret not in captured.err
+    assert "unsafe or invalid" in captured.err
+
+
+def test_doctor_validates_final_serialized_bundle_before_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = tmp_path / "failure.json"
+    capture.write_text(json.dumps({"request": {"method": "GET", "url": "https://example.test/healthz/ready"}}))
+    output = tmp_path / "bundle.json"
+    monkeypatch.setattr(
+        cli,
+        "assert_diagnostic_bundle",
+        lambda _bundle: (_ for _ in ()).throw(diagnostics.DiagnosticValidationError(("forced drift",))),
+    )
+
+    result = cli.main(
+        [
+            "doctor",
+            "--exchange",
+            str(capture),
+            "--classification",
+            "internal",
+            "--redaction-acknowledged",
+            "true",
+            "--share-with-support",
+            "false",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 1
+    assert not output.exists()
+
+
+def test_doctor_help_describes_local_no_upload_workflow(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        cli.main(["doctor", "--help"])
+
+    assert exit_info.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "sanitized diagnostic-bundle.v1" in help_text
+    assert "never uploads" in help_text
+
+
+def test_cli_empty_table_message_remains_covered() -> None:
+    output = io.StringIO()
+
+    cli._print_table([], ["name"], output)
+
+    assert output.getvalue() == "(no entries)\n"
+
+
+def test_doctor_replay_validates_then_writes_new_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source_bundle = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        exchanges=[{"method": "GET", "url": "https://source.test/healthz/ready"}],
+    )
+    source = tmp_path / "source.json"
+    source.write_text(json.dumps(source_bundle))
+    output = tmp_path / "replayed.json"
+    replayed = diagnostics.create_diagnostic_bundle(
+        content_classification="internal",
+        redaction_acknowledged=True,
+        share_with_support=False,
+        exchanges=[{"method": "GET", "url": "https://target.test/healthz/ready", "statusCode": 200}],
+    )
+    monkeypatch.setattr(cli, "replay_diagnostic_bundle", lambda *_args, **_kwargs: replayed)
+
+    result = cli.main(
+        [
+            "doctor",
+            "--replay",
+            str(source),
+            "--base-url",
+            "https://target.test",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert result == 0
+    diagnostics.assert_diagnostic_bundle(json.loads(output.read_text()))
+    assert json.loads(capsys.readouterr().out)["outcome"] == "replayed"
+
+
+def test_doctor_rejects_incomplete_emit_and_replay_invocations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HONUA_BASE_URL", raising=False)
+    source = tmp_path / "source.json"
+    source.write_text(
+        json.dumps(
+            diagnostics.create_diagnostic_bundle(
+                content_classification="internal",
+                redaction_acknowledged=True,
+                share_with_support=False,
+                exchanges=[{"method": "GET", "url": "https://source.test/healthz/ready"}],
+            )
+        )
+    )
+    base = {"output": str(tmp_path / "out.json"), "timeout": 1.0}
+    invalid = [
+        {**base, "replay": str(source), "exchange": "also.json", "base_url": "https://target.test"},
+        {**base, "replay": str(source), "exchange": None, "base_url": None},
+        {
+            **base,
+            "replay": None,
+            "exchange": None,
+            "base_url": None,
+            "classification": None,
+            "redaction_acknowledged": None,
+            "share_with_support": None,
+        },
+        {
+            **base,
+            "replay": None,
+            "exchange": None,
+            "base_url": None,
+            "classification": "internal",
+            "redaction_acknowledged": "true",
+            "share_with_support": "false",
+            "bundle_id": None,
+            "granted_by": None,
+        },
+    ]
+    for arguments in invalid:
+        with pytest.raises(cli._DoctorCliError):
+            cli._cmd_doctor(_Namespace(**arguments), io.StringIO())
+
+
+def test_doctor_input_shape_and_file_failures_are_safe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(cli._DoctorCliError):
+        cli._read_diagnostic_json(str(missing))
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    with pytest.raises(cli._DoctorCliError):
+        cli._read_diagnostic_json(str(directory))
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("{not-json")
+    with pytest.raises(cli._DoctorCliError):
+        cli._read_diagnostic_json(str(malformed))
+
+    for value in (None, {}, {"request": {}}, {"request": {"method": 42, "url": "/x"}}):
+        with pytest.raises(cli._DoctorCliError):
+            cli._captured_exchange(value)
+    with pytest.raises(cli._DoctorCliError):
+        cli._captured_exchange({"request": {"method": "GET", "url": "/x"}, "response": "bad"})
+    with pytest.raises(cli._DoctorCliError):
+        cli._explicit_bool("yes")
+
+    monkeypatch.setattr(cli, "_write_diagnostic_bundle", lambda *_args: (_ for _ in ()).throw(OSError("disk")))
+    with pytest.raises(cli._DoctorCliError):
+        cli._write_diagnostic_bundle_safe(str(tmp_path / "out.json"), {})
+
+
+def _walk_values(value: object) -> list[object]:
+    if isinstance(value, dict):
+        return [item for nested in value.values() for item in _walk_values(nested)]
+    if isinstance(value, list):
+        return [item for nested in value for item in _walk_values(nested)]
+    return [value]
+
+
+class _Namespace:
+    def __init__(self, **kwargs: object) -> None:
+        self.__dict__.update(kwargs)

--- a/tests/test_doctor_cli.py
+++ b/tests/test_doctor_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import io
+import os
 import stat
 from pathlib import Path
 import pytest
@@ -62,7 +63,8 @@ def test_doctor_emits_valid_sanitized_bundle_and_machine_summary(
     assert summary["schemaSha256"] == diagnostics.DIAGNOSTIC_SCHEMA_SHA256
     assert summary["uploaded"] is False
     assert str(output) not in json.dumps(summary)
-    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    if os.name != "nt":
+        assert stat.S_IMODE(output.stat().st_mode) == 0o600
 
 
 def test_doctor_probe_failure_keeps_supplied_failure_last(


### PR DESCRIPTION
Fixes #171
Related to honua-io/honua-support#54

## Summary

Add `honua doctor` emission and read-only replay for the canonical sanitized `diagnostic-bundle.v1` support contract. The Python SDK now carries the byte-pinned public schema, provenance, and support-owned conformance corpus; validates every final artifact before atomic output; and never serializes raw HTTP bodies, credentials, cookies, URL values, or non-allowlisted headers.

## Why

Support intake already fails closed against `diagnostic-bundle.v1`, but Python users had no matching client-side emitter. SDK interoperability tickets therefore lacked a trustworthy, schema-conformant way to provide bounded request/response evidence without manually handling secrets.

## Changes

- Vendor the canonical 6,494-byte schema at SHA-256 `4dd7282d17bb417d56f1c3cfa243e03b612a401e5d22be766658849287e431a9`, its source provenance, and the full merged valid/invalid support conformance corpus.
- Add a dependency-free exact v1 validator with strict required fields, types, bounds, additional-property rejection, and optional-field omission rather than `null`.
- Add conservative exchange sanitization: normalized/placeholdered paths and query values, strict safe-header allowlist, credential-shaped metadata rejection, and body hashing in memory with metadata-only output. Python emits no body preview.
- Add one bounded anonymous capability probe. Probe failure remains a minimal envelope and never displaces the explicitly supplied final failure.
- Add `honua doctor --replay`: validate and safety-check the entire source artifact before network access, permit one anonymous bounded `GET`/`HEAD` on the conservative public read vocabulary, strip query values, and refuse bodies, mutations, subscriptions, traversal, placeholders, unsafe headers, hash drift, timeouts, and over-budget responses.
- Atomically write owner-only local JSON after validating both the object and serialized round trip. The command never uploads; stdout contains only a machine summary with SDK/runtime context and schema provenance.
- Document local review/submission, provenance, privacy boundaries, limits, and replay behavior.

## Compatibility and privacy

The artifact contains only fields allowed by canonical v1. SDK/runtime context remains in the machine summary because v1 forbids extension fields. No existing client API, generated sync client, support event, or server contract changes.

## Validation

- Full deterministic suite with combined coverage gate: 1,365 passed, 44 expected skips; 94.01% total coverage (new diagnostics module 100%).
- Focused doctor/CLI tests: 40 passed.
- `ruff check .` — passed.
- Full SDK/admin strict mypy: 69 source files passed.
- `python scripts/compatibility_gate.py` — passed.
- `python scripts/gen_sync.py --check` — passed.
- Wheel and sdist build — passed; schema, provenance, and conformance corpus included.
- Installed Python 3.11 wheel smoke exercised `honua doctor --help`, sanitized emission, secret absence, and installed schema byte/SHA pin — passed.
