### PR TITLE
fix(release): resume verified asset attachment

### DIFF
--- a/.github/workflows/publish-python-sdk.yml
+++ b/.github/workflows/publish-python-sdk.yml
@@ -494,7 +494,11 @@ jobs:
     needs:
       - resolve-publish-targets
       - verify-honua-sdk-pypi
-    if: needs.resolve-publish-targets.outputs.publish == 'true'
+    if: >
+      always()
+      && needs.resolve-publish-targets.result == 'success'
+      && needs.verify-honua-sdk-pypi.result == 'success'
+      && needs.resolve-publish-targets.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -843,7 +847,11 @@ jobs:
     needs:
       - resolve-publish-targets
       - verify-honua-admin-pypi
-    if: needs.resolve-publish-targets.outputs.publish == 'true'
+    if: >
+      always()
+      && needs.resolve-publish-targets.result == 'success'
+      && needs.verify-honua-admin-pypi.result == 'success'
+      && needs.resolve-publish-targets.outputs.publish == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/tests/test_release_please_config.py
+++ b/tests/test_release_please_config.py
@@ -193,6 +193,9 @@ def test_registry_and_release_assets_require_exact_hash_parity() -> None:
 
     for package in ("honua-sdk", "honua-admin"):
         attachment = _job_block(workflow, f"attach-{package}-release")
+        assert "always()" in attachment
+        assert "needs.resolve-publish-targets.result == 'success'" in attachment
+        assert f"needs.verify-{package}-pypi.result == 'success'" in attachment
         assert "contents: write" in attachment
         assert "id-token: write" not in attachment
         assert "gh release upload" in attachment


### PR DESCRIPTION
## Summary

- make release-asset attachment explicitly resumable after an occupied-coordinate PyPI parity pass
- require successful target resolution and exact registry verification before either contents-write job can run
- add workflow contract coverage for the lways()/result gates

## Live evidence

The first public 0.1.11/0.1.8 uploads succeeded, but PyPI propagation exceeded the verifier retry window. On the safe rerun, both preflights and registry parity checks passed while GitHub skipped the attachment jobs because a skipped publish ancestor made the implicit success condition false. This patch fixes only that orchestration seam; it cannot publish or overwrite packages.

## Validation

- 26 focused publication/workflow tests passed
- workflow YAML parsed
- git diff --check passed

No tag, package, release asset, or repository setting is changed by this PR.