### PR TITLE
ci: fix publish smoke test path after monorepo restructure

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Run SDK tests
         # Exercise both packages so the publish smoke test mirrors CI; the prior
         # `-k "not admin"` filter let admin regressions slip past sdk releases.
-        run: python -m pytest ../../tests/ -q --tb=short
+        run: python -m pytest tests/ -q --tb=short
         working-directory: ${{ github.workspace }}
         env:
           PYTHONPATH: ${{ github.workspace }}/packages/honua-sdk
@@ -217,7 +217,7 @@ jobs:
         # publish smoke mirrors the sdk job and CI; an sdk-side regression
         # should block an admin release just as it blocks an sdk one, since
         # honua-admin depends on honua-sdk. Both packages are installed above.
-        run: python -m pytest ../../tests/ -q --tb=short
+        run: python -m pytest tests/ -q --tb=short
         working-directory: ${{ github.workspace }}
         env:
           PYTHONPATH: ${{ github.workspace }}/packages/honua-sdk


### PR DESCRIPTION
The publish workflow's two "Run SDK tests" steps kept the pre-monorepo `../../tests/` relative path while their `working-directory` was later set to the workspace root, so pytest resolved two levels above the checkout and failed with "file or directory not found". Because release-please tags are created with `GITHUB_TOKEN` and cannot trigger this workflow, it had never executed — the first-ever dry-run dispatch (run [30891434754](https://github.com/honua-io/honua-sdk-python/actions/runs/30891434754)) surfaced the rot.

Fix: run `pytest tests/` from the repo root, matching the green invocation in `ci.yml`.

Validation: dry-run dispatch of this branch — run [30891657918](https://github.com/honua-io/honua-sdk-python/actions/runs/30891657918) (package=both, dry_run=true) exercising typecheck, compatibility gate, coverage gate, full test suite, and `hatch build` end to end.

Part of the #178 publish-path validation (PyPI trusted publishing).