### PR TITLE
test: certify core protocols from the installed wheel

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -66,11 +66,24 @@ jobs:
           cache: pip
           cache-dependency-path: packages/honua-sdk/pyproject.toml
 
-      - name: Install honua-sdk
+      - name: Build and install honua-sdk wheel
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
-          pip install -e packages/honua-sdk
-          pip install pytest
+          python -m pip install build
+          python -m build --wheel --outdir dist packages/honua-sdk
+          wheel="$(find dist -maxdepth 1 -name 'honua_sdk-*.whl' -type f -print -quit)"
+          [[ -n "${wheel}" ]]
+          wheel_sha256="$(sha256sum "${wheel}" | cut -d ' ' -f 1)"
+          python -m venv "${RUNNER_TEMP}/honua-sdk-certification"
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install --upgrade pip
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install "${wheel}" pytest
+          {
+            echo "HONUA_SDK_CERT_PYTHON=${RUNNER_TEMP}/honua-sdk-certification/bin/python"
+            echo "HONUA_SDK_INSTALL_ROOT=${RUNNER_TEMP}/honua-sdk-certification"
+            echo "HONUA_SDK_WHEEL_FILENAME=$(basename "${wheel}")"
+            echo "HONUA_SDK_WHEEL_SHA256=${wheel_sha256}"
+          } >> "${GITHUB_ENV}"
 
       - name: Verify fixture pin matches conformance/FIXTURES_VERSION
         run: |
@@ -245,7 +258,7 @@ jobs:
           HONUA_CONFORMANCE_SUMMARY_PATH: conformance-summary.md
           HONUA_PROTOCOL_CERTIFICATION_FRAGMENT_PATH: protocol-certification-fragment.json
         run: |
-          python -m pytest tests/conformance \
+          "${HONUA_SDK_CERT_PYTHON}" -m pytest tests/conformance \
             -q \
             --run-integration \
             -m "integration and conformance" \

--- a/scripts/_conformance.py
+++ b/scripts/_conformance.py
@@ -203,6 +203,8 @@ class ConformanceTarget:
     server_commit: str | None = None
     server_image_digest: str | None = None
     sdk_source_sha: str | None = None
+    sdk_wheel_filename: str | None = None
+    sdk_wheel_sha256: str | None = None
     evidence_uri: str | None = None
     candidate_cut_at: str | None = None
     certification_tier: str = "nightly"
@@ -228,6 +230,8 @@ def load_target_from_env() -> ConformanceTarget:
         server_commit=os.environ.get("HONUA_SERVER_COMMIT"),
         server_image_digest=os.environ.get("HONUA_SERVER_IMAGE_DIGEST"),
         sdk_source_sha=os.environ.get("HONUA_SDK_SOURCE_SHA"),
+        sdk_wheel_filename=os.environ.get("HONUA_SDK_WHEEL_FILENAME"),
+        sdk_wheel_sha256=os.environ.get("HONUA_SDK_WHEEL_SHA256"),
         evidence_uri=os.environ.get("HONUA_EVIDENCE_URI"),
         candidate_cut_at=os.environ.get("HONUA_CANDIDATE_CUT_AT"),
         certification_tier=os.environ.get("HONUA_CERTIFICATION_TIER", "nightly"),
@@ -1410,12 +1414,24 @@ def build_certification_fragment(
             "evidence_uri": target.evidence_uri,
             "candidate_cut_at": target.candidate_cut_at,
             "sdk_source_sha": target.sdk_source_sha,
+            "sdk_wheel_filename": target.sdk_wheel_filename,
+            "sdk_wheel_sha256": target.sdk_wheel_sha256,
         }.items()
         if not value
     ]
     if missing_target:
         raise ConformanceFixturesError(
             "normalized certification evidence needs " + ", ".join(missing_target)
+        )
+    wheel_filename = target.sdk_wheel_filename
+    wheel_sha256 = target.sdk_wheel_sha256
+    if not isinstance(wheel_filename, str) or not wheel_filename.endswith(".whl"):
+        raise ConformanceFixturesError("sdk_wheel_filename must identify a wheel")
+    if not isinstance(wheel_sha256, str) or len(wheel_sha256) != 64 or any(
+        char not in "0123456789abcdef" for char in wheel_sha256
+    ):
+        raise ConformanceFixturesError(
+            "sdk_wheel_sha256 must be a lowercase 64-character SHA-256 digest"
         )
 
     client_version = importlib.metadata.version("honua-sdk")
