### PR TITLE
ci: bind PyPI publish jobs to per-package environments

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -80,12 +80,16 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref_name, 'python-sdk-v'))
       || (github.event_name == 'workflow_dispatch' && (github.event.inputs.package == 'honua-sdk' || github.event.inputs.package == 'both'))
     runs-on: ubuntu-latest
+    environment: pypi-honua-sdk
     # PyPI Trusted Publishing requires `id-token: write` so the action can mint
     # an OIDC token and exchange it for a short-lived upload credential. The
     # Trusted Publisher MUST be configured at:
     #   https://pypi.org/manage/project/honua-sdk/settings/publishing/
-    # with workflow `publish-python-sdk.yml` (and the matching environment, if
-    # any) bound to this repository. See: https://docs.pypi.org/trusted-publishers/
+    # with workflow `publish-python-sdk.yml` and environment `pypi-honua-sdk`
+    # bound to this repository. The per-package environment names keep the two
+    # publishers' OIDC configurations distinct — PyPI rejects two pending
+    # publishers with an identical repo/workflow/environment tuple.
+    # See: https://docs.pypi.org/trusted-publishers/
     permissions:
       contents: read
       id-token: write
@@ -166,12 +170,16 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref_name, 'python-admin-v'))
       || (github.event_name == 'workflow_dispatch' && (github.event.inputs.package == 'honua-admin' || github.event.inputs.package == 'both'))
     runs-on: ubuntu-latest
+    environment: pypi-honua-admin
     # PyPI Trusted Publishing requires `id-token: write` so the action can mint
     # an OIDC token and exchange it for a short-lived upload credential. The
     # Trusted Publisher MUST be configured at:
     #   https://pypi.org/manage/project/honua-admin/settings/publishing/
-    # with workflow `publish-python-sdk.yml` (and the matching environment, if
-    # any) bound to this repository. See: https://docs.pypi.org/trusted-publishers/
+    # with workflow `publish-python-sdk.yml` and environment `pypi-honua-admin`
+    # bound to this repository. The per-package environment names keep the two
+    # publishers' OIDC configurations distinct — PyPI rejects two pending
+    # publishers with an identical repo/workflow/environment tuple.
+    # See: https://docs.pypi.org/trusted-publishers/
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
PyPI refused the second pending trusted publisher: two pending publishers cannot share an identical repo/workflow/environment configuration, and both of ours pointed at `publish-python-sdk.yml` with no environment. Each publish job now runs in its own GitHub environment (`pypi-honua-sdk`, `pypi-honua-admin` — both created in repo settings, no protection rules), so the publishers register with distinct tuples. Environment names are also reflected in the workflow comments.

No behavior change for CI lanes; the environments carry no secrets or approvals. Publisher registration on PyPI should use the matching environment name per package.

Refs #178