### PR TITLE
test: qualify exact public SDK wheel

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -80,15 +80,26 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip build
-          python -m build --wheel --outdir dist packages/honua-sdk
+          python -m pip install \
+            --require-hashes \
+            --only-binary=:all: \
+            -r .github/requirements/publish-python.lock
+          python -m build --wheel --no-isolation --outdir dist packages/honua-sdk
           wheel="$(find dist -maxdepth 1 -name 'honua_sdk-*.whl' -type f -print -quit)"
           [[ -n "${wheel}" ]]
           wheel_filename="$(basename "${wheel}")"
           wheel_sha256="$(sha256sum "${wheel}" | cut -d ' ' -f 1)"
+          wheel_requirement="${RUNNER_TEMP}/honua-sdk-wheel-requirement.txt"
+          printf '%s --hash=sha256:%s\n' "$(realpath "${wheel}")" "${wheel_sha256}" > "${wheel_requirement}"
           python -m venv "${RUNNER_TEMP}/honua-sdk-certification"
-          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install --upgrade pip
-          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install "${wheel}" pytest
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install \
+            --require-hashes \
+            --only-binary=:all: \
+            -r .github/requirements/publish-python.lock
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install \
+            --require-hashes \
+            --no-deps \
+            -r "${wheel_requirement}"
           {
             echo "HONUA_SDK_CERT_PYTHON=${RUNNER_TEMP}/honua-sdk-certification/bin/python"
             echo "HONUA_SDK_INSTALL_ROOT=${RUNNER_TEMP}/honua-sdk-certification"
@@ -102,7 +113,6 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
-          python -m pip install --upgrade pip
           mkdir -p dist
           python -m pip download \
             --dest dist \
@@ -112,9 +122,17 @@ jobs:
           wheel="dist/${HONUA_SDK_PUBLIC_WHEEL}"
           [[ -f "${wheel}" ]]
           echo "${HONUA_SDK_PUBLIC_WHEEL_SHA256}  ${wheel}" | sha256sum --check --strict
+          wheel_requirement="${RUNNER_TEMP}/honua-sdk-wheel-requirement.txt"
+          printf '%s --hash=sha256:%s\n' "$(realpath "${wheel}")" "${HONUA_SDK_PUBLIC_WHEEL_SHA256}" > "${wheel_requirement}"
           python -m venv "${RUNNER_TEMP}/honua-sdk-certification"
-          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install --upgrade pip
-          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install "${wheel}" pytest
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install \
+            --require-hashes \
+            --only-binary=:all: \
+            -r .github/requirements/publish-python.lock
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install \
+            --require-hashes \
+            --no-deps \
+            -r "${wheel_requirement}"
           installed_version="$("${RUNNER_TEMP}/honua-sdk-certification/bin/python" -c \
             'import importlib.metadata; print(importlib.metadata.version("honua-sdk"))')"
           [[ "${installed_version}" == "${HONUA_SDK_PUBLIC_VERSION}" ]]

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -160,7 +160,7 @@ jobs:
               echo "::error::release certification requires a full 40-character server_seed_ref"
               exit 1
             fi
-            python - "${CANDIDATE_CUT_AT_INPUT}" <<'PY'
+            "${HONUA_SDK_CERT_PYTHON}" - "${CANDIDATE_CUT_AT_INPUT}" <<'PY'
           import sys
 
           from scripts._conformance import validate_candidate_cut_at
@@ -285,7 +285,7 @@ jobs:
       - name: Enforce release evidence outcomes
         if: ${{ github.event.inputs.certification_tier == 'release' }}
         run: |
-          python - <<'PY'
+          "${HONUA_SDK_CERT_PYTHON}" - <<'PY'
           import json
           from pathlib import Path
           from scripts._conformance import validate_release_certification_fragment

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,6 +47,14 @@ env:
   # Shared geospatial-grpc fixture pin (must equal conformance/FIXTURES_VERSION).
   # The fetch helper verifies the bundle's embedded VERSION equals this value.
   CONFORMANCE_FIXTURES_VERSION: "0.2.0-alpha.1"
+  # Exact public wheel currently published on PyPI. This intentionally differs
+  # from honua-release's stale 0.1.10 client-artifact pin; the lane qualifies
+  # the bytes users can actually install while lock convergence remains owned
+  # by the release worklist.
+  HONUA_SDK_PUBLIC_VERSION: "0.1.11"
+  HONUA_SDK_PUBLIC_WHEEL: "honua_sdk-0.1.11-py3-none-any.whl"
+  HONUA_SDK_PUBLIC_WHEEL_SHA256: "80ac6a25fa5fed0ee7d8dca4ca94d14c098d9f72a149c9e271b1a1d04b78c3e9"
+  HONUA_SDK_PUBLIC_SOURCE_SHA: "f7930b6e9c3ce47ade148bba3d4510eeffd2ccc4"
   # Current nightly image and its exact embedded source revision. Update these as
   # one identity so scheduled evidence never joins a candidate to unrelated seed
   # fixtures. Release dispatches continue to override both explicitly.
@@ -66,23 +74,31 @@ jobs:
           cache: pip
           cache-dependency-path: packages/honua-sdk/pyproject.toml
 
-      - name: Build and install honua-sdk wheel
+      - name: Download and install exact public honua-sdk wheel
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install build
-          python -m build --wheel --outdir dist packages/honua-sdk
-          wheel="$(find dist -maxdepth 1 -name 'honua_sdk-*.whl' -type f -print -quit)"
-          [[ -n "${wheel}" ]]
-          wheel_sha256="$(sha256sum "${wheel}" | cut -d ' ' -f 1)"
+          mkdir -p dist
+          python -m pip download \
+            --dest dist \
+            --no-deps \
+            --only-binary=:all: \
+            "honua-sdk==${HONUA_SDK_PUBLIC_VERSION}"
+          wheel="dist/${HONUA_SDK_PUBLIC_WHEEL}"
+          [[ -f "${wheel}" ]]
+          echo "${HONUA_SDK_PUBLIC_WHEEL_SHA256}  ${wheel}" | sha256sum --check --strict
           python -m venv "${RUNNER_TEMP}/honua-sdk-certification"
           "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install --upgrade pip
           "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install "${wheel}" pytest
+          installed_version="$("${RUNNER_TEMP}/honua-sdk-certification/bin/python" -c \
+            'import importlib.metadata; print(importlib.metadata.version("honua-sdk"))')"
+          [[ "${installed_version}" == "${HONUA_SDK_PUBLIC_VERSION}" ]]
           {
             echo "HONUA_SDK_CERT_PYTHON=${RUNNER_TEMP}/honua-sdk-certification/bin/python"
             echo "HONUA_SDK_INSTALL_ROOT=${RUNNER_TEMP}/honua-sdk-certification"
-            echo "HONUA_SDK_WHEEL_FILENAME=$(basename "${wheel}")"
-            echo "HONUA_SDK_WHEEL_SHA256=${wheel_sha256}"
+            echo "HONUA_SDK_WHEEL_FILENAME=${HONUA_SDK_PUBLIC_WHEEL}"
+            echo "HONUA_SDK_WHEEL_SHA256=${HONUA_SDK_PUBLIC_WHEEL_SHA256}"
+            echo "HONUA_SDK_WHEEL_SOURCE=pypi"
           } >> "${GITHUB_ENV}"
 
       - name: Verify fixture pin matches conformance/FIXTURES_VERSION
@@ -230,7 +246,7 @@ jobs:
             echo "HONUA_LAYER_ID=0"
             echo "HONUA_API_KEY=ClientCompatAdmin123!"
             echo "HONUA_SERVER_IMAGE_DIGEST=${image_digest}"
-            echo "HONUA_SDK_SOURCE_SHA=${GITHUB_SHA}"
+            echo "HONUA_SDK_SOURCE_SHA=${HONUA_SDK_PUBLIC_SOURCE_SHA}"
             echo "HONUA_EVIDENCE_URI=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             echo "HONUA_CANDIDATE_CUT_AT=${candidate_cut_at}"
             echo "HONUA_CERTIFICATION_TIER=${HONUA_CERTIFICATION_TIER}"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -7,6 +7,8 @@ name: Python SDK Conformance
 #
 # Unlike the scheduled, advisory staging-integration lane, this job runs on
 # every pull_request and push to trunk and is intended to be a required check.
+# PRs exercise the candidate wheel; trunk pushes and manual certification qualify
+# the exact public wheel separately.
 
 on:
   push:
@@ -74,7 +76,30 @@ jobs:
           cache: pip
           cache-dependency-path: packages/honua-sdk/pyproject.toml
 
+      - name: Build and install candidate honua-sdk wheel
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist packages/honua-sdk
+          wheel="$(find dist -maxdepth 1 -name 'honua_sdk-*.whl' -type f -print -quit)"
+          [[ -n "${wheel}" ]]
+          wheel_filename="$(basename "${wheel}")"
+          wheel_sha256="$(sha256sum "${wheel}" | cut -d ' ' -f 1)"
+          python -m venv "${RUNNER_TEMP}/honua-sdk-certification"
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install --upgrade pip
+          "${RUNNER_TEMP}/honua-sdk-certification/bin/python" -m pip install "${wheel}" pytest
+          {
+            echo "HONUA_SDK_CERT_PYTHON=${RUNNER_TEMP}/honua-sdk-certification/bin/python"
+            echo "HONUA_SDK_INSTALL_ROOT=${RUNNER_TEMP}/honua-sdk-certification"
+            echo "HONUA_SDK_WHEEL_FILENAME=${wheel_filename}"
+            echo "HONUA_SDK_WHEEL_SHA256=${wheel_sha256}"
+            echo "HONUA_SDK_WHEEL_SOURCE=github-actions"
+            echo "HONUA_SDK_SOURCE_SHA=${GITHUB_SHA}"
+          } >> "${GITHUB_ENV}"
+
       - name: Download and install exact public honua-sdk wheel
+        if: ${{ github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
@@ -99,6 +124,7 @@ jobs:
             echo "HONUA_SDK_WHEEL_FILENAME=${HONUA_SDK_PUBLIC_WHEEL}"
             echo "HONUA_SDK_WHEEL_SHA256=${HONUA_SDK_PUBLIC_WHEEL_SHA256}"
             echo "HONUA_SDK_WHEEL_SOURCE=pypi"
+            echo "HONUA_SDK_SOURCE_SHA=${HONUA_SDK_PUBLIC_SOURCE_SHA}"
           } >> "${GITHUB_ENV}"
 
       - name: Verify fixture pin matches conformance/FIXTURES_VERSION
@@ -246,7 +272,6 @@ jobs:
             echo "HONUA_LAYER_ID=0"
             echo "HONUA_API_KEY=ClientCompatAdmin123!"
             echo "HONUA_SERVER_IMAGE_DIGEST=${image_digest}"
-            echo "HONUA_SDK_SOURCE_SHA=${HONUA_SDK_PUBLIC_SOURCE_SHA}"
             echo "HONUA_EVIDENCE_URI=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
             echo "HONUA_CANDIDATE_CUT_AT=${candidate_cut_at}"
             echo "HONUA_CERTIFICATION_TIER=${HONUA_CERTIFICATION_TIER}"
@@ -272,7 +297,7 @@ jobs:
       - name: Run shared-fixture conformance suite
         env:
           HONUA_CONFORMANCE_SUMMARY_PATH: conformance-summary.md
-          HONUA_PROTOCOL_CERTIFICATION_FRAGMENT_PATH: protocol-certification-fragment.json
+          HONUA_PROTOCOL_CERTIFICATION_FRAGMENT_PATH: ${{ github.event_name != 'pull_request' && 'protocol-certification-fragment.json' || '' }}
         run: |
           "${HONUA_SDK_CERT_PYTHON}" -m pytest tests/conformance \
             -q \

--- a/scripts/_conformance.py
+++ b/scripts/_conformance.py
@@ -205,6 +205,7 @@ class ConformanceTarget:
     sdk_source_sha: str | None = None
     sdk_wheel_filename: str | None = None
     sdk_wheel_sha256: str | None = None
+    sdk_wheel_source: str | None = None
     evidence_uri: str | None = None
     candidate_cut_at: str | None = None
     certification_tier: str = "nightly"
@@ -232,6 +233,7 @@ def load_target_from_env() -> ConformanceTarget:
         sdk_source_sha=os.environ.get("HONUA_SDK_SOURCE_SHA"),
         sdk_wheel_filename=os.environ.get("HONUA_SDK_WHEEL_FILENAME"),
         sdk_wheel_sha256=os.environ.get("HONUA_SDK_WHEEL_SHA256"),
+        sdk_wheel_source=os.environ.get("HONUA_SDK_WHEEL_SOURCE"),
         evidence_uri=os.environ.get("HONUA_EVIDENCE_URI"),
         candidate_cut_at=os.environ.get("HONUA_CANDIDATE_CUT_AT"),
         certification_tier=os.environ.get("HONUA_CERTIFICATION_TIER", "nightly"),
@@ -1416,6 +1418,7 @@ def build_certification_fragment(
             "sdk_source_sha": target.sdk_source_sha,
             "sdk_wheel_filename": target.sdk_wheel_filename,
             "sdk_wheel_sha256": target.sdk_wheel_sha256,
+            "sdk_wheel_source": target.sdk_wheel_source,
         }.items()
         if not value
     ]
@@ -1433,6 +1436,8 @@ def build_certification_fragment(
         raise ConformanceFixturesError(
             "sdk_wheel_sha256 must be a lowercase 64-character SHA-256 digest"
         )
+    if target.sdk_wheel_source != "pypi":
+        raise ConformanceFixturesError("sdk_wheel_source must be pypi")
 
     client_version = importlib.metadata.version("honua-sdk")
     payload_base64 = base64.b64encode(json.dumps(
@@ -1471,6 +1476,7 @@ def build_certification_fragment(
                 "client_package": {
                     "filename": target.sdk_wheel_filename,
                     "sha256": target.sdk_wheel_sha256,
+                    "source": target.sdk_wheel_source,
                 },
                 "image_digest": target.server_image_digest,
                 "fixture_revision": f"geospatial-grpc@{bundle.version}",
@@ -1512,6 +1518,7 @@ def build_certification_fragment(
                 "client_package": {
                     "filename": target.sdk_wheel_filename,
                     "sha256": target.sdk_wheel_sha256,
+                    "source": target.sdk_wheel_source,
                 },
                 "image_digest": target.server_image_digest,
                 "fixture_revision": f"geospatial-grpc@{bundle.version}",

--- a/tests/test_certification_fragment.py
+++ b/tests/test_certification_fragment.py
@@ -57,6 +57,7 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
         sdk_source_sha=sdk_sha,
         sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
         sdk_wheel_sha256="d" * 64,
+        sdk_wheel_source="pypi",
         evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",
@@ -103,6 +104,7 @@ def test_build_certification_fragment_normalizes_identity_and_results(monkeypatc
     assert passed["client_package"] == {
         "filename": "honua_sdk-9.9.9-py3-none-any.whl",
         "sha256": "d" * 64,
+        "source": "pypi",
     }
     assert passed["evidence_receipt"]["identity"]["client_package"] == passed["client_package"]
     assert passed["fixture_revision"] == "geospatial-grpc@fixture-v1"
@@ -132,6 +134,7 @@ def test_every_observation_satisfies_truthful_identity_ingest_rules(monkeypatch)
         sdk_source_sha="c" * 40,
         sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
         sdk_wheel_sha256="d" * 64,
+        sdk_wheel_source="pypi",
         evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",
@@ -172,6 +175,7 @@ def test_certification_rejects_malformed_wheel_digest(monkeypatch) -> None:
         sdk_source_sha="c" * 40,
         sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
         sdk_wheel_sha256="not-a-digest",
+        sdk_wheel_source="pypi",
         evidence_uri="local://test",
         candidate_cut_at="2026-08-20T00:00:00Z",
     )
@@ -214,6 +218,7 @@ def test_candidate_cut_changes_the_content_addressed_receipt(monkeypatch) -> Non
             sdk_source_sha="c" * 40,
             sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
             sdk_wheel_sha256="d" * 64,
+            sdk_wheel_source="pypi",
             evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
             candidate_cut_at=cut_at,
             certification_tier="release",
@@ -239,6 +244,7 @@ def test_release_validator_rejects_receipt_bound_to_another_cut(monkeypatch) -> 
         sdk_source_sha="c" * 40,
         sdk_wheel_filename="honua_sdk-9.9.9-py3-none-any.whl",
         sdk_wheel_sha256="d" * 64,
+        sdk_wheel_source="pypi",
         evidence_uri="https://github.com/honua-io/honua-sdk-python/actions/runs/1",
         candidate_cut_at="2026-08-20T00:00:00Z",
         certification_tier="release",

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -20,16 +20,22 @@ def test_release_certification_uses_the_governed_candidate_cut() -> None:
     ) in workflow
 
 
-def test_conformance_downloads_public_wheel_and_runs_from_isolated_install() -> None:
+def test_conformance_uses_candidate_on_pr_and_public_wheel_elsewhere() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
+    assert "if: ${{ github.event_name == 'pull_request' }}" in workflow
+    assert "python -m build --wheel --outdir dist packages/honua-sdk" in workflow
+    assert "HONUA_SDK_WHEEL_SOURCE=github-actions" in workflow
+    assert "HONUA_SDK_SOURCE_SHA=${GITHUB_SHA}" in workflow
+    assert "HONUA_PROTOCOL_CERTIFICATION_FRAGMENT_PATH: ${{ github.event_name != 'pull_request'" in workflow
+
+    assert "if: ${{ github.event_name != 'pull_request' }}" in workflow
     assert 'HONUA_SDK_PUBLIC_VERSION: "0.1.11"' in workflow
     assert 'HONUA_SDK_PUBLIC_WHEEL: "honua_sdk-0.1.11-py3-none-any.whl"' in workflow
     assert "python -m pip download" in workflow
     assert '"honua-sdk==${HONUA_SDK_PUBLIC_VERSION}"' in workflow
     assert "--only-binary=:all:" in workflow
     assert "sha256sum --check --strict" in workflow
-    assert "python -m build" not in workflow
     assert "pip install -e packages/honua-sdk" not in workflow
     assert "HONUA_SDK_WHEEL_SHA256=${HONUA_SDK_PUBLIC_WHEEL_SHA256}" in workflow
     assert "HONUA_SDK_WHEEL_SOURCE=pypi" in workflow

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -24,10 +24,14 @@ def test_conformance_uses_candidate_on_pr_and_public_wheel_elsewhere() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert "if: ${{ github.event_name == 'pull_request' }}" in workflow
-    assert "python -m build --wheel --outdir dist packages/honua-sdk" in workflow
+    assert "python -m build --wheel --no-isolation --outdir dist packages/honua-sdk" in workflow
     assert "HONUA_SDK_WHEEL_SOURCE=github-actions" in workflow
     assert "HONUA_SDK_SOURCE_SHA=${GITHUB_SHA}" in workflow
     assert "HONUA_PROTOCOL_CERTIFICATION_FRAGMENT_PATH: ${{ github.event_name != 'pull_request'" in workflow
+    assert workflow.count("--require-hashes") == 5
+    assert workflow.count(".github/requirements/publish-python.lock") == 3
+    assert "--no-isolation" in workflow
+    assert "pip install --upgrade" not in workflow
 
     assert "if: ${{ github.event_name != 'pull_request' }}" in workflow
     assert 'HONUA_SDK_PUBLIC_VERSION: "0.1.11"' in workflow

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -11,6 +11,8 @@ def test_release_certification_uses_the_governed_candidate_cut() -> None:
     assert "CANDIDATE_CUT_AT_INPUT: ${{ github.event.inputs.candidate_cut_at }}" in workflow
     assert "from scripts._conformance import validate_candidate_cut_at" in workflow
     assert "validate_candidate_cut_at(sys.argv[1])" in workflow
+    assert '"${HONUA_SDK_CERT_PYTHON}" - "${CANDIDATE_CUT_AT_INPUT}"' in workflow
+    assert '"${HONUA_SDK_CERT_PYTHON}" - <<\'PY\'' in workflow
     assert 'candidate_cut_at="${CANDIDATE_CUT_AT_INPUT}"' in workflow
     assert (
         'candidate_cut_at="$(git -C "${server_root}" show -s --format=%cI '

--- a/tests/test_conformance_workflow_contract.py
+++ b/tests/test_conformance_workflow_contract.py
@@ -18,10 +18,18 @@ def test_release_certification_uses_the_governed_candidate_cut() -> None:
     ) in workflow
 
 
-def test_conformance_builds_and_runs_from_an_isolated_wheel_install() -> None:
+def test_conformance_downloads_public_wheel_and_runs_from_isolated_install() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    assert "python -m build --wheel --outdir dist packages/honua-sdk" in workflow
+    assert 'HONUA_SDK_PUBLIC_VERSION: "0.1.11"' in workflow
+    assert 'HONUA_SDK_PUBLIC_WHEEL: "honua_sdk-0.1.11-py3-none-any.whl"' in workflow
+    assert "python -m pip download" in workflow
+    assert '"honua-sdk==${HONUA_SDK_PUBLIC_VERSION}"' in workflow
+    assert "--only-binary=:all:" in workflow
+    assert "sha256sum --check --strict" in workflow
+    assert "python -m build" not in workflow
     assert "pip install -e packages/honua-sdk" not in workflow
-    assert "HONUA_SDK_WHEEL_SHA256=${wheel_sha256}" in workflow
+    assert "HONUA_SDK_WHEEL_SHA256=${HONUA_SDK_PUBLIC_WHEEL_SHA256}" in workflow
+    assert "HONUA_SDK_WHEEL_SOURCE=pypi" in workflow
+    assert "HONUA_SDK_SOURCE_SHA=${HONUA_SDK_PUBLIC_SOURCE_SHA}" in workflow
     assert '"${HONUA_SDK_CERT_PYTHON}" -m pytest tests/conformance' in workflow


### PR DESCRIPTION
## Summary

- download the exact public `honua-sdk==0.1.11` wheel from PyPI into a clean certification environment
- fail closed unless its filename, version, and SHA-256 match the published candidate bytes
- run the unchanged public SDK protocol suite against the existing digest-pinned server target
- record PyPI provenance and the 0.1.11 release source SHA in normalized receipts

## Findings retained

- `honua-release/platform-manifest.yaml` still pins client artifact 0.1.10; this lane deliberately qualifies published 0.1.11 and does not paper over the lock mismatch
- the staging compatibility binding is expired and refresh remains manual; the upstream demo canary is currently red, so no truthful replacement binding exists yet

## Validation

- focused certification/workflow/probe tests: 65 passed
- public wheel: `honua_sdk-0.1.11-py3-none-any.whl`
- public wheel SHA-256: `80ac6a25fa5fed0ee7d8dca4ca94d14c098d9f72a149c9e271b1a1d04b78c3e9`
- `git diff --check`: pass

Closes #21
Related staging binding: #203
Server gate: honua-io/honua-server#3381