### PR TITLE
Refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,74 @@
 # Honua Python SDK
 
+[![CI](https://github.com/honua-io/honua-sdk-python/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-sdk-python/actions/workflows/ci.yml)
+[![Conformance](https://github.com/honua-io/honua-sdk-python/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-sdk-python/actions/workflows/conformance.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-sdk-python/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-sdk-python)
 
-[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue)](https://honua-io.github.io/honua-sdk-python/)
+Python client libraries for [Honua](https://honua.io), the cloud-native
+geospatial platform built around
+[honua-server](https://github.com/honua-io/honua-server). One typed client
+covers feature queries, geocoding, map/image export, editing, and server
+administration across the server's protocol adapters — GeoServices REST
+(FeatureServer/MapServer/ImageServer/GeocodeServer/GeometryServer), OGC API
+Features, STAC, OData, WFS/WMS/WMTS, and gRPC streaming — with one-call
+GeoDataFrame interop for the pandas/GeoPandas stack.
 
-Monorepo for the Honua Python client libraries. Two independently installable
-packages live under `packages/`:
+## Packages
 
-| Package | PyPI name | Description |
-|---------|-----------|-------------|
-| [`packages/honua-sdk`](packages/honua-sdk/) | `honua-sdk` | Data-plane client -- feature queries, geocoding, gRPC streaming, GeoPandas integration |
-| [`packages/honua-admin`](packages/honua-admin/) | `honua-admin` | Control-plane client -- services, connections, layers, styles, metadata, manifests |
+Two independently installable, Apache-2.0 packages live under `packages/`:
+
+| Package | Import | Description |
+|---------|--------|-------------|
+| [`packages/honua-sdk`](packages/honua-sdk/) | `honua_sdk` | Data-plane client — feature queries, geocoding, protocol clients, gRPC streaming, GeoPandas/raster interop, `honua` CLI |
+| [`packages/honua-admin`](packages/honua-admin/) | `honua_admin` | Control-plane client — services, connections, layers, styles, metadata, manifests, compatibility checks (depends on `honua-sdk`) |
+
+Also in this repo: [`packages/honua-gp`](packages/honua-gp/), a proprietary
+geoprocessing compatibility layer for teams migrating scripts from ArcGIS
+`arcpy` (separate license, not published), and
+[`packages/honua-arcpy`](packages/honua-arcpy/), a deprecated shim that
+re-exports it.
+
+## Status
+
+Alpha (`0.x`): `honua-sdk` 0.1.9, `honua-admin` 0.1.6. APIs may change before
+1.0; breaking changes to the public API are gated by a
+[compatibility snapshot](docs/compatibility.md).
+
+**Not yet published to PyPI** — install from source (below). Release
+automation is in place (release-please + a tag-triggered publish workflow
+using PyPI Trusted Publishing), so `pip install honua-sdk` becomes the install
+path once the first publish lands.
+
+## Install
+
+Requires Python 3.11+ (CI tests 3.11, 3.12, 3.13). Until the packages are on
+PyPI, install from a clone:
+
+```bash
+git clone https://github.com/honua-io/honua-sdk-python.git
+cd honua-sdk-python
+
+# Data-plane client
+pip install ./packages/honua-sdk
+
+# With optional extras: gRPC streaming, GeoPandas vector interop,
+# raster interop (rasterio / rioxarray / xarray)
+pip install "./packages/honua-sdk[grpc,geopandas,raster]"
+
+# Control-plane (admin) client — installs honua-sdk alongside it
+pip install ./packages/honua-sdk ./packages/honua-admin
+```
+
+Or straight from GitHub without cloning:
+
+```bash
+pip install "honua-sdk[geopandas] @ git+https://github.com/honua-io/honua-sdk-python.git@python-sdk-v0.1.9#subdirectory=packages/honua-sdk"
+```
+
+The repo-root `pyproject.toml` is intentionally **not** installable (it holds
+shared tool config only) — install the per-package directories, not `.`.
+[INSTALL.md](INSTALL.md) has extras details and install-time troubleshooting;
+its `pip install honua-sdk` commands apply once the packages are published.
 
 ## I want to...
 
@@ -20,69 +78,45 @@ packages live under `packages/`:
 | Stream features over gRPC       | [INSTALL.md#with-grpc](INSTALL.md#with-grpc)                    |
 | Build an ETL pipeline           | [examples/geospatial_etl/](examples/geospatial_etl/)            |
 | Wire a FastAPI service          | [examples/fastapi_spatial_service.py](examples/fastapi_spatial_service.py) |
+| Run spatial queries from Jupyter / pandas | [docs/quickstart.md](docs/quickstart.md) + [examples/data_quality_report.py](examples/data_quality_report.py) |
 | Manage services & connections   | [packages/honua-admin/](packages/honua-admin/)                  |
 | Understand the protocol matrix  | [docs/protocol-parity.md](docs/protocol-parity.md)              |
 | Diagnose an error               | [docs/quickstart.md#common-errors](docs/quickstart.md#common-errors) |
 
-## Who is this for?
+## Quick start
 
-| You are a... | Start with |
-|--------------|------------|
-| **Data analyst** running spatial queries from Jupyter / pandas | [docs/quickstart.md](docs/quickstart.md) + [examples/data_quality_report.py](examples/data_quality_report.py) |
-| **App developer** wiring a FastAPI / async service | [examples/fastapi_spatial_service.py](examples/fastapi_spatial_service.py) |
-| **SDK / platform developer** managing services & connections | [packages/honua-admin/](packages/honua-admin/) |
-
-## Install
-
-```bash
-# Data / protocol client
-pip install honua-sdk
-
-# Install both packages at once:
-pip install honua-sdk honua-admin
-
-# With gRPC support
-pip install honua-sdk[grpc]
-
-# With GeoPandas integration (vector result interop)
-pip install honua-sdk[geopandas]
-
-# With raster result interop (rasterio / rioxarray / xarray)
-pip install honua-sdk[raster]
-
-# Admin / control-plane client (depends on honua-sdk)
-pip install honua-admin
-
-# Everything
-pip install honua-sdk[grpc,geopandas,raster] honua-admin
-```
-
-Requires Python 3.11+. See [INSTALL.md](INSTALL.md) for full details.
-
-## Quick Example
-
-### Data client
+Query features through the canonical `Source` / `Query` / `Result` API and
+convert to a GeoDataFrame in one call:
 
 ```python
 from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
 
 with HonuaClient("https://your-honua-server.com") as client:
-    # List available services
-    services = client.list_services()
-
-    # Query features through the shared Source/Query/Result API
     source = client.source(
         SourceDescriptor(
-            id="test_service",
+            id="parcels",
             protocol="geoservices-feature-service",
-            locator=SourceLocator(service_id="test_service", layer_id=0),
+            locator=SourceLocator(service_id="parcels", layer_id=0),
         )
     )
     result = source.query(Query(where="status = 'active'", out_fields=["*"]))
 
-    features = result.features
-    print(f"Found {len(features)} features")
+    print(f"Found {len(result.features)} features")
+    for feature in result.features[:3]:
+        print(feature.id, feature.properties)
+
+    # Requires: pip install "./packages/honua-sdk[geopandas]"
+    gdf = result.to_geodataframe()  # GeoDataFrame with geometry column + CRS set
+    print(gdf.head(), gdf.crs)
 ```
+
+`client.source(...)` returns a source-bound facade with `query()`,
+`query_all()`, `stream()`/`iter_features()`, `apply_edits()`, and
+`protocol(...)`. `source.query()` returns a canonical `Result` of normalized
+`QueryFeature` entries (`id`, `properties`, `geometry`, `protocol`, `source`,
+`raw`) — the same shape across FeatureServer, OGC API Features, STAC, and
+OData. The reverse helper `honua_sdk.geopandas.geodataframe_to_features` turns
+an edited GeoDataFrame back into `apply_edits` payloads.
 
 ### OGC API Features
 
@@ -95,79 +129,38 @@ with HonuaClient("https://your-honua-server.com") as client:
 
     parcels = ogc.collection("parcels")
     items = parcels.items(limit=100, filter="status = 'active'")
-    all_items = parcels.items_all(page_size=500, max_pages=20)
     feature = parcels.item("123")
 ```
 
-### Shared Source/Query API
+### Geocoding
 
 ```python
-from honua_sdk import FeatureQuery, HonuaClient, Query, SourceDescriptor, SourceLocator
+from honua_sdk import HonuaGeocodingClient
 
-with HonuaClient("https://your-honua-server.com") as client:
-    parcels = client.source(
+with HonuaGeocodingClient("https://your-honua-server.com") as geocoder:
+    results = geocoder.forward_geocode("1600 Pennsylvania Ave NW, Washington, DC")
+    for r in results:
+        print(f"{r.address}  ({r.latitude}, {r.longitude})  score={r.score}")
+```
+
+### Async
+
+Every HTTP workflow has an async counterpart with the same factory and method
+names — works with FastAPI, asyncio pipelines, and Jupyter:
+
+```python
+from honua_sdk import AsyncHonuaClient, Query, SourceDescriptor, SourceLocator
+
+async with AsyncHonuaClient("https://your-honua-server.com") as client:
+    source = client.source(
         SourceDescriptor(
             id="parcels",
             protocol="geoservices-feature-service",
             locator=SourceLocator(service_id="parcels", layer_id=0),
         )
     )
-    result = parcels.query(
-        Query(
-            where="status = 'active'",
-            out_fields=["objectid", "name", "status"],
-            pagination={"limit": 2000},
-        )
-    )
-
-    ogc_features = client.query(
-        "parcels",
-        protocol="ogc-features",
-        filter="status = 'active'",
-        bbox=[-180, -90, 180, 90],
-        fields=["name", "status"],
-        limit=2000,
-    )
-
-    stac_items = client.query(
-        FeatureQuery(
-            source="imagery",
-            protocol="stac",
-            filter="eo:cloud_cover < 10",
-            bbox=[-180, -90, 180, 90],
-            limit=500,
-        )
-    )
-
-    odata_features = client.query(
-        "4",
-        protocol="odata",
-        filter="Status eq 'active'",
-        fields=["ObjectId", "Name"],
-        limit=2000,
-    )
+    result = await source.query(Query(where="1=1"))
 ```
-
-`client.source(...)` accepts a `SourceDescriptor` and returns a source-bound
-facade with `query()`, `query_all()`, `stream()`/`iter_features()`,
-`apply_edits()`, and `protocol(...)`. `source.query()` returns a canonical
-`Result` with normalized `QueryFeature` entries: `id`, `properties`, `geometry`,
-`protocol`, `source`, and `raw`.
-
-> **Protocol IDs.** All docs and examples in this repo use the canonical
-> cross-SDK protocol ids (for example, `geoservices-feature-service`,
-> `ogc-features`, `stac`, `odata`). Common aliases such as `feature-server`,
-> `featureserver`, `feature-service`, and `ogc-api-features` are accepted at
-> runtime and normalized by `honua_sdk.normalize_protocol(...)`. The full alias
-> table lives in `honua_sdk.PROTOCOL_ALIASES`.
-
-The older `client.query()` and `client.iter_query()` helpers remain available as
-the compact FeatureServer, OGC Features, STAC, and OData path. Protocol-specific
-clients are still available through `source.protocol(...)` or direct factories
-for native payloads, map and tile bytes, OData metadata, WMS/WMTS
-`BinaryResponse` metadata, and advanced protocol options. See
-[Protocol Examples](docs/protocol-examples.md) for every wrapper and
-[Protocol Parity](docs/protocol-parity.md) for the Python/JS coverage map.
 
 ### Admin client
 
@@ -185,157 +178,95 @@ with HonuaAdminClient("https://your-honua-server.com", api_key="honua-api-key") 
         print(f"Manifest resources: {len(manifest.resources)}")
 ```
 
-## Async
+> **Protocol IDs.** Docs and examples use the canonical cross-SDK protocol ids
+> (`geoservices-feature-service`, `ogc-features`, `stac`, `odata`, ...).
+> Common aliases (`feature-server`, `ogc-api-features`, ...) are accepted at
+> runtime and normalized by `honua_sdk.normalize_protocol(...)`; the full
+> table lives in `honua_sdk.PROTOCOL_ALIASES`. Compact helpers
+> (`client.query(...)`, `client.query_features(...)`) remain for one-liners —
+> see [Protocol Examples](docs/protocol-examples.md) for every wrapper and
+> [Protocol Parity](docs/protocol-parity.md) for the Python/JS coverage map.
 
-HTTP data and protocol workflows have async counterparts with the same factory
-and method names:
+## Key features
 
-```python
-from honua_sdk import AsyncHonuaClient, Query, SourceDescriptor, SourceLocator
-
-async with AsyncHonuaClient("https://your-honua-server.com") as client:
-    source = client.source(
-        SourceDescriptor(
-            id="test_service",
-            protocol="geoservices-feature-service",
-            locator=SourceLocator(service_id="test_service", layer_id=0),
-        )
-    )
-    result = await source.query(Query(where="1=1"))
-    features = result.features
-```
-
-Works with FastAPI, asyncio pipelines, Jupyter async, and any other async framework.
-
-> **Legacy / compact form.**
-> `await client.query_features(service_id="test_service", layer_id=0)`
-> returns the raw GeoServices dict. Equivalent to
-> `client.source(...).query(...)`; preferred for one-liners. The `Source`
-> API returns typed `Result`/`QueryFeature` objects.
-
-## GeoPandas
-
-Convert query results to GeoDataFrames in one call:
-
-```python
-from honua_sdk import HonuaClient, Query, SourceDescriptor, SourceLocator
-from honua_sdk.geopandas import geodataframe_to_features
-
-with HonuaClient("https://your-honua-server.com") as client:
-    source = client.source(
-        SourceDescriptor(
-            id="test_service",
-            protocol="geoservices-feature-service",
-            locator=SourceLocator(service_id="test_service", layer_id=0),
-        )
-    )
-    result = source.query(Query(where="1=1"))
-    gdf = result.to_geodataframe()
-
-    # gdf is a GeoDataFrame with geometry column + CRS set
-    print(gdf.head())
-    print(gdf.crs)
-
-    # Convert back for edits
-    features = geodataframe_to_features(gdf)
-```
-
-Requires `pip install honua-sdk[geopandas]`.
-
-> **Legacy / compact form.**
-> `client.query_features(service_id="test_service", layer_id=0)` returns
-> the raw GeoServices dict that `features_to_geodataframe` also accepts.
-> Equivalent to `client.source(...).query(...)`; preferred for
-> one-liners. The `Source` API returns typed `Result`/`QueryFeature`
-> objects.
-
-## Geocoding
-
-```python
-from honua_sdk import HonuaGeocodingClient
-
-with HonuaGeocodingClient("https://your-honua-server.com") as geocoder:
-    results = geocoder.forward_geocode("1600 Pennsylvania Ave NW, Washington, DC")
-    for r in results:
-        print(f"{r.address}  ({r.latitude}, {r.longitude})  score={r.score}")
-```
-
-## Retry
-
-All clients retry automatically on transient failures (429, 502, 503) with
-exponential backoff and `Retry-After` header support. Configurable:
-
-```python
-# Default: 3 retries with exponential backoff
-with HonuaClient("https://your-server.com") as client:
-    services = client.list_services()
-
-# Disable retry
-with HonuaClient("https://your-server.com", max_retries=0) as client:
-    services = client.list_services()
-```
+| | |
+|---|---|
+| Typed, canonical query surface | `Source` / `Query` / `Result` with normalized `QueryFeature` across FeatureServer, OGC Features, STAC, OData |
+| Protocol clients | GeoServices (Feature/Map/Image/Geocode/Geometry servers), OGC API Features, STAC, OData, WFS, WMS, WMTS — see [protocol parity](docs/protocol-parity.md) |
+| GIS interop | `Result.to_geodataframe()`, `features_to_geodataframe` (Esri JSON aware), raster results via `rasterio`/`rioxarray` (`[raster]` extra) |
+| gRPC streaming | `honua_sdk.grpc.HonuaGrpcClient` / `HonuaGrpcAsyncClient` for unary + streaming feature queries (`[grpc]` extra) |
+| Sync + async | `HonuaClient` / `AsyncHonuaClient` in lockstep (sync clients generated from the async source of truth) |
+| Automatic retry | 429/502/503 with exponential backoff and `Retry-After` support; configurable via `max_retries`, `retry_methods` |
+| Typed errors | `HonuaAuthError`, `HonuaRateLimitError`, `HonuaHttpError`, `HonuaTimeoutError`, `HonuaTransportError` — see [common errors](docs/quickstart.md#common-errors) |
+| CLI | `honua` (services / layers / style apply / sanitized `doctor` diagnostics) and `honua-migrate` (offline ArcPy script scan / translate / `.pyt` classify) |
+| Quality gates | mypy `strict` workspace-wide, 94% coverage gate, public-API [compatibility snapshot](docs/compatibility.md), live-server [conformance lane](.github/workflows/conformance.yml) against shared [geospatial-grpc](https://github.com/honua-io/geospatial-grpc) fixtures |
 
 ## Documentation
 
-### Get started
+Repo docs live under [docs/](docs/README.md) (MkDocs sources; browsable on
+GitHub). Platform-level docs are at
+[honua.gitbook.io/honuaio](https://honua.gitbook.io/honuaio/).
 
-- [5-Minute Quickstart](docs/quickstart.md) -- query, GeoDataFrame, and plot
-- [Geospatial ETL demo](examples/geospatial_etl/README.md) -- canonical script-first ETL flow plus notebook companion, with `load-summary.json` / `post-load-preview.png` artifacts and the `apply_edits` contract
-- [INSTALL.md](INSTALL.md) -- installation options and version policy
+- [5-Minute Quickstart](docs/quickstart.md) — query, GeoDataFrame, plot, common errors
+- [Core Client](docs/core-client.md) — typed service, FeatureServer, applyEdits, pagination, error handling
+- [Protocol Examples](docs/protocol-examples.md) — OGC, STAC, WFS, WMS, WMTS, OData, geocoding, gRPC with response shapes
+- [Authentication](docs/auth.md) — refreshable bearer tokens, storage, rotation, failure modes
+- [Geospatial ETL demo](examples/geospatial_etl/README.md) — script-first ETL flow with notebook companion
+- [Compatibility](docs/compatibility.md) — supported server matrix and public-API snapshot gate
+- [Troubleshooting](docs/troubleshooting.md) — base URL, auth, staging smoke env vars, cleanup
 
-### Reference
+## Related Honua repos
 
-- [Core Client](docs/core-client.md) -- typed service, FeatureServer, applyEdits, pagination, and error handling helpers
-- [Protocol Examples](docs/protocol-examples.md) -- OGC, STAC, WFS, WMS, WMTS, OData, geocoding, and gRPC examples with response shapes
-- [Authentication](docs/auth.md) -- refreshable bearer tokens, secure storage guidance, revocation, rotation, and failure modes
-- See `honua_sdk.grpc.HonuaGrpcClient` for gRPC usage -- streaming feature queries
-- [Admin client](packages/honua-admin/honua_admin/) -- server administration
-
-### Project process
-
-- [Compatibility](docs/compatibility.md) -- supported server matrix, public API snapshot gate, and release blocking policy
-- [Troubleshooting](docs/troubleshooting.md) -- staging smoke env vars and result artifacts, auth expectations, seeded `test_service` / layer `0` assumptions, optional example dependencies, and cleanup guidance
-- [Operating Cadence](docs/operating-cadence.md) -- weekly backlog review, scope gate, and done/close hygiene
-
-## Status
-
-These packages are in **alpha** (`0.x`).
-Release automation is configured for PyPI publishing from `python-sdk-v<version>`
-and `python-admin-v<version>` tags.
-APIs may change before the 1.0 stable release.
+| Repo | What it is |
+|------|------------|
+| [honua-server](https://github.com/honua-io/honua-server) | Flagship multi-protocol geospatial server this SDK talks to |
+| [honua-sdk-js](https://github.com/honua-io/honua-sdk-js) | JavaScript/TypeScript SDKs + MCP server |
+| [honua-sdk-dotnet](https://github.com/honua-io/honua-sdk-dotnet) | .NET SDKs |
+| [honua-console](https://github.com/honua-io/honua-console) | Unified web console (Studio, Catalog, Operate, Share) |
+| [honua-qgis-plugin](https://github.com/honua-io/honua-qgis-plugin) | QGIS plugin |
+| [geospatial-grpc](https://github.com/honua-io/geospatial-grpc) | Vendor-neutral gRPC protocol standard; source of this repo's conformance fixtures |
 
 ## Development
 
 ```bash
-# Install both packages in editable mode
+# Editable install of both packages with extras
 pip install -e "packages/honua-sdk[grpc,geopandas]"
 pip install -e "packages/honua-admin"
+pip install pytest pytest-cov ruff mypy
 
-# Run the deterministic local suite
+# Lint + type-check (mypy runs in strict mode)
+ruff check .
+python -m mypy packages/honua-sdk/honua_sdk packages/honua-admin/honua_admin
+
+# Deterministic local test suite
 python3 -m pytest tests/ -q
 
-# Run the compatibility gate
+# Public-API compatibility gate
 python3 scripts/compatibility_gate.py
-
-# Run the opt-in staging smoke suite
-python3 -m pytest tests/integration -q --run-integration -m "integration and staging and smoke"
-
-# Run the release smoke helper against an installed SDK build
-python3 scripts/release_smoke.py
 ```
 
-The staging smoke command and `scripts/release_smoke.py` both require
-`HONUA_BASE_URL`. Set `HONUA_ENABLE_WRITE_SMOKE=true` when you want the
-add/query/update/delete roundtrip enabled outside the default read-only local run.
+Sync clients (`client.py`, `_client.py`) are generated from their async
+counterparts — edit the async module and run `python scripts/gen_sync.py`;
+never hand-edit the generated files.
 
-The staging smoke suite writes `staging-smoke-results.json` by default.
-`scripts/release_smoke.py` writes `release-smoke-results.json` unless `--results-path` overrides it.
-The dedicated GitHub staging lane in `.github/workflows/staging-integration.yml`
-uploads both `staging-smoke-results.json` and `staging-smoke-junit.xml`, then
-renders the JSON report into the workflow step summary. Same-repo pull requests
-skip that live lane until `HONUA_BASE_URL` is configured in GitHub Actions;
-`trunk`, scheduled, and manual runs still fail fast when the staging base URL is missing.
+Opt-in integration lanes (staging smoke, live-server conformance, release
+smoke) need `HONUA_BASE_URL` and the `--run-integration` flag; see
+[docs/troubleshooting.md](docs/troubleshooting.md) and
+[docs/compatibility.md](docs/compatibility.md) for env vars, markers, and
+result artifacts.
+
+Bugs and feature requests: [GitHub issues](https://github.com/honua-io/honua-sdk-python/issues).
+Pull requests are welcome — CI enforces lint, strict typing, the coverage
+gate, and the compatibility snapshot.
+
+## Security
+
+Report vulnerabilities to <security@honua.io> — see the
+[org security policy](https://github.com/honua-io/.github/blob/main/SECURITY.md).
+Do not open public issues for security reports.
 
 ## License
 
-Apache-2.0
+`honua-sdk` and `honua-admin` are licensed under
+[Apache-2.0](LICENSE). `packages/honua-gp` and `packages/honua-arcpy` are
+proprietary (see their respective `LICENSE` files) and are not published.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/honua-io/honua-sdk-python/actions/workflows/ci.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-sdk-python/actions/workflows/ci.yml)
 [![Conformance](https://github.com/honua-io/honua-sdk-python/actions/workflows/conformance.yml/badge.svg?branch=trunk)](https://github.com/honua-io/honua-sdk-python/actions/workflows/conformance.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/honua-io/honua-sdk-python/badge)](https://scorecard.dev/viewer/?uri=github.com/honua-io/honua-sdk-python)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 Python client libraries for [Honua](https://honua.io), the cloud-native
 geospatial platform built around


### PR DESCRIPTION
Rewrites the top-level README against the shared editorial brief: first-screen positioning, honest status/maturity signaling, verified quick start, and ecosystem cross-links.

## What changed

- **Honest install path.** `honua-sdk` / `honua-admin` are not on PyPI (verified: `pip index versions` and pypi.org both 404), but the README led with `pip install honua-sdk`. Install section now shows the working from-source paths (`pip install ./packages/honua-sdk[...]` from a clone, or `git+https...#subdirectory=` direct URL pinned to `python-sdk-v0.1.9`) and states that the PyPI commands take over once the tag-triggered Trusted Publishing workflow does its first real publish.
- **Removed the docs badge** pointing at https://honua-io.github.io/honua-sdk-python/ — the Pages site 404s (docs.yml itself notes the badge is a forward link that only resolves after the first deploy). In-repo docs/ links and the hosted GitBook platform docs are linked instead.
- **Added real badges**: CI and Conformance workflow badges (both run on push/PR to trunk); kept the OpenSSF Scorecard badge (verified it resolves).
- **Acknowledged all four packages.** README claimed "two packages live under packages/"; `honua-gp` (proprietary arcpy-migration GP compat layer) and `honua-arcpy` (deprecated shim) now have an honest one-liner, and the License section notes they are proprietary/not published while `honua-sdk`/`honua-admin` are Apache-2.0.
- **New sections per the shared structure**: Status (alpha 0.x with current versions 0.1.9/0.1.6 and the compatibility-snapshot gate), Key features table, Related Honua repos (server, sdk-js, sdk-dotnet, console, qgis-plugin, geospatial-grpc), Security (org SECURITY.md + security@honua.io).
- **Trimmed duplication**: the long "Shared Source/Query API" and duplicate legacy-form call-outs collapsed into a single quick-start plus short OGC/geocoding/async/admin snippets, with links to docs/protocol-examples.md and docs/protocol-parity.md for the full surface. Development section keeps the CI-verified commands (ruff, mypy strict, pytest, compatibility gate) and the gen_sync rule.

## Verified

- Every relative link resolves to a real file on this branch (scripted check), including anchors `INSTALL.md#with-grpc` and `docs/quickstart.md#common-errors`.
- All code snippets are taken from the repo's own docs (quickstart/INSTALL) and their symbols were checked against package source (`HonuaClient.source/list_services/ogc_features`, `Result.to_geodataframe`, `geodataframe_to_features`, `forward_geocode`, admin `check_compatibility`/`get_capability_flags`/`get_manifest`, CLI entry points `honua`/`honua-migrate`).
- Extras (`grpc`, `geopandas`, `raster`), Python 3.11+ floor, retry semantics (429/502/503 + Retry-After), coverage/mypy-strict gates checked against pyproject.toml and ci.yml.

## Stale claims found (outside README scope, not fixed here)

- INSTALL.md also leads with `pip install honua-sdk` for the unpublished packages (README now flags that those commands apply post-publish).
- Both package pyprojects carry the `Development Status :: 5 - Production/Stable` classifier while the project is documented as alpha 0.x.