### PR TITLE
fix(eval): seed the SpatialJoin join layer before honua-server starts

### DIFF
--- a/.github/workflows/honua-gp-eval.yml
+++ b/.github/workflows/honua-gp-eval.yml
@@ -239,6 +239,12 @@ jobs:
           services:
             seed:
               image: client-compat-seed:latest
+              # The in-repo SpatialJoin join-layer fixture has to be applied by
+              # this one-shot seed job, BEFORE honua starts -- see the entrypoint
+              # comment below. Compose merges this list with the base file's
+              # ../../tests mount.
+              volumes:
+                - ${GITHUB_WORKSPACE}/packages/honua-gp/eval/seed:/workspace/gp-seed:ro
               entrypoint:
                 - /bin/sh
                 - -c
@@ -253,6 +259,21 @@ jobs:
                   done
                   echo "Applying honua-gp smoke seed: tests/seed/client-compat-v1.sql"
                   psql -v ON_ERROR_STOP=1 -f tests/seed/client-compat-v1.sql
+                  # The canonical client-compat seed registers a single layer
+                  # (layer 0) and honua-server's analytics.spatial-join rejects a
+                  # self-join, so the SpatialJoin eval scripts need a second,
+                  # distinct join layer.
+                  #
+                  # This MUST run here, in the seed job, and not after the server
+                  # is up: honua-server compiles and activates a metadata-v2
+                  # snapshot from the v1 tables at startup and then serves from
+                  # that snapshot. A layer inserted into honua.layers after the
+                  # server has started is absent from the activated snapshot, so
+                  # the GPServer submit path cannot resolve it and rejects the
+                  # job with HTTP 403 "layer read authorization" -- which is
+                  # exactly how the two SpatialJoin eval scripts used to fail.
+                  echo "Applying honua-gp SpatialJoin join-layer fixture: gp-seed/spatial-join-second-layer.sql"
+                  psql -v ON_ERROR_STOP=1 -f /workspace/gp-seed/spatial-join-second-layer.sql
                   echo "honua-gp smoke seed complete."
             honua:
               image: ${HONUA_LOCAL_SERVER_IMAGE}
@@ -297,14 +318,18 @@ jobs:
             docker compose -f "${compose_file}" -f "${override_file}" logs honua | tail -100 || true
             exit 1
           fi
-          # The canonical client-compat seed registers a single layer (layer 0).
-          # honua-server's analytics.spatial-join rejects a self-join, so the
-          # SpatialJoin eval scripts need a second, distinct join layer. Apply
-          # the in-repo second-layer fixture against the seeded postgres. See
-          # packages/honua-gp/eval/seed/spatial-join-second-layer.sql (#157).
-          second_layer_sql="${GITHUB_WORKSPACE}/packages/honua-gp/eval/seed/spatial-join-second-layer.sql"
-          docker compose -f "${compose_file}" -f "${override_file}" exec -T postgres \
-            psql -U postgres -d honua_compat -v ON_ERROR_STOP=1 < "${second_layer_sql}"
+          # Assert the SpatialJoin join layer made it into the activated
+          # metadata-v2 snapshot the server is serving from. The fixture is
+          # applied by the seed job (see the override above); if that ordering
+          # ever regresses, the SpatialJoin eval scripts fail with an opaque
+          # HTTP 403 instead of a diagnosable seed error, so check it here.
+          if ! curl -fsS -H "X-API-Key: ClientCompatAdmin123!" \
+            "http://localhost:5000/rest/services/test_service/FeatureServer/1?f=json" \
+            | grep -q '"id"'; then
+            echo "::error::The SpatialJoin join layer (test_service layer 1) is not served by honua-server. The seed job must apply packages/honua-gp/eval/seed/spatial-join-second-layer.sql BEFORE the server starts, or the server's activated metadata-v2 snapshot will not contain it."
+            docker compose -f "${compose_file}" -f "${override_file}" logs seed | tail -50 || true
+            exit 1
+          fi
 
       - name: Run ephemeral smoke (live value diff -- honua_gp <-> real honua-server)
         env:
@@ -340,3 +365,16 @@ jobs:
             --audit-root packages/honua-gp/eval/.audit-live \
             --pass-threshold 0.70 \
             --require-supported-pass-rate 1.0