@@ -1452,6 +1468,10 @@ def build_certification_fragment(
                 "deployment_target": "local-docker",
                 "source_sha": target.server_commit,
                 "producer_source_sha": target.sdk_source_sha,
+                "client_package": {
+                    "filename": target.sdk_wheel_filename,
+                    "sha256": target.sdk_wheel_sha256,
+                },
                 "image_digest": target.server_image_digest,
                 "fixture_revision": f"geospatial-grpc@{bundle.version}",
                 "contract_revision": contract_revision,
@@ -1489,6 +1509,10 @@ def build_certification_fragment(
                 "skip_reason": known_gap,
                 "source_sha": target.server_commit,
                 "producer_source_sha": target.sdk_source_sha,
+                "client_package": {
+                    "filename": target.sdk_wheel_filename,
+                    "sha256": target.sdk_wheel_sha256,
+                },
                 "image_digest": target.server_image_digest,
                 "fixture_revision": f"geospatial-grpc@{bundle.version}",
                 "contract_revision": contract_revision,

--- a/tests/conformance/conftest.py
+++ b/tests/conformance/conftest.py
@@ -37,7 +37,20 @@ def conformance_target():
 
 @pytest.fixture(scope="session")
 def conformance_client(conformance_target):
+    import honua_sdk
     from honua_sdk import HonuaClient
+
+    install_root = os.environ.get("HONUA_SDK_INSTALL_ROOT")
+    if not install_root:
+        pytest.fail("HONUA_SDK_INSTALL_ROOT is required; certification must use an installed wheel")
+    package_path = Path(honua_sdk.__file__).resolve()
+    try:
+        package_path.relative_to(Path(install_root).resolve())
+    except ValueError:
+        pytest.fail(
+            f"honua_sdk resolved outside the isolated install root: {package_path}",
+            pytrace=False,
+        )
 
     with HonuaClient(conformance_target.base_url, api_key=conformance_target.api_key) as client:
         yield client

--- a/tests/test_certification_fragment.py
+++ b/tests/test_certification_fragment.py
@@ -55,6 +55,8 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
         server_commit=source_sha,
         server_image_digest=image_digest,
         sdk_source_sha=sdk_sha,
+        sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
+        sdk_wheel_sha256="d" * 64,
         evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",
@@ -98,6 +100,11 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
     assert passed["result"] == "pass"
     assert passed["skip_reason"] is None
     assert passed["producer_source_sha"] == sdk_sha
+    assert passed["client_package"] == {
+        "filename": "honua_sdk-9.9.9-py3-none-any.whl",
+        "sha256": "d" * 64,
+    }
+    assert passed["evidence_receipt"]["identity"]["client_package"] == passed["client_package"]
     assert passed["fixture_revision"] == "geospatial-grpc@fixture-v1"
     assert passed["contract_revision"] == f"sdk-python-certification@{sdk_sha}"
     assert passed["auth_policy_revision"] == "anonymous-public-v1"
@@ -123,6 +130,8 @@ def test_every_observation_satisfies_truthful_identity_ingest_rules(monkeypatch)
         server_commit="a" * 40,
         server_image_digest="sha256:" + "b" * 64,
         sdk_source_sha="c" * 40,
+        sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
+        sdk_wheel_sha256="d" * 64,
         evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",
@@ -154,6 +163,27 @@ def test_every_observation_satisfies_truthful_identity_ingest_rules(monkeypatch)
             )
 
 
+def test_certification_rejects_malformed_wheel_digest(monkeypatch) -> None:
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "9.9.9")
+    target = ConformanceTarget(
+        base_url="http://localhost:5000",
+        server_commit="a" * 40,
+        server_image_digest="sha256:" + "b" * 64,
+        sdk_source_sha="c" * 40,
+        sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
+        sdk_wheel_sha256="not-a-digest",
+        evidence_uri="local://test",
+        candidate_cut_at="2026-08-20T00:00:00Z",
+    )
+
+    with pytest.raises(RuntimeError, match="sdk_wheel_sha256"):
+        build_certification_fragment(
+            FixtureBundle(Path("."), "fixture-v1"),
+            target,
+            [(_case("feature_query_envelope"), _result("feature_query_envelope", "passed"))],
+        )
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -182,6 +212,8 @@ def test_candidate_cut_changes_the_content_addressed_receipt(monkeypatch) -> Non
             server_commit="a" * 40,
             server_image_digest="sha256:" + "b" * 64,
             sdk_source_sha="c" * 40,
+            sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
+            sdk_wheel_sha256="d" * 64,
             evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
             candidate_cut_at=cut_at,
             certification_tier="release",
@@ -205,6 +237,8 @@ def test_release_validator_rejects_receipt_bound_to_another_cut(monkeypatch) -> 
         server_commit="a" * 40,
         server_image_digest="sha256:" + "b" * 64,
         sdk_source_sha="c" * 40,
+        sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
+        sdk_wheel_sha256="d" * 64,
         evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -16,3 +16,12 @@ def test_release_certification_uses_the_governed_candidate_cut() -> None:
         'candidate_cut_at="$(git -C "${server_root}" show -s --format=%cI '
         '"${image_revision}")"'
     ) in workflow
+
+
+def test_conformance_builds_and_runs_from_an_isolated_wheel_install() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python -m build --wheel --outdir dist packages/honua-sdk" in workflow
+    assert "pip install -e packages/honua-sdk" not in workflow
+    assert "HONUA_SDK_WHEEL_SHA256=${wheel_sha256}" in workflow
+    assert '"${HONUA_SDK_CERT_PYTHON}" -m pytest tests/conformance' in workflow


### PR DESCRIPTION
## Summary

- build `honua-sdk` as a wheel and install it into an isolated certification environment
- fail live certification if `honua_sdk` resolves outside that installed environment
- bind normalized operation evidence to the exact wheel filename and SHA-256
- preserve every existing core protocol assertion and release fail-closed behavior

## Truthful local evidence

- installed wheel: `honua_sdk-0.1.11-py3-none-any.whl`
- server image: `ghcr.io/honua-io/honua-server@sha256:e6db39f64cd38f88ac0cb36cff63d7ef5324ef8a0f12961f6a6583fdce35a5e2`
- embedded server revision: `52a56a19a266935fccc79312708b469e92ee3cbe`
- result: 11 passed

The registry `:trunk` tag resolved to that immutable digest/revision during the run. GitHub server trunk had advanced to `bba42e69ecd9498563a468c2b78447f98d5742a0`, so this proves the current published trunk image, not an image for the newer unbuilt source head.

## Validation

- focused certification/workflow/probe tests: 65 passed
- live installed-wheel conformance: 11 passed
- `git diff --check`: pass

Closes #214
Parent: #21
Server gate: honua-io/honua-server#3381