### PR TITLE
Emit truthful protocol certification identity

### DIFF
--- a/scripts/_conformance.py
+++ b/scripts/_conformance.py
@@ -1139,6 +1139,7 @@ def build_cases() -> list[ConformanceCase]:
     """
     fs_query_path = "/rest/services/{service}/FeatureServer/{layer}/query"
     fs_meta_path = "/rest/services/{service}/FeatureServer/{layer}"
+    fs_service_path = "/rest/services/{service}/FeatureServer"
     ogc_items_path = "/ogc/features/v1/collections/{collection}/items"
     return [
         ConformanceCase(
@@ -1202,7 +1203,9 @@ def build_cases() -> list[ConformanceCase]:
             name="replica_sync_surface",
             fixture="feature_apply_edits",
             sdk_method="HonuaClient.feature_server(...).metadata",
-            request_path=fs_meta_path,
+            # service-level metadata: _run_replica_surface calls
+            # feature_server(...).metadata(), which never touches a layer path
+            request_path=fs_service_path,
             runner=_run_replica_surface,
             known_gap_issue="honua-server#2645",
         ),

--- a/scripts/_conformance.py
+++ b/scripts/_conformance.py
@@ -47,7 +47,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import quote, urljoin, urlsplit
 
 from honua_sdk import HonuaClient, HonuaHttpError
 
@@ -1279,7 +1279,38 @@ CASE_CERTIFICATION: dict[str, tuple[str, str, str, list[str]]] = {
 
 CERTIFICATION_SCOPE_OWNER = "https://github.com/honua-io/honua-sdk-python/issues/21"
 CERTIFICATION_AUTH_POLICY_REVISION = "anonymous-public-v1"
+CERTIFICATION_CLIENT_ID = "Honua SDK Python"
+CERTIFICATION_RUNNER_LANE = "sdk-python-certification"
+CERTIFICATION_PROTOCOL_CONTEXT: dict[str, tuple[str, str]] = {
+    "geoservices-root": ("11.0", "GeoServices REST"),
+    "geoservices-featureserver": ("11.0", "GeoServices REST"),
+    "ogc-api-features": ("1.0", "core"),
+    "ogc-api-processes": ("1.0", "core"),
+}
 _CANDIDATE_CUT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _certification_request_url(
+    case: ConformanceCase,
+    result: CaseResult,
+    target: ConformanceTarget,
+) -> str:
+    """Build the observed operation URL from the live run's target context."""
+    collection_id = result.details.get("collection_id")
+    if not isinstance(collection_id, str) or not collection_id:
+        collection_id = _configured_ogc_collection_candidates(target)[0]
+    request_path = case.request_path.format(
+        service=quote(target.service_id, safe=""),
+        layer=target.layer_id,
+        collection=quote(collection_id, safe=""),
+    )
+    request_url = urljoin(target.base_url.rstrip("/") + "/", request_path.lstrip("/"))
+    parsed = urlsplit(request_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ConformanceFixturesError(
+            "normalized certification evidence needs an absolute HTTP(S) target base_url"
+        )
+    return request_url
 
 
 def validate_candidate_cut_at(value: str | None) -> str:
@@ -1397,6 +1428,7 @@ def build_certification_fragment(
     observations: list[dict[str, Any]] = []
     for case, result in case_results:
         capability_key, surface, operation, scenario_facets = CASE_CERTIFICATION[case.name]
+        protocol_version, protocol_profile = CERTIFICATION_PROTOCOL_CONTEXT[surface]
         known_gap = case.known_gap_issue if result.status != "passed" else None
         normalized_result = (
             "pass" if result.status == "passed"
@@ -1405,13 +1437,14 @@ def build_certification_fragment(
         )
         contract_revision = f"sdk-python-certification@{target.sdk_source_sha}"
         receipt_facets = {facet: normalized_result for facet in scenario_facets}
+        exercised_capabilities = scenario_facets if normalized_result == "pass" else []
         evidence_receipt = None if normalized_result == "skip" else {
             "schema": "honua.certification-evidence-receipt/v1",
             "identity": {
                 "capability_key": capability_key,
                 "surface": surface,
                 "operation": operation,
-                "canonical_client": "Honua SDK Python",
+                "canonical_client": CERTIFICATION_CLIENT_ID,
                 "client_version": client_version,
                 "deployment_target": "local-docker",
                 "source_sha": target.server_commit,
@@ -1439,7 +1472,14 @@ def build_certification_fragment(
                 "surface": surface,
                 "operation": operation,
                 "scenario_facets": scenario_facets,
-                "canonical_client": "Honua SDK Python",
+                "canonical_client": CERTIFICATION_CLIENT_ID,
+                "client_id": CERTIFICATION_CLIENT_ID,
+                "runner_lane": CERTIFICATION_RUNNER_LANE,
+                "protocol_version": protocol_version,
+                "protocol_profile": protocol_profile,
+                "performed_by": CERTIFICATION_CLIENT_ID,
+                "request_url": _certification_request_url(case, result, target),
+                "exercised_capabilities": exercised_capabilities,
                 "client_version": client_version,
                 "deployment_target": "local-docker",
                 "result": normalized_result,

--- a/tests/test_certification_fragment.py
+++ b/tests/test_certification_fragment.py
@@ -4,6 +4,7 @@ import importlib.metadata
 import json
 import tomllib
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -13,6 +14,7 @@ from scripts._conformance import (
     ConformanceCase,
     ConformanceTarget,
     FixtureBundle,
+    build_cases,
     build_certification_fragment,
     validate_candidate_cut_at,
     validate_release_certification_fragment,
@@ -57,8 +59,9 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",
     )
-    passing = _case("feature_query_envelope")
-    gap = _case("temporal_query", "https://github.com/honua-io/honua-server/issues/2643")
+    cases_by_name = {case.name: case for case in build_cases()}
+    passing = cases_by_name["feature_query_envelope"]
+    gap = cases_by_name["temporal_query"]
 
     fragment = build_certification_fragment(
         FixtureBundle(Path("."), "fixture-v1"),
@@ -82,6 +85,15 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
     assert passed["capability_key"] == "serve.geoservices-featureserver"
     assert passed["scenario_facets"] == ["positive", "pagination"]
     assert passed["canonical_client"] == "Honua SDK Python"
+    assert passed["client_id"] == passed["canonical_client"]
+    assert passed["runner_lane"] == "sdk-python-certification"
+    assert passed["protocol_version"] == "11.0"
+    assert passed["protocol_profile"] == "GeoServices REST"
+    assert passed["performed_by"] == passed["client_id"]
+    assert passed["request_url"] == (
+        "http://localhost:5000/rest/services/test_service/FeatureServer/0/query"
+    )
+    assert passed["exercised_capabilities"] == passed["scenario_facets"]
     assert passed["client_version"] == "9.9.9"
     assert passed["result"] == "pass"
     assert passed["skip_reason"] is None
@@ -101,6 +113,45 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
     assert failed["skip_reason"] == gap.known_gap_issue
     assert failed["evidence_digest"] is None
     assert failed["facet_results"] is None
+    assert failed["exercised_capabilities"] == []
+
+
+def test_every_observation_satisfies_truthful_identity_ingest_rules(monkeypatch) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "9.9.9")
+    target = ConformanceTarget(
+        base_url="https://candidate.test/root/",
+        server_commit="a" * 40,
+        server_image_digest="sha256:" + "b" * 64,
+        sdk_source_sha="c" * 40,
+        evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
+        candidate_cut_at="2026-08-20T00:00:00Z",
+        certification_tier="release",
+    )
+    cases = [(_case(name), _result(name, "passed")) for name in CASE_CERTIFICATION]
+
+    fragment = build_certification_fragment(FixtureBundle(Path("."), "fixture-v1"), target, cases)
+    expected_protocol_context = {
+        "geoservices-root": ("11.0", "GeoServices REST"),
+        "geoservices-featureserver": ("11.0", "GeoServices REST"),
+        "ogc-api-features": ("1.0", "core"),
+        "ogc-api-processes": ("1.0", "core"),
+    }
+
+    for observation in fragment["observations"]:
+        assert observation["client_id"] == observation["canonical_client"]
+        assert observation["runner_lane"] == "sdk-python-certification"
+        assert observation["performed_by"] == observation["client_id"]
+        assert (
+            observation["protocol_version"], observation["protocol_profile"]
+        ) == expected_protocol_context[observation["surface"]]
+        parsed_url = urlsplit(observation["request_url"])
+        assert parsed_url.scheme in {"http", "https"}
+        assert parsed_url.netloc
+        assert isinstance(observation["exercised_capabilities"], list)
+        if observation["result"] == "pass":
+            assert set(observation["scenario_facets"]).issubset(
+                observation["exercised_capabilities"]
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- emit the seven truthful-identity fields required by honua-evidence ingestion
- derive absolute request URLs from the recorded conformance target and case context
- select protocol version/profile per exercised surface and record only passed facets as exercised capabilities
- assert every observation satisfies the fail-closed ingest identity rules

`client_id` and `performed_by` are the existing canonical client `Honua SDK Python`; `runner_lane` is the governed lane `sdk-python-certification`. Every represented observation is performed through `HonuaClient`; none is performed by a standalone generic HTTP client.

## Validation

- `python3 -m pytest tests/ -q` — 1,697 passed, 18 skipped
- `python3 -m pytest tests/test_certification_fragment.py -q` — 11 passed
- `ruff check .` — pass
- `python -m mypy packages/honua-sdk/honua_sdk packages/honua-admin/honua_admin` — pass
- `python scripts/compatibility_gate.py` — pass
- `python scripts/gen_sync.py --check` — pass

Refs honua-io/honua-evidence#46