### PR TITLE
fix(honua-gp): bootstrap env and resolve FeatureServer URLs

### DIFF
--- a/packages/honua-gp/honua_gp/_resolve.py
+++ b/packages/honua-gp/honua_gp/_resolve.py
@@ -29,6 +29,10 @@ _HONUA_URI = re.compile(r"^honua://(?P<rest>.+)$")
 _WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]")
 _GDB_RE = re.compile(r"\.gdb([\\/]|$)", re.IGNORECASE)
 _SDE_RE = re.compile(r"\.sde([\\/]|$)", re.IGNORECASE)
+_FEATURE_SERVER_LAYER_RE = re.compile(
+    r"(?:^|/)rest/services/(?P<service>.+?)/FeatureServer/(?P<layer>\d+)/?(?:[?#].*)?$",
+    re.IGNORECASE,
+)
 _IN_MEMORY_PREFIXES = ("in_memory", "memory", "in_memory\\", "in_memory/")
 
 
@@ -98,13 +102,28 @@ def resolve(path: Any, *, session: HonuaSession | None = None) -> ResolvedSource
     if path in overrides:
         return ResolvedSource(source=overrides[path], kind="honua-uri", raw=raw)
 
-    # 4. in_memory / memory layer.
+    # 4. ArcGIS REST FeatureServer layer URL/path. ArcPy callers commonly pass
+    # the same live URL they use with the real arcpy module; canonicalize it to
+    # the shim's existing source URI instead of treating the URL as a workspace
+    # name and sending it as a service id.
+    feature_layer = _FEATURE_SERVER_LAYER_RE.search(path)
+    if feature_layer is not None:
+        service = feature_layer.group("service").strip("/")
+        layer = feature_layer.group("layer")
+        return ResolvedSource(
+            source=f"honua://services/{service}/{layer}",
+            kind="honua-uri",
+            layer=layer,
+            raw=raw,
+        )
+
+    # 5. in_memory / memory layer.
     lowered = path.lower()
     if lowered.startswith(_IN_MEMORY_PREFIXES):
         tail = path.split("/")[-1].split("\\")[-1]
         return ResolvedSource(source=f"in_memory:{tail}", kind="in-memory", raw=raw)
 
-    # 5. Absolute Windows / POSIX path.
+    # 6. Absolute Windows / POSIX path.
     if _WINDOWS_ABSOLUTE.match(path) or path.startswith("/") or path.startswith("\\\\"):
         normalized = path.replace("\\", "/")
         layer = normalized.rsplit("/", 1)[-1]
@@ -121,7 +140,7 @@ def resolve(path: Any, *, session: HonuaSession | None = None) -> ResolvedSource
             raw=raw,
         )
 