+
+      # Without this the only trace of a live failure is the aggregate pass-rate
+      # line -- the failing script names and their reasons live in the JSON.
+      - name: Upload ephemeral smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: honua-gp-smoke-eval
+          path: |
+            packages/honua-gp/smoke-eval.json
+            packages/honua-gp/smoke-eval.xml
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/honua-gp-eval.yml
+++ b/.github/workflows/honua-gp-eval.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload eval artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: honua-gp-eval
           path: |
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload honua-gp wheel artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: honua-gp-wheel
           path: packages/honua-gp/dist/*.whl
@@ -370,7 +370,7 @@ jobs:
       # line -- the failing script names and their reasons live in the JSON.
       - name: Upload ephemeral smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: honua-gp-smoke-eval
           path: |

--- a/packages/honua-gp/eval/run_eval.py
+++ b/packages/honua-gp/eval/run_eval.py
@@ -658,6 +658,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"({summary.supported_pass_rate:.0%}); "
         f"supported-required {args.require_supported_pass_rate:.0%}\n"
     )
+    # Name the failures on stdout. The aggregate pass-rate line alone makes a
+    # red CI lane undiagnosable from the job log -- the script names and their
+    # reasons otherwise only exist in --output-json.
+    for result in summary.results:
+        if result.status == "fail":
+            scope = "expected_failure" if result.expected_failure else "supported"
+            sys.stdout.write(
+                f"honua-gp eval: FAIL [{scope}] {result.name}: {result.reason or 'no reason recorded'}\n"
+            )
     if args.update_golden:
         sys.stdout.write("honua-gp eval: golden value oracles updated; review the diff before committing.\n")
         return 0

--- a/packages/honua-gp/eval/seed/spatial-join-second-layer.sql
+++ b/packages/honua-gp/eval/seed/spatial-join-second-layer.sql
@@ -64,3 +64,27 @@ FROM (
         ('POINT(-122.4000 37.7700)', 'zone-c')
 ) AS seed(wkt, zone)
 WHERE NOT EXISTS (SELECT 1 FROM features WHERE layer_id = 1);
+
+-- Refresh the v1 -> metadata-v2 compatibility snapshot so the layer registered
+-- above is present in the ACTIVATED snapshot the server serves from.
+--
+-- honua-server reads its catalog from an activated metadata-v2 snapshot, not
+-- from honua.layers directly. tests/seed/client-compat-v1.sql builds and
+-- activates that snapshot as its last statement, which is before this file
+-- runs, so without this call layer 1 exists in the v1 tables but not in the
+-- snapshot -- and the GPServer submit path rejects analytics.spatial-join with
+-- HTTP 403 "layer read authorization". This file must therefore also be applied
+-- BEFORE honua-server starts (the ephemeral-server-smoke job applies it in the
+-- one-shot seed container); a server that has already started and compiled its
+-- own snapshot will not pick up a later refresh.
+--
+-- Guarded so the file stays applicable against a target seeded some other way.
+DO $$
+BEGIN
+    IF to_regprocedure('honua.seed_metadata_v2_compat_snapshot()') IS NOT NULL THEN
+        PERFORM honua.seed_metadata_v2_compat_snapshot();
+    ELSE
+        RAISE NOTICE 'honua.seed_metadata_v2_compat_snapshot() not present; skipping metadata-v2 snapshot refresh.';
+    END IF;
+END
+$$;


### PR DESCRIPTION
Fixes the `honua-sdk-python` third of honua-io/honua-release#102: the `ephemeral-server-smoke` core lane.

## Verdict: this is a real code/fixture bug, not an env-gated lane

The task allowed for classifying this `env-gated` in `honua-release`'s `certification/env-gated-checks.yaml` if the lane needed a backend CI does not have. **It does not.** `ephemeral-server-smoke` provisions its own target: it checks out `honua-io/honua-server`, builds the client-compat seed image, and stands up seeded PostGIS + Redis + `ghcr.io/honua-io/honua-server:nightly-aot` in Docker on the runner. No secret, no external service, no `vars.HONUA_GP_EVAL_BASE_URL` is involved — the default posture is deliberately the fresh local stack. (`staging-smoke`, the lane in the same repo that *does* need a persistent server, is already env-gated and is untouched here.) So the honest outcome is a fix, and the fix is below.

## Failing-log evidence

The lane has failed on **every** run that got past the `eval` job, with an identical result — 2026-08-05 (`30964015046`), 2026-08-10 (`31349058614`) and the release-pinned `23e9dd3` (`31734132379`):

```
honua-gp eval [live]: 48/50 passed (96%); threshold 70%; supported 23/25 (92%); supported-required 100%
honua-gp eval: supported-surface pass rate 92% is below required 100%
##[error]Process completed with exit code 1.
```

That is the entire signal in the job log. The job uploads no artifacts and `run_eval.py` printed only the aggregate, so *which* two supported scripts failed was not recoverable from CI at all. I reproduced the lane locally — same server image, same seed, same env — and got byte-identical numbers, then read `smoke-eval.json`:

```
=== spatial_join_addresses_parcels.py fail
  checks: {'exit': 'fail'}
  reason: exited 1: honua_gp._errors.ExecuteError: analysis.SpatialJoin failed:
          HTTP 403: You do not have permission to perform this operation.
=== spatial_join_with_radius.py fail          (identical)
```

The server side of that 403:

```
POST /ogc/processes/processes/analytics.spatial-join/execution
Submit rejected by layer read authorization: LayerId=1, StepId="ogc-analytics-spatial-join", ProcessId="analytics.spatial-join"
HTTP POST .../execution responded 403 in 7.99 ms
```

## Root cause

`LayerId=1` is the join layer this repo adds in `packages/honua-gp/eval/seed/spatial-join-second-layer.sql` (honua-server's `analytics.spatial-join` rejects a self-join, so the two SpatialJoin scripts need a second, distinct layer).

honua-server does not resolve its catalog from the v1 `honua.layers` tables — it serves from an **activated metadata-v2 snapshot** which it compiles at startup. Queried against the reproduced stack:

```
environment | revision | resources
------------+----------+---------------------------------
default     |        1 | ["res-image-layer-0", "res-layer-0"]
Development |        1 | ["res-image-layer-0", "res-layer-0"]   <- built by the seed SQL (md5 etag)
Development |        2 | ["res-image-layer-0", "res-layer-0"]   <- compiled by the server at startup, ACTIVE
```

The workflow applied the join-layer fixture with `docker compose exec postgres psql` **after** the `/healthz/ready` poll — i.e. after the server had already compiled and activated revision 2. Layer 1 existed in `honua.layers` but in no snapshot, so every spatial-join submit was rejected on layer-read authorization. Restarting the container does not help either: an activated snapshot already exists, so the server does not recompile (confirmed — restart left revision 2 unchanged with only layer 0).

## The fix

`.github/workflows/honua-gp-eval.yml`
- The compose override now mounts `packages/honua-gp/eval/seed` into the one-shot `seed` service and applies `spatial-join-second-layer.sql` there, right after `tests/seed/client-compat-v1.sql` — so the join layer exists **before** honua starts and is picked up by the startup compile. The `docker compose exec postgres psql` step after readiness is removed.
- In its place, a guard asserts `test_service` layer 1 is actually served (`FeatureServer/1?f=json`) and fails with an explicit message if the ordering ever regresses, instead of letting it resurface as an opaque HTTP 403 from inside the eval.
- The smoke job now uploads `smoke-eval.json` / `smoke-eval.xml` (it uploaded nothing before).

`packages/honua-gp/eval/seed/spatial-join-second-layer.sql`
- Re-runs `honua.seed_metadata_v2_compat_snapshot()` at the end, guarded on the function existing. The canonical client-compat seed builds and activates that snapshot as its *last* statement, which is before this fixture runs, so without the refresh the seeded snapshot is also missing layer 1.

`packages/honua-gp/eval/run_eval.py`
- Prints one `FAIL [supported|expected_failure] <script>: <reason>` line per failure. The aggregate pass-rate line alone is what made this lane undiagnosable from CI for three weeks.

Nothing was weakened: `--require-supported-pass-rate 1.0` and `--pass-threshold 0.70` are unchanged, no script was moved to `expected_failure`, and no golden oracle was re-blessed.

## Verification (local, full lane reproduction)

Same image (`ghcr.io/honua-io/honua-server:nightly-aot`), same seed, same `HONUA_GP_PATH_MAP`, Python 3.11.

Before — trunk `23e9dd3`, reproducing CI exactly:
```
honua-gp eval [live]: 48/50 passed (96%); threshold 70%; supported 23/25 (92%); supported-required 100%
honua-gp eval: supported-surface pass rate 92% is below required 100%
EVAL EXIT=1
```

After — this branch, fresh stack from scratch:
```
seed-1  | Applying honua-gp SpatialJoin join-layer fixture: gp-seed/spatial-join-second-layer.sql
seed-1  | INSERT 0 1 / UPDATE 1 / INSERT 0 2 / INSERT 0 1 / INSERT 0 3 / DO
seed-1  | honua-gp smoke seed complete.
=== join-layer guard ===
GUARD PASSED: layer 1 served
honua-gp eval [live]: 50/50 passed (100%); threshold 70%; supported 25/25 (100%); supported-required 100%
EVAL EXIT=0
```

Other lanes in this workflow, unchanged and green:
- `python -m honua_gp._cli matrix --check packages/honua-gp/docs/compatibility-matrix.md` → clean
- `pytest packages/honua-gp/tests -q` → `195 passed, 4 skipped`
- stub-mode eval → `50/50 passed (100%); supported 25/25 (100%)`, exit 0
- `actionlint` (pinned image) over `.github/workflows/` → exit 0, no findings

New failure reporting, exercised against a deliberately unreachable server:
```
honua-gp eval [live]: 1/2 passed (50%); ... supported 0/1 (0%); supported-required 100%
honua-gp eval: FAIL [supported] spatial_join_addresses_parcels.py: exited 1: honua_gp._errors.ExecuteError: analysis.SpatialJoin failed: Transport error: [Errno 111] Connection refused
```

## Note for the release train

This lane's target is `honua-server:nightly-aot` and an unpinned checkout of `honua-server` trunk for the seed, so it carries a moving upstream baseline. That is a separate concern from this bug and is not changed here.
