### PR TITLE
fix(client): align compatibility and redirect handling

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -143,7 +143,8 @@ All packages follow [Semantic Versioning](https://semver.org/). Major versions a
 The admin SDK uses `GET /api/v1/admin/capabilities` as the runtime compatibility
 source of truth. It currently expects:
 
-- server version `>= 2026.3.0`
+- server version `>= 1.0.0` for GA SemVer identities, or `>= 2026.3.0` for
+  pre-GA CalVer identities
 - control-plane API major `v1`
 - release channel `preview` or newer
 

--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -181,7 +181,7 @@
           "fields": [
             {
               "annotation": "str",
-              "default": "'2026.3.0'",
+              "default": "'1.0.0'",
               "name": "minimum_server_version"
             },
             {
@@ -203,7 +203,7 @@
           "kind": "class",
           "module": "honua_admin._models",
           "qualname": "AdminCompatibilityBaseline",
-          "signature": "(minimum_server_version: 'str' = '2026.3.0', control_plane_api_major: 'int' = 1, base_path: 'str' = '/api/v1/admin', minimum_release_channel: 'str' = 'preview') -> None"
+          "signature": "(minimum_server_version: 'str' = '1.0.0', control_plane_api_major: 'int' = 1, base_path: 'str' = '/api/v1/admin', minimum_release_channel: 'str' = 'preview') -> None"
         },
         "AdminCompatibilityCheckResult": {
           "fields": [
@@ -1417,7 +1417,7 @@
         "MINIMUM_SUPPORTED_SERVER_VERSION": {
           "kind": "constant",
           "type": "str",
-          "value": "'2026.3.0'"
+          "value": "'1.0.0'"
         },
         "ManifestApplyEntry": {
           "fields": [

--- a/compatibility/server-matrix.json
+++ b/compatibility/server-matrix.json
@@ -131,9 +131,9 @@
     },
     {
       "name": "server-version-below-baseline",
-      "description": "Pre-GA SemVer servers older than the minimum supported line are blocked.",
+      "description": "Pre-GA CalVer servers older than the minimum supported line are blocked.",
       "compatibility": {
-        "serverVersion": "0.99.0-preview.1",
+        "serverVersion": "2026.2.28-preview.1",
         "releaseChannel": "preview",
         "controlPlaneApi": {
           "major": 1,
@@ -153,6 +153,27 @@
           "manifestDryRun": true,
           "manifestPrune": true
         }
+      },
+      "expected": {
+        "supported": false,
+        "reasonsContain": [
+          "below required"
+        ]
+      }
+    },
+    {
+      "name": "semver-server-version-below-baseline",
+      "description": "SemVer servers older than the GA minimum supported line are blocked.",
+      "compatibility": {
+        "serverVersion": "0.99.0-preview.1",
+        "releaseChannel": "preview",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [],
+        "features": {}
       },
       "expected": {
         "supported": false,

--- a/compatibility/server-matrix.json
+++ b/compatibility/server-matrix.json
@@ -1,12 +1,30 @@
 {
   "schemaVersion": 1,
   "baseline": {
-    "minimumServerVersion": "2026.3.0",
+    "minimumServerVersion": "1.0.0",
     "controlPlaneApiMajor": 1,
     "basePath": "/api/v1/admin",
     "minimumReleaseChannel": "preview"
   },
   "cases": [
+    {
+      "name": "ga-semver-server",
+      "description": "The GA server identity uses SemVer 1.x with optional build metadata.",
+      "compatibility": {
+        "serverVersion": "1.0.0+ac30266f",
+        "releaseChannel": "stable",
+        "controlPlaneApi": {
+          "major": 1,
+          "basePath": "/api/v1/admin",
+          "deprecated": false
+        },
+        "metadataSchemas": [],
+        "features": {}
+      },
+      "expected": {
+        "supported": true
+      }
+    },
     {
       "name": "minimum-preview-server",
       "description": "The lowest supported public-preview server line remains compatible.",

--- a/compatibility/server-matrix.json
+++ b/compatibility/server-matrix.json
@@ -131,9 +131,9 @@
     },
     {
       "name": "server-version-below-baseline",
-      "description": "Servers older than the minimum supported line are blocked.",
+      "description": "Pre-GA SemVer servers older than the minimum supported line are blocked.",
       "compatibility": {
-        "serverVersion": "2026.2.28-preview.1",
+        "serverVersion": "0.99.0-preview.1",
         "releaseChannel": "preview",
         "controlPlaneApi": {
           "major": 1,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,6 +13,7 @@ Release builds support Honua Server versions that meet all of these conditions:
 
 - `serverVersion` parses to at least `1.0.0`. Honua Server GA identities use
   SemVer `1.x` values and may include build metadata such as `1.0.0+<sha>`.
+- Pre-GA CalVer identities remain supported from `2026.3.0` onward.
 - `releaseChannel` is `preview` or a later channel (`beta`, `rc`, `stable`, or
   `lts`).
 - `controlPlaneApi.major` is `1`.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -11,7 +11,8 @@ The Python SDK compatibility gate protects two contracts:
 
 Release builds support Honua Server versions that meet all of these conditions:
 
-- `serverVersion` parses to at least `2026.3.0`.
+- `serverVersion` parses to at least `1.0.0`. Honua Server GA identities use
+  SemVer `1.x` values and may include build metadata such as `1.0.0+<sha>`.
 - `releaseChannel` is `preview` or a later channel (`beta`, `rc`, `stable`, or
   `lts`).
 - `controlPlaneApi.major` is `1`.

--- a/packages/honua-admin/honua_admin/_async_client.py
+++ b/packages/honua-admin/honua_admin/_async_client.py
@@ -444,7 +444,7 @@ class AsyncHonuaAdminClient:
             response = await self._client.request(**request_kwargs)
         except httpx.HTTPError as exc:
             raise to_transport_error(exc) from exc
-        if response.status_code >= 400:
+        if not 200 <= response.status_code < 300:
             raise to_http_error(response)
         return response
 

--- a/packages/honua-admin/honua_admin/_client.py
+++ b/packages/honua-admin/honua_admin/_client.py
@@ -445,7 +445,7 @@ class HonuaAdminClient:
             response = self._client.request(**request_kwargs)
         except httpx.HTTPError as exc:
             raise to_transport_error(exc) from exc
-        if response.status_code >= 400:
+        if not 200 <= response.status_code < 300:
             raise to_http_error(response)
         return response
 

--- a/packages/honua-admin/honua_admin/_models.py
+++ b/packages/honua-admin/honua_admin/_models.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass, field, fields
 from typing import Any, Literal, TypeAlias
 
-MINIMUM_SUPPORTED_SERVER_VERSION = "2026.3.0"
+MINIMUM_SUPPORTED_SERVER_VERSION = "1.0.0"
 MINIMUM_SUPPORTED_CONTROL_PLANE_API_MAJOR = 1
 MINIMUM_SUPPORTED_CONTROL_PLANE_BASE_PATH = "/api/v1/admin"
 MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL = "preview"
@@ -1834,5 +1834,4 @@ class MigrationInventoryScanRequest:
 
     def to_dict(self) -> dict[str, Any]:
         return _dataclass_to_camel_dict(self)
-
 

--- a/packages/honua-admin/honua_admin/_models.py
+++ b/packages/honua-admin/honua_admin/_models.py
@@ -8,6 +8,9 @@ from dataclasses import dataclass, field, fields
 from typing import Any, Literal, TypeAlias
 
 MINIMUM_SUPPORTED_SERVER_VERSION = "1.0.0"
+# Pre-GA Honua Server releases used CalVer; keep their established cutoff
+# while accepting the GA SemVer identity above.
+_MINIMUM_SUPPORTED_CALVER = "2026.3.0"
 MINIMUM_SUPPORTED_CONTROL_PLANE_API_MAJOR = 1
 MINIMUM_SUPPORTED_CONTROL_PLANE_BASE_PATH = "/api/v1/admin"
 MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL = "preview"
@@ -24,6 +27,7 @@ _RELEASE_CHANNEL_ORDER = {
 }
 
 _VERSION_COMPONENT_PATTERN = re.compile(r"\d+")
+_CALVER_PATTERN = re.compile(r"^\d{4}[.-]\d{1,2}[.-]\d{1,2}(?:[-+].*)?$")
 
 
 def _to_snake(name: str) -> str:
@@ -90,6 +94,10 @@ def _parse_version_components(version: str | None) -> tuple[int, int, int] | Non
     if len(parts) < 3:
         return None
     return (parts[0], parts[1], parts[2])
+
+
+def _is_calver(version: str | None) -> bool:
+    return bool(version and _CALVER_PATTERN.fullmatch(version))
 
 
 # ---------------------------------------------------------------------------
@@ -599,7 +607,12 @@ def evaluate_admin_compatibility(
         )
 
     actual_version = _parse_version_components(compatibility.server_version)
-    minimum_version = _parse_version_components(baseline.minimum_server_version)
+    minimum_version_text = (
+        _MINIMUM_SUPPORTED_CALVER
+        if _is_calver(compatibility.server_version)
+        else baseline.minimum_server_version
+    )
+    minimum_version = _parse_version_components(minimum_version_text)
     if actual_version is None:
         reasons.append(f"Server version {compatibility.server_version!r} could not be parsed.")
     elif minimum_version is None:
@@ -608,7 +621,7 @@ def evaluate_admin_compatibility(
         reasons.append(
             "Server version "
             f"{compatibility.server_version!r} is below required "
-            f"{baseline.minimum_server_version!r}."
+            f"{minimum_version_text!r}."
         )
 
     if compatibility.control_plane_api.major != baseline.control_plane_api_major:
@@ -1834,4 +1847,3 @@ class MigrationInventoryScanRequest:
 
     def to_dict(self) -> dict[str, Any]:
         return _dataclass_to_camel_dict(self)
-

--- a/packages/honua-sdk/honua_sdk/async_client.py
+++ b/packages/honua-sdk/honua_sdk/async_client.py
@@ -1609,8 +1609,7 @@ class AsyncHonuaClient:
             response = await self._client.request(**request_kwargs)
         except httpx.HTTPError as exc:
             raise _to_transport_error(exc) from exc
-        if response.status_code >= 400:
+        if not 200 <= response.status_code < 300:
             raise _to_http_error(response)
         return response
-
 

--- a/packages/honua-sdk/honua_sdk/client.py
+++ b/packages/honua-sdk/honua_sdk/client.py
@@ -1610,8 +1610,7 @@ class HonuaClient:
             response = self._client.request(**request_kwargs)
         except httpx.HTTPError as exc:
             raise _to_transport_error(exc) from exc
-        if response.status_code >= 400:
+        if not 200 <= response.status_code < 300:
             raise _to_http_error(response)
         return response
-
 

--- a/tests/admin/test_compatibility.py
+++ b/tests/admin/test_compatibility.py
@@ -131,8 +131,18 @@ def test_check_compatibility_rejects_major_mismatch(make_client) -> None:
 
 def test_check_compatibility_rejects_server_version_below_baseline(make_client) -> None:
     def handler(_: httpx.Request) -> httpx.Response:
-        # The baseline now follows GA SemVer; the old 2026.x fixture compares
-        # newer than 1.0.0 and therefore no longer exercises this contract.
+        payload = _make_capabilities_payload(server_version="2026.2.28-preview.1")
+        return httpx.Response(200, json=make_api_response(payload))
+
+    with make_client(handler) as client:
+        result = client.check_compatibility()
+
+    assert result.supported is False
+    assert any("below required" in reason for reason in result.reasons)
+
+
+def test_check_compatibility_rejects_semver_below_baseline(make_client) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
         payload = _make_capabilities_payload(server_version="0.99.0-preview.1")
         return httpx.Response(200, json=make_api_response(payload))
 

--- a/tests/admin/test_compatibility.py
+++ b/tests/admin/test_compatibility.py
@@ -105,6 +105,18 @@ def test_check_compatibility_accepts_supported_server(make_client) -> None:
     assert result.baseline.minimum_release_channel == MINIMUM_SUPPORTED_SERVER_RELEASE_CHANNEL
 
 
+def test_check_compatibility_accepts_ga_semver_server(make_client) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        payload = _make_capabilities_payload(server_version="1.0.0+ac30266f")
+        return httpx.Response(200, json=make_api_response(payload))
+
+    with make_client(handler) as client:
+        result = client.check_compatibility()
+
+    assert result.supported is True
+    assert result.reasons == []
+
+
 def test_check_compatibility_rejects_major_mismatch(make_client) -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         payload = _make_capabilities_payload(major=2)

--- a/tests/admin/test_compatibility.py
+++ b/tests/admin/test_compatibility.py
@@ -131,7 +131,9 @@ def test_check_compatibility_rejects_major_mismatch(make_client) -> None:
 
 def test_check_compatibility_rejects_server_version_below_baseline(make_client) -> None:
     def handler(_: httpx.Request) -> httpx.Response:
-        payload = _make_capabilities_payload(server_version="2026.2.28-preview.1")
+        # The baseline now follows GA SemVer; the old 2026.x fixture compares
+        # newer than 1.0.0 and therefore no longer exercises this contract.
+        payload = _make_capabilities_payload(server_version="0.99.0-preview.1")
         return httpx.Response(200, json=make_api_response(payload))
 
     with make_client(handler) as client:

--- a/tests/admin/test_services.py
+++ b/tests/admin/test_services.py
@@ -242,7 +242,7 @@ def test_update_protocols_400_raises_http_error(make_client) -> None:
     assert "Invalid protocol" in exc_info.value.message
 
 
-def test_does_not_follow_redirects_by_default() -> None:
+def test_does_not_follow_redirects_by_default_and_raises() -> None:
     seen: list[tuple[str, str]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -260,9 +260,10 @@ def test_does_not_follow_redirects_by_default() -> None:
         transport=transport,
         api_key="test-key",
     ) as client:
-        result = client.list_services()
+        with pytest.raises(HonuaHttpError) as exc_info:
+            client.list_services()
 
-    assert result == []
+    assert exc_info.value.status_code == 302
     assert len(seen) == 1
     assert seen[0][0] == "http://test.honua.io/api/v1/admin/services/"
     assert seen[0][1] == "test-key"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -709,7 +709,7 @@ def test_non_success_raises_honua_http_error() -> None:
     assert isinstance(err.body, dict)
 
 
-def test_does_not_follow_redirects_by_default() -> None:
+def test_does_not_follow_redirects_by_default_and_raises() -> None:
     seen: list[tuple[str, str]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -723,9 +723,10 @@ def test_does_not_follow_redirects_by_default() -> None:
 
     transport = httpx.MockTransport(handler)
     with HonuaClient("http://example.test", transport=transport, api_key="test-key") as client:
-        response = client.readiness()
+        with pytest.raises(HonuaHttpError) as exc_info:
+            client.readiness()
 
-    assert response == {}
+    assert exc_info.value.status_code == 302
     assert len(seen) == 1
     assert seen[0][0] == "http://example.test/healthz/ready"
     assert seen[0][1] == "test-key"


### PR DESCRIPTION
## Issue

Raw bug-hunt findings: #9, #47.

## Summary

Align the compatibility baseline with GA server SemVer and reject successful-looking 3xx responses.

## Changes Made

- Updated packages/, compatibility/, docs/, tests/.
- Added or updated focused regression coverage where available.

## Breaking Changes

None intended.

## Gate Impact

- [x] Correctness/security or contract behavior

## Testing

- [x] Focused compatibility tests and compatibility gate passed.
- [x] Full actionable CI matrix passed at the current head.
- [ ] `staging-smoke` remains non-actionable: the operator-held client-compat binding expired on 2026-08-16.

---

## Disposition

- `honua-release#264` finding #9: fixed — the Admin compatibility baseline now accepts GA SemVer `1.x` server identities, with the corrected pre-GA rejection fixture and API snapshot.
- `honua-release#264` finding #47: fixed — successful-looking 3xx responses remain rejected by the operator’s redirect-handling fix.