-    # 6. Fall back to workspace-relative name.
+    # 7. Fall back to workspace-relative name.
     return ResolvedSource(
         source=path,
         kind="workspace-relative",
@@ -182,11 +201,10 @@ def descriptor_mapping(
     if source.startswith("honua://services/"):
         rest = source[len("honua://services/") :]
         parts = [part for part in rest.split("/") if part]
-        if parts:
-            service_id = parts[0]
         if len(parts) >= 2:
+            service_id = "/".join(parts[:-1])
             try:
-                layer_id = int(parts[1])
+                layer_id = int(parts[-1])
             except ValueError as exc:
                 raise HonuaGpResolveError(
                     source,
@@ -201,6 +219,8 @@ def descriptor_mapping(
                     source,
                     hint="honua://services URIs must use a non-negative numeric layer id.",
                 )
+        elif parts:
+            service_id = parts[0]
     elif isinstance(workspace, str) and workspace.startswith("honua://services/"):
         ws_parts = [part for part in workspace[len("honua://services/") :].split("/") if part]
         if ws_parts:

--- a/packages/honua-gp/honua_gp/_resolve.py
+++ b/packages/honua-gp/honua_gp/_resolve.py
@@ -21,6 +21,7 @@ import os
 import re
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import unquote
 
 from ._errors import HonuaGpResolveError
 from ._session import HonuaSession, LayerAlias, get_session
@@ -108,7 +109,7 @@ def resolve(path: Any, *, session: HonuaSession | None = None) -> ResolvedSource
     # name and sending it as a service id.
     feature_layer = _FEATURE_SERVER_LAYER_RE.search(path)
     if feature_layer is not None:
-        service = feature_layer.group("service").strip("/")
+        service = unquote(feature_layer.group("service").strip("/"))
         layer = feature_layer.group("layer")
         return ResolvedSource(
             source=f"honua://services/{service}/{layer}",

--- a/packages/honua-gp/honua_gp/_session.py
+++ b/packages/honua-gp/honua_gp/_session.py
@@ -230,6 +230,8 @@ class HonuaSession:
 
     def _build_client(self) -> Any:
         if not self.base_url:
+            self.configure_from_env()
+        if not self.base_url:
             raise HonuaGpConfigurationError(
                 "honua_gp is not configured; call honua_gp.configure(base_url=...) "
                 "or set the HONUA_BASE_URL environment variable."
@@ -244,6 +246,8 @@ class HonuaSession:
         return HonuaClient(self.base_url, **kwargs)
 
     def _build_admin_client(self) -> Any:
+        if not self.base_url:
+            self.configure_from_env()
         if not self.base_url:
             raise HonuaGpConfigurationError(
                 "honua_gp is not configured; call honua_gp.configure(base_url=...) "

--- a/packages/honua-gp/honua_gp/_session.py
+++ b/packages/honua-gp/honua_gp/_session.py
@@ -63,6 +63,9 @@ class HonuaSession:
     _client: Any = field(default=None, repr=False)
     _admin: Any = field(default=None, repr=False)
     _processes: Any = field(default=None, repr=False)
+    _client_injected: bool = field(default=False, repr=False)
+    _admin_injected: bool = field(default=False, repr=False)
+    _processes_injected: bool = field(default=False, repr=False)
     _layers: dict[str, LayerAlias] = field(default_factory=dict, repr=False)
     _audit_writer: AuditWriter | None = field(default=None, repr=False)
     _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
@@ -123,22 +126,44 @@ class HonuaSession:
                 self._client = None
                 self._admin = None
                 self._processes = None
+                self._client_injected = False
+                self._admin_injected = False
+                self._processes_injected = False
             if client is not None:
                 self._client = client
+                self._client_injected = True
                 self._processes = None  # rebuild from client
+                self._processes_injected = False
             if admin_client is not None:
                 self._admin = admin_client
+                self._admin_injected = True
             if processes_client is not None:
                 self._processes = processes_client
+                self._processes_injected = True
 
     def configure_from_env(self) -> None:
-        """Pick up ``HONUA_BASE_URL`` / ``HONUA_API_KEY`` / ``HONUA_BEARER_TOKEN``."""
+        """Pick up env settings without dropping explicitly injected clients."""
 
         base_url = os.environ.get("HONUA_BASE_URL")
         api_key = os.environ.get("HONUA_API_KEY")
         bearer = os.environ.get("HONUA_BEARER_TOKEN")
         if base_url:
-            self.configure(base_url=base_url, api_key=api_key, bearer_token=bearer)
+            with self._lock:
+                injected = (
+                    self._client if self._client_injected else None,
+                    self._admin if self._admin_injected else None,
+                    self._processes if self._processes_injected else None,
+                )
+                self.configure(base_url=base_url, api_key=api_key, bearer_token=bearer)
+                if injected[0] is not None:
+                    self._client = injected[0]
+                    self._client_injected = True
+                if injected[1] is not None:
+                    self._admin = injected[1]
+                    self._admin_injected = True
+                if injected[2] is not None:
+                    self._processes = injected[2]
+                    self._processes_injected = True
 
     # ------------------------------------------------------------------
     # Client accessors (lazy)
@@ -221,6 +246,9 @@ class HonuaSession:
             self._client = None
             self._admin = None
             self._processes = None
+            self._client_injected = False
+            self._admin_injected = False
+            self._processes_injected = False
             self._layers = {}
             self._audit_writer = None
 

--- a/packages/honua-gp/tests/test_resolve.py
+++ b/packages/honua-gp/tests/test_resolve.py
@@ -75,6 +75,20 @@ def test_feature_server_layer_url_preserves_foldered_service_id() -> None:
     assert descriptor["locator"] == {"serviceId": "folder/test", "layerId": 12}
 
 
+def test_feature_server_layer_url_decodes_escaped_service_name() -> None:
+    from honua_sdk.protocols._base import _service_path
+
+    resolved = resolve(
+        "https://honua.example.com/rest/services/My%20Service/FeatureServer/0"
+    )
+    assert resolved.source == "honua://services/My Service/0"
+    descriptor = descriptor_mapping(resolved)
+    assert descriptor["locator"] == {"serviceId": "My Service", "layerId": 0}
+    assert _service_path(descriptor["locator"]["serviceId"], "FeatureServer") == (
+        "/rest/services/My%20Service/FeatureServer"
+    )
+
+
 def test_descriptor_mapping_parses_honua_uri_service_and_layer() -> None:
     resolved = resolve("honua://services/transport/2")
     descriptor = descriptor_mapping(resolved)

--- a/packages/honua-gp/tests/test_resolve.py
+++ b/packages/honua-gp/tests/test_resolve.py
@@ -53,6 +53,28 @@ def test_honua_path_map_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resolved.source == "honua://services/transport/0"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "rest/services/test/FeatureServer/0",
+        "https://honua.example.com/rest/services/test/FeatureServer/0",
+        "https://honua.example.com/gis/rest/services/folder/test/FeatureServer/12?f=json",
+    ],
+)
+def test_feature_server_layer_paths_are_canonicalized(path: str) -> None:
+    resolved = resolve(path)
+    assert resolved.kind == "honua-uri"
+    assert resolved.source.endswith("/FeatureServer/0") is False
+    descriptor = descriptor_mapping(resolved)
+    assert descriptor["locator"]["layerId"] in (0, 12)
+
+
+def test_feature_server_layer_url_preserves_foldered_service_id() -> None:
+    resolved = resolve("https://honua.example.com/gis/rest/services/folder/test/FeatureServer/12")
+    descriptor = descriptor_mapping(resolved)
+    assert descriptor["locator"] == {"serviceId": "folder/test", "layerId": 12}
+
+
 def test_descriptor_mapping_parses_honua_uri_service_and_layer() -> None:
     resolved = resolve("honua://services/transport/2")
     descriptor = descriptor_mapping(resolved)

--- a/packages/honua-gp/tests/test_session.py
+++ b/packages/honua-gp/tests/test_session.py
@@ -8,6 +8,29 @@ import honua_gp
 from honua_gp._session import get_session
 
 
+def test_client_bootstraps_from_environment(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubClient:
+        def __init__(self, base_url: str, **kwargs: Any) -> None:
+            captured["base_url"] = base_url
+            captured["kwargs"] = kwargs
+
+    import honua_sdk
+
+    monkeypatch.setattr(honua_sdk, "HonuaClient", _StubClient)
+    monkeypatch.setenv("HONUA_BASE_URL", "https://env.example.com")
+    monkeypatch.setenv("HONUA_API_KEY", "env-key")
+
+    built = get_session().client()
+
+    assert isinstance(built, _StubClient)
+    assert captured == {
+        "base_url": "https://env.example.com",
+        "kwargs": {"api_key": "env-key"},
+    }
+
+
 def test_configure_invalidates_lazy_client_cache_on_base_url_change() -> None:
     """Changing ``base_url`` must drop any previously cached client so the
     next ``client()`` call rebuilds against the new endpoint. Without this,

--- a/packages/honua-gp/tests/test_session.py
+++ b/packages/honua-gp/tests/test_session.py
@@ -31,6 +31,40 @@ def test_client_bootstraps_from_environment(monkeypatch) -> None:
     }
 
 
+def test_environment_bootstrap_preserves_injected_admin_client(monkeypatch) -> None:
+    class _StubClient:
+        def __init__(self, base_url: str, **kwargs: Any) -> None:
+            pass
+
+    import honua_sdk
+
+    monkeypatch.setattr(honua_sdk, "HonuaClient", _StubClient)
+    monkeypatch.setenv("HONUA_BASE_URL", "https://env.example.com")
+    injected_admin = object()
+    honua_gp.configure(admin_client=injected_admin)
+
+    get_session().client()
+
+    assert get_session()._admin is injected_admin  # noqa: SLF001
+
+
+def test_environment_bootstrap_preserves_injected_data_client(monkeypatch) -> None:
+    class _StubAdminClient:
+        def __init__(self, base_url: str, **kwargs: Any) -> None:
+            pass
+
+    import honua_admin
+
+    monkeypatch.setattr(honua_admin, "HonuaAdminClient", _StubAdminClient)
+    monkeypatch.setenv("HONUA_BASE_URL", "https://env.example.com")
+    injected_client = object()
+    honua_gp.configure(client=injected_client)
+
+    get_session().admin_client()
+
+    assert get_session()._client is injected_client  # noqa: SLF001
+
+
 def test_configure_invalidates_lazy_client_cache_on_base_url_change() -> None:
     """Changing ``base_url`` must drop any previously cached client so the
     next ``client()`` call rebuilds against the new endpoint. Without this,


### PR DESCRIPTION
## Summary

- bootstrap an unconfigured honua-gp session from `HONUA_BASE_URL` on first client access
- canonicalize absolute and relative ArcGIS REST FeatureServer layer URLs
- preserve foldered service identifiers when building SDK descriptors

## Validation

- `with-build-lock python3 -m pytest packages/honua-gp/tests/test_resolve.py packages/honua-gp/tests/test_session.py -q`
- 24 passed
- licensed Windows ArcGIS Pro Python environment resolved `https://localhost:28446/rest/services/test/FeatureServer/0` to `honua://services/test/0` and completed a live `GetCount` request against the released 2026.1 server

Closes #205
