### PR TITLE
fix(certification): bind Python evidence to governed candidate cut

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -23,6 +23,10 @@ on:
         description: "honua-server git ref to source the conformance seed from (should match the server_image commit). Blank = default branch."
         required: false
         default: ""
+      candidate_cut_at:
+        description: "Exact governed candidate cut timestamp (YYYY-MM-DDTHH:MM:SSZ). Required for release certification."
+        required: false
+        default: ""
       certification_tier:
         description: "Evidence policy tier: nightly or release. Release requires immutable image and full server SHA."
         required: false
@@ -110,6 +114,7 @@ jobs:
           COMPOSE_PROJECT_NAME: honua-python-conformance-${{ github.run_id }}-${{ github.run_attempt }}
           HONUA_CERTIFICATION_TIER: ${{ github.event.inputs.certification_tier || (github.event_name == 'pull_request' && 'pr') || 'nightly' }}
           SERVER_SEED_REF_INPUT: ${{ github.event.inputs.server_seed_ref }}
+          CANDIDATE_CUT_AT_INPUT: ${{ github.event.inputs.candidate_cut_at }}
         run: |
           set -euo pipefail
 
@@ -124,6 +129,10 @@ jobs:
             fi
             if [[ ! "${SERVER_SEED_REF_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
               echo "::error::release certification requires a full 40-character server_seed_ref"
+              exit 1
+            fi
+            if [[ ! "${CANDIDATE_CUT_AT_INPUT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+              echo "::error::release certification requires the exact governed candidate_cut_at in UTC"
               exit 1
             fi
           fi
@@ -184,7 +193,11 @@ jobs:
           image_digest="${resolved_image##*@}"
           image_revision="$(docker image inspect "${HONUA_SERVER_IMAGE}" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null || true)"
           seed_revision="$(git -C "${server_root}" rev-parse HEAD)"
-          candidate_cut_at="$(git -C "${server_root}" show -s --format=%cI "${image_revision}")"
+          if [[ "${HONUA_CERTIFICATION_TIER}" == "release" ]]; then
+            candidate_cut_at="${CANDIDATE_CUT_AT_INPUT}"
+          else
+            candidate_cut_at="$(git -C "${server_root}" show -s --format=%cI "${image_revision}")"
+          fi
 
           if [[ ! "${image_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
             echo "::error::could not resolve an immutable server image digest"
@@ -219,6 +232,7 @@ jobs:
             if [[ -n "${image_revision}" && "${image_revision}" != "<no value>" ]]; then
               echo "- Image revision: \`${image_revision}\`"
             fi
+            echo "- Governed candidate cut: \`${candidate_cut_at}\`"
             echo "- Fixture set: \`${CONFORMANCE_FIXTURES_VERSION}\` (geospatial-grpc shared fixtures)"
             echo "- Base URL: \`http://localhost:5000\` (service \`test_service\`, layer \`0\`)"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -131,10 +131,13 @@ jobs:
               echo "::error::release certification requires a full 40-character server_seed_ref"
               exit 1
             fi
-            if [[ ! "${CANDIDATE_CUT_AT_INPUT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
-              echo "::error::release certification requires the exact governed candidate_cut_at in UTC"
-              exit 1
-            fi
+            python - "${CANDIDATE_CUT_AT_INPUT}" <<'PY'
+          import sys
+
+          from scripts._conformance import validate_candidate_cut_at
+
+          validate_candidate_cut_at(sys.argv[1])
+          PY
           fi
 
           # Override the one-shot seed to apply the canonical client-compat seed

--- a/scripts/_conformance.py
+++ b/scripts/_conformance.py
@@ -1279,10 +1279,38 @@ CASE_CERTIFICATION: dict[str, tuple[str, str, str, list[str]]] = {
 
 CERTIFICATION_SCOPE_OWNER = "https://github.com/honua-io/honua-sdk-python/issues/21"
 CERTIFICATION_AUTH_POLICY_REVISION = "anonymous-public-v1"
+_CANDIDATE_CUT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def validate_candidate_cut_at(value: str | None) -> str:
+    """Require an exact, calendar-valid UTC release cut timestamp."""
+    if not isinstance(value, str):
+        raise ConformanceFixturesError(
+            "candidate_cut_at must use the exact UTC format YYYY-MM-DDTHH:MM:SSZ"
+        )
+    try:
+        parsed = datetime.strptime(value, _CANDIDATE_CUT_FORMAT)
+    except ValueError as exc:
+        raise ConformanceFixturesError(
+            "candidate_cut_at must be a calendar-valid UTC timestamp in "
+            "YYYY-MM-DDTHH:MM:SSZ format"
+        ) from exc
+    if parsed.strftime(_CANDIDATE_CUT_FORMAT) != value:
+        raise ConformanceFixturesError(
+            "candidate_cut_at must use the canonical UTC format YYYY-MM-DDTHH:MM:SSZ"
+        )
+    return value
 
 
 def validate_release_certification_fragment(fragment: Mapping[str, Any]) -> None:
     """Reject incomplete, duplicated, missing, or non-pass release evidence."""
+    candidate = fragment.get("candidate")
+    _require(isinstance(candidate, Mapping), "release SDK certification is missing candidate identity")
+    try:
+        candidate_cut_at = validate_candidate_cut_at(candidate.get("cut_at"))
+    except ConformanceFixturesError as exc:
+        raise AssertionError(str(exc)) from exc
+
     scope = fragment.get("operation_scope")
     _require(isinstance(scope, Mapping), "release SDK certification is missing operation_scope")
     if scope.get("complete") is not True:
@@ -1323,6 +1351,15 @@ def validate_release_certification_fragment(fragment: Mapping[str, Any]) -> None
         if row.get("result") != "pass"
     ]
     _require(not failed, "release SDK certification has non-pass cells: " + ", ".join(failed))
+    for row in observations:
+        receipt = row.get("evidence_receipt")
+        identity = receipt.get("identity") if isinstance(receipt, Mapping) else None
+        _require(
+            isinstance(identity, Mapping)
+            and identity.get("candidate_cut_at") == candidate_cut_at,
+            f"release SDK certification receipt for {row['surface']}/{row['operation']} "
+            "is not bound to candidate.cut_at",
+        )
 
 
 def build_certification_fragment(
@@ -1383,6 +1420,7 @@ def build_certification_fragment(
                 "fixture_revision": f"geospatial-grpc@{bundle.version}",
                 "contract_revision": contract_revision,
                 "auth_policy_revision": CERTIFICATION_AUTH_POLICY_REVISION,
+                "candidate_cut_at": target.candidate_cut_at,
                 "started_at": result.started_at,
                 "completed_at": result.completed_at,
             },

--- a/tests/test_certification_fragment.py
+++ b/tests/test_certification_fragment.py
@@ -14,6 +14,7 @@ from scripts._conformance import (
     ConformanceTarget,
     FixtureBundle,
     build_certification_fragment,
+    validate_candidate_cut_at,
     validate_release_certification_fragment,
 )
 
@@ -88,6 +89,7 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
     assert passed["fixture_revision"] == "geospatial-grpc@fixture-v1"
     assert passed["contract_revision"] == f"sdk-python-certification@{sdk_sha}"
     assert passed["auth_policy_revision"] == "anonymous-public-v1"
+    assert passed["evidence_receipt"]["identity"]["candidate_cut_at"] == target.candidate_cut_at
     assert passed["evidence_digest"].startswith("sha256:")
     assert set(passed["facet_results"]) == set(passed["scenario_facets"])
     assert all(
@@ -99,6 +101,71 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
     assert failed["skip_reason"] == gap.known_gap_issue
     assert failed["evidence_digest"] is None
     assert failed["facet_results"] is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "2026-13-40T25:61:61Z",
+        "2026-08-20T00:00:00+00:00",
+        "2026-08-20T00:00:00.000Z",
+        "2026-8-20T00:00:00Z",
+        "",
+        None,
+    ],
+)
+def test_candidate_cut_requires_a_calendar_valid_canonical_utc_timestamp(
+    value: str | None,
+) -> None:
+    with pytest.raises(RuntimeError, match="candidate_cut_at"):
+        validate_candidate_cut_at(value)
+
+
+def test_candidate_cut_changes_the_content_addressed_receipt(monkeypatch) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "9.9.9")
+    case = _case("feature_query_envelope")
+
+    def build(cut_at: str) -> dict:
+        target = ConformanceTarget(
+            base_url="http://localhost:5000",
+            server_commit="a" * 40,
+            server_image_digest="sha256:" + "b" * 64,
+            sdk_source_sha="c" * 40,
+            evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
+            candidate_cut_at=cut_at,
+            certification_tier="release",
+        )
+        return build_certification_fragment(
+            FixtureBundle(Path("."), "fixture-v1"),
+            target,
+            [(case, _result(case.name, "passed"))],
+        )["observations"][0]
+
+    first = build("2026-08-20T00:00:00Z")
+    second = build("2026-08-20T00:00:01Z")
+    assert first["evidence_digest"] != second["evidence_digest"]
+    assert first["evidence_uri"] != second["evidence_uri"]
+
+
+def test_release_validator_rejects_receipt_bound_to_another_cut(monkeypatch) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "9.9.9")
+    target = ConformanceTarget(
+        base_url="http://localhost:5000",
+        server_commit="a" * 40,
+        server_image_digest="sha256:" + "b" * 64,
+        sdk_source_sha="c" * 40,
+        evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
+        candidate_cut_at="2026-08-20T00:00:00Z",
+        certification_tier="release",
+    )
+    cases = [(_case(name), _result(name, "passed")) for name in CASE_CERTIFICATION]
+    fragment = build_certification_fragment(FixtureBundle(Path("."), "fixture-v1"), target, cases)
+    fragment["observations"][0]["evidence_receipt"]["identity"]["candidate_cut_at"] = (
+        "2026-08-20T00:00:01Z"
+    )
+
+    with pytest.raises(AssertionError, match="not bound to candidate.cut_at"):
+        validate_release_certification_fragment(fragment)
 
 
 def test_machine_readable_certification_contract_matches_case_mapping() -> None:

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "conformance.yml"
+
+
+def test_release_certification_uses_the_governed_candidate_cut() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "candidate_cut_at:" in workflow
+    assert "CANDIDATE_CUT_AT_INPUT: ${{ github.event.inputs.candidate_cut_at }}" in workflow
+    assert (
+        'if [[ ! "${CANDIDATE_CUT_AT_INPUT}" =~ '
+        "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]"
+    ) in workflow
+    assert 'candidate_cut_at="${CANDIDATE_CUT_AT_INPUT}"' in workflow
+    assert (
+        'candidate_cut_at="$(git -C "${server_root}" show -s --format=%cI '
+        '"${image_revision}")"'
+    ) in workflow

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -9,10 +9,8 @@ def test_release_certification_uses_the_governed_candidate_cut() -> None:
 
     assert "candidate_cut_at:" in workflow
     assert "CANDIDATE_CUT_AT_INPUT: ${{ github.event.inputs.candidate_cut_at }}" in workflow
-    assert (
-        'if [[ ! "${CANDIDATE_CUT_AT_INPUT}" =~ '
-        "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]"
-    ) in workflow
+    assert "from scripts._conformance import validate_candidate_cut_at" in workflow
+    assert "validate_candidate_cut_at(sys.argv[1])" in workflow
     assert 'candidate_cut_at="${CANDIDATE_CUT_AT_INPUT}"' in workflow
     assert (
         'candidate_cut_at="$(git -C "${server_root}" show -s --format=%cI '


### PR DESCRIPTION
## Summary

- add a governed `candidate_cut_at` dispatch input for release-tier conformance
- reject missing, non-canonical, or calendar-invalid release cut timestamps
- use the governed release cut while preserving derived commit-time cuts for PR/nightly evidence
- bind every Python observation receipt digest to the candidate cut and validate the binding before upload

## Validation

- `PYTHONPATH=packages/honua-sdk:packages/honua-admin:. python -m pytest -q` — 1700 passed, 14 skipped
- `ruff check scripts/_conformance.py tests/test_certification_fragment.py tests/test_conformance_workflow_contract.py`
- workflow YAML parse and diff checks
- hosted conformance passed on the previous head; fresh exact-head checks are running

## Release follow-up

After merge, dispatch release conformance with the exact 2026.1 source SHA, image digest, and governed cut. The central evidence aggregator support is tracked by honua-evidence#34.

The unrelated staging smoke remains fail-closed on the expired production client-compat binding tracked by honua-demo-infra#28 / honua-server#3384; this PR does not weaken that policy.
