### PR TITLE
docs: README refresh follow-ups - honest install docs and Alpha classifiers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,27 +12,44 @@
 - Python 3.11 or later
 - A running Honua Server instance
 
-## Install via pip
+## Install
+
+**Not yet published to PyPI** -- `pip install honua-sdk` will not resolve
+until the first public release lands. Until then, install from a clone:
 
 ```bash
+git clone https://github.com/honua-io/honua-sdk-python.git
+cd honua-sdk-python
+
 # Core data client (REST/HTTP, sync + async)
-pip install honua-sdk
+pip install ./packages/honua-sdk
 
 # With gRPC support
-pip install honua-sdk[grpc]
+pip install "./packages/honua-sdk[grpc]"
 
 # With GeoPandas integration (vector result interop)
-pip install honua-sdk[geopandas]
+pip install "./packages/honua-sdk[geopandas]"
 
 # With raster result interop (rasterio / rioxarray / xarray)
-pip install honua-sdk[raster]
+pip install "./packages/honua-sdk[raster]"
 
-# Admin / control-plane client
-pip install honua-admin
+# Admin / control-plane client (installs honua-sdk alongside it)
+pip install ./packages/honua-sdk ./packages/honua-admin
 
 # Everything
-pip install honua-sdk[grpc,geopandas,raster] honua-admin
+pip install "./packages/honua-sdk[grpc,geopandas,raster]" ./packages/honua-admin
 ```
+
+Or straight from GitHub without cloning:
+
+```bash
+pip install "honua-sdk[geopandas] @ git+https://github.com/honua-io/honua-sdk-python.git@python-sdk-v0.1.9#subdirectory=packages/honua-sdk"
+```
+
+The repo-root `pyproject.toml` is intentionally **not** installable (it
+holds shared tool config only) -- install the per-package directories,
+not `.`. Once the packages are published, the commands above collapse to
+`pip install honua-sdk[...]` / `pip install honua-admin`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ pip install "honua-sdk[geopandas] @ git+https://github.com/honua-io/honua-sdk-py
 
 The repo-root `pyproject.toml` is intentionally **not** installable (it holds
 shared tool config only) — install the per-package directories, not `.`.
-[INSTALL.md](INSTALL.md) has extras details and install-time troubleshooting;
-its `pip install honua-sdk` commands apply once the packages are published.
+[INSTALL.md](INSTALL.md) has extras details and install-time troubleshooting.
 
 ## I want to...
 

--- a/packages/honua-admin/pyproject.toml
+++ b/packages/honua-admin/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Honua" }]
 keywords = ["geospatial", "admin", "gis", "honua", "control-plane"]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",

--- a/packages/honua-sdk/honua_sdk/protocols/scenes.py
+++ b/packages/honua-sdk/honua_sdk/protocols/scenes.py
@@ -1120,6 +1120,7 @@ def _elevation_value_params(
 
 def _elevation_profile_params(
     line: str,
+    *,
     sample_count: int | None,
     interval: float | None,
     srid: str | int | None,
@@ -2110,7 +2111,14 @@ class ElevationClient(_SyncProtocol):
     ) -> ElevationProfile:
         resolved = _require_dataset_id(dataset_id)
         path = f"{self.root}/{_encode_path_segment(resolved)}/profile"
-        params = _elevation_profile_params(line, sample_count, interval, srid, mosaic_rule, extra_params)
+        params = _elevation_profile_params(
+            line,
+            sample_count=sample_count,
+            interval=interval,
+            srid=srid,
+            mosaic_rule=mosaic_rule,
+            extra_params=extra_params,
+        )
         response = self._json("GET", path, params=params, timeout=timeout, extra_headers=extra_headers)
         return parse_elevation_profile(response)
 
@@ -2310,6 +2318,13 @@ class AsyncElevationClient(_AsyncProtocol):
     ) -> ElevationProfile:
         resolved = _require_dataset_id(dataset_id)
         path = f"{self.root}/{_encode_path_segment(resolved)}/profile"
-        params = _elevation_profile_params(line, sample_count, interval, srid, mosaic_rule, extra_params)
+        params = _elevation_profile_params(
+            line,
+            sample_count=sample_count,
+            interval=interval,
+            srid=srid,
+            mosaic_rule=mosaic_rule,
+            extra_params=extra_params,
+        )
         response = await self._json("GET", path, params=params, timeout=timeout, extra_headers=extra_headers)
         return parse_elevation_profile(response)

--- a/packages/honua-sdk/pyproject.toml
+++ b/packages/honua-sdk/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.11"
 authors = [{ name = "Honua" }]
 keywords = ["geospatial", "mobile", "gis", "offline", "sync", "grpc", "honua"]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",


### PR DESCRIPTION
Fixes #181

## Summary
Doc-side follow-ups from the README refresh (#180). Recon against current `trunk` confirmed both doc items were still stale; the PyPI publish itself remains an operator action (verified `pypi.org` still returns 404 for `honua-sdk` and `honua-admin`).

## Changes Made
- `INSTALL.md`: replaced the bare `pip install honua-sdk` / `pip install honua-admin` section with the from-source clone install and git-URL install, matching the README, with a clear "not yet published to PyPI" statement and a note that the commands collapse to plain `pip install` after first publish.
- `README.md`: dropped the now-obsolete caveat that INSTALL.md's `pip install honua-sdk` commands "apply once the packages are published" (INSTALL.md no longer shows them as the current path).
- `packages/honua-sdk/pyproject.toml`, `packages/honua-admin/pyproject.toml`: downgraded `Development Status :: 5 - Production/Stable` to `Development Status :: 3 - Alpha`, matching the documented alpha 0.x status. (`honua-gp` was already `3 - Alpha`; `honua-arcpy` is `7 - Inactive`.)

## Verification
- Both pyprojects parse (`tomllib`).
- Touched files are outside the mkdocs `docs_dir`, so the strict docs build is unaffected; no build/test matrix run for this doc-only change.

## Operator items remaining (not addressed here)
- First publish of `honua-sdk` / `honua-admin` to PyPI via the Trusted Publishing workflow — tracked separately in #178; docs intentionally continue to state that the packages are not yet on PyPI.
