### PR TITLE
feat(errors): expose terminal failure receipts (#221)

### DIFF
--- a/compatibility/public-api.json
+++ b/compatibility/public-api.json
@@ -4014,11 +4014,13 @@
         "DegradedReason",
         "EditOperationResult",
         "Extent",
+        "FailureKind",
         "Feature",
         "FeatureQuery",
         "FeatureQueryResult",
         "FeatureSet",
         "Field",
+        "FieldFailure",
         "GeocodeResult",
         "GeocodeSuggestion",
         "HonuaAuthError",
@@ -4037,6 +4039,7 @@
         "PROTOCOL_ALIASES",
         "Pagination",
         "Protocol",
+        "ProtocolMetadata",
         "Query",
         "QueryFeature",
         "QueryProtocol",
@@ -4048,6 +4051,7 @@
         "SourceDescriptor",
         "SourceLocator",
         "StaticAuthProvider",
+        "TerminalFailureReceipt",
         "TokenStore",
         "__version__",
         "capability_set",
@@ -4629,6 +4633,21 @@
           "qualname": "Extent",
           "signature": "(xmin: 'float', ymin: 'float', xmax: 'float', ymax: 'float', srid: 'int | None' = None) -> None"
         },
+        "FailureKind": {
+          "kind": "enum",
+          "members": {
+            "AUTHENTICATION": "authentication",
+            "AUTHORIZATION": "authorization",
+            "CONFLICT": "conflict",
+            "NOT_FOUND": "not-found",
+            "THROTTLED": "throttled",
+            "UNAVAILABLE": "unavailable",
+            "UNKNOWN": "unknown",
+            "VALIDATION": "validation"
+          },
+          "module": "honua_sdk.errors",
+          "qualname": "FailureKind"
+        },
         "Feature": {
           "fields": [
             {
@@ -4893,6 +4912,44 @@
           "qualname": "Field",
           "signature": "(name: 'str', type: 'str', alias: 'str | None' = None, length: 'int | None' = None, nullable: 'bool' = True, editable: 'bool' = True, default_value: 'Any' = None, domain: 'Mapping[str, Any] | None' = None) -> None"
         },
+        "FieldFailure": {
+          "fields": [
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "code"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "severity"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "path"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "field_id"
+            },
+            {
+              "annotation": "int | None",
+              "default": "None",
+              "name": "item_index"
+            },
+            {
+              "annotation": "str | None",
+              "default": "None",
+              "name": "message"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "FieldFailure",
+          "signature": "(code: 'str | None' = None, severity: 'str | None' = None, path: 'str | None' = None, field_id: 'str | None' = None, item_index: 'int | None' = None, message: 'str | None' = None) -> None"
+        },
         "GeocodeResult": {
           "fields": [
             {
@@ -4945,7 +5002,7 @@
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaAuthError",
-          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None) -> 'None'"
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None, receipt: 'TerminalFailureReceipt | None' = None) -> 'None'"
         },
         "HonuaCapabilityNotSupportedError": {
           "kind": "class",
@@ -5146,19 +5203,19 @@
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaGrpcError",
-          "signature": "(code: 'Any', message: 'str', details: 'Any' = None) -> 'None'"
+          "signature": "(code: 'Any', message: 'str', details: 'Any' = None, *, initial_metadata: 'Mapping[str, Any] | None' = None, trailing_metadata: 'Mapping[str, Any] | None' = None) -> 'None'"
         },
         "HonuaHttpError": {
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaHttpError",
-          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None) -> 'None'"
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None, receipt: 'TerminalFailureReceipt | None' = None) -> 'None'"
         },
         "HonuaRateLimitError": {
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaRateLimitError",
-          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, retry_after: 'float | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None) -> 'None'"
+          "signature": "(status_code: 'int', message: 'str', *, body: 'Any | None' = None, retry_after: 'float | None' = None, request_id: 'str | None' = None, headers: 'Mapping[str, str] | None' = None, error_code: 'int | None' = None, receipt: 'TerminalFailureReceipt | None' = None) -> 'None'"
         },
         "HonuaTimeoutError": {
           "kind": "class",
@@ -5303,6 +5360,22 @@
           "kind": "constant",
           "type": "_LiteralGenericAlias",
           "value": "typing.Literal['grpc', 'geoservices-feature-service', 'geoservices-map-service', 'geoservices-image-service', 'geoservices-geometry-service', 'geoservices-gp-service', 'ogc-features', 'ogc-tiles', 'ogc-maps', 'stac', 'wfs', 'wms', 'wmts', 'odata', 'maplibre-vector', 'maplibre-raster', 'maplibre-geojson']"
+        },
+        "ProtocolMetadata": {
+          "fields": [
+            {
+              "annotation": "ProtocolValues",
+              "name": "initial"
+            },
+            {
+              "annotation": "ProtocolValues",
+              "name": "trailing"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "ProtocolMetadata",
+          "signature": "(initial: 'ProtocolValues', trailing: 'ProtocolValues') -> None"
         },
         "Query": {
           "fields": [
@@ -5753,6 +5826,50 @@
           "qualname": "StaticAuthProvider",
           "signature": "(headers: 'Mapping[str, str]') -> 'None'"
         },
+        "TerminalFailureReceipt": {
+          "fields": [
+            {
+              "annotation": "int | None",
+              "name": "transport_status"
+            },
+            {
+              "annotation": "str | None",
+              "name": "protocol_code"
+            },
+            {
+              "annotation": "FailureKind",
+              "name": "kind"
+            },
+            {
+              "annotation": "str",
+              "name": "code"
+            },
+            {
+              "annotation": "bool",
+              "name": "retryable"
+            },
+            {
+              "annotation": "float | None",
+              "name": "retry_after_seconds"
+            },
+            {
+              "annotation": "str | None",
+              "name": "correlation_id"
+            },
+            {
+              "annotation": "tuple[FieldFailure, ...]",
+              "name": "field_errors"
+            },
+            {
+              "annotation": "ProtocolMetadata",
+              "name": "protocol_metadata"
+            }
+          ],
+          "kind": "class",
+          "module": "honua_sdk.errors",
+          "qualname": "TerminalFailureReceipt",
+          "signature": "(transport_status: 'int | None', protocol_code: 'str | None', kind: 'FailureKind', code: 'str', retryable: 'bool', retry_after_seconds: 'float | None', correlation_id: 'str | None', field_errors: 'tuple[FieldFailure, ...]', protocol_metadata: 'ProtocolMetadata') -> None"
+        },
         "TokenStore": {
           "kind": "class",
           "methods": {
@@ -6042,7 +6159,7 @@
           "kind": "class",
           "module": "honua_sdk.errors",
           "qualname": "HonuaGrpcError",
-          "signature": "(code: 'Any', message: 'str', details: 'Any' = None) -> 'None'"
+          "signature": "(code: 'Any', message: 'str', details: 'Any' = None, *, initial_metadata: 'Mapping[str, Any] | None' = None, trailing_metadata: 'Mapping[str, Any] | None' = None) -> 'None'"
         },
         "QueryFeaturesRequest": {
           "fields": [

--- a/packages/honua-sdk/honua_sdk/__init__.py
+++ b/packages/honua-sdk/honua_sdk/__init__.py
@@ -59,6 +59,8 @@ from .auth import (
 )
 from .client import HonuaClient
 from .errors import (
+    FailureKind,
+    FieldFailure,
     HonuaAuthError,
     HonuaCapabilityNotSupportedError,
     HonuaError,
@@ -67,6 +69,8 @@ from .errors import (
     HonuaRateLimitError,
     HonuaTimeoutError,
     HonuaTransportError,
+    ProtocolMetadata,
+    TerminalFailureReceipt,
 )
 from .geocoding import HonuaGeocodingClient
 from .models import (
@@ -171,4 +175,8 @@ __all__ = [  # noqa: RUF022 -- grouped by category for human discoverability
     "HonuaTransportError",
     "HonuaTimeoutError",
     "HonuaGrpcError",
+    "FailureKind",
+    "FieldFailure",
+    "ProtocolMetadata",
+    "TerminalFailureReceipt",
 ]

--- a/packages/honua-sdk/honua_sdk/_http.py
+++ b/packages/honua-sdk/honua_sdk/_http.py
@@ -21,6 +21,7 @@ from .errors import (
     HonuaRateLimitError,
     HonuaTimeoutError,
     HonuaTransportError,
+    _http_failure_receipt,
 )
 
 
@@ -354,6 +355,13 @@ def _build_http_error(
         or response.headers.get("x-correlation-id")
     )
     headers = dict(response.headers)
+    retry_after = _parse_retry_after(response.headers.get("retry-after"))
+    receipt = _http_failure_receipt(
+        transport_status=response.status_code,
+        body=body,
+        headers=headers,
+        retry_after_seconds=retry_after,
+    )
     if status_code in (401, 403):
         return HonuaAuthError(
             status_code,
@@ -361,9 +369,9 @@ def _build_http_error(
             body=body,
             request_id=request_id,
             headers=headers,
+            receipt=receipt,
         )
     if status_code == 429:
-        retry_after = _parse_retry_after(response.headers.get("retry-after"))
         return HonuaRateLimitError(
             status_code,
             message,
@@ -371,6 +379,7 @@ def _build_http_error(
             retry_after=retry_after,
             request_id=request_id,
             headers=headers,
+            receipt=receipt,
         )
     return HonuaHttpError(
         status_code,
@@ -378,6 +387,7 @@ def _build_http_error(
         body=body,
         request_id=request_id,
         headers=headers,
+        receipt=receipt,
     )
 
 
@@ -496,6 +506,14 @@ def _build_geoservices_error(
     )
     headers = dict(response.headers)
     status_code = _normalize_geoservices_status(error_code)
+    retry_after = _parse_retry_after(response.headers.get("retry-after"))
+    receipt = _http_failure_receipt(
+        transport_status=getattr(response, "status_code", 200),
+        body=body,
+        headers=headers,
+        protocol_code=error_code,
+        retry_after_seconds=retry_after,
+    )
     if error_code in _GEOSERVICES_AUTH_CODES:
         return HonuaAuthError(
             status_code,
@@ -504,9 +522,9 @@ def _build_geoservices_error(
             request_id=request_id,
             headers=headers,
             error_code=error_code,
+            receipt=receipt,
         )
     if error_code == 429:
-        retry_after = _parse_retry_after(response.headers.get("retry-after"))
         return HonuaRateLimitError(
             status_code,
             message,
@@ -515,6 +533,7 @@ def _build_geoservices_error(
             request_id=request_id,
             headers=headers,
             error_code=error_code,
+            receipt=receipt,
         )
     return HonuaHttpError(
         status_code,
@@ -523,6 +542,7 @@ def _build_geoservices_error(
         request_id=request_id,
         headers=headers,
         error_code=error_code,
+        receipt=receipt,
     )
 
 

--- a/packages/honua-sdk/honua_sdk/errors.py
+++ b/packages/honua-sdk/honua_sdk/errors.py
@@ -176,7 +176,7 @@ def _default_code(kind: FailureKind) -> str:
         FailureKind.NOT_FOUND: "resource_not_found",
         FailureKind.VALIDATION: "validation_failed",
         FailureKind.CONFLICT: "resource_conflict",
-        FailureKind.THROTTLED: "rate_limited",
+        FailureKind.THROTTLED: "rate_limit_exceeded",
         FailureKind.UNAVAILABLE: "service_unavailable",
     }.get(kind, "unknown_failure")
 
@@ -275,7 +275,9 @@ def _grpc_failure_receipt(
     declared_kind = _first(trailing, "honua-error-kind") or _first(initial, "honua-error-kind")
     kind = _kind(declared_kind, _grpc_kind(number))
     machine_code = _first(trailing, "honua-error-code") or _first(initial, "honua-error-code")
-    declared_retryable = _first(trailing, "honua-error-retryable") or _first(initial, "honua-error-retryable")
+    declared_retryable = _first(trailing, "honua-retryable", "honua-error-retryable") or _first(
+        initial, "honua-retryable", "honua-error-retryable"
+    )
     retryable = declared_retryable == "true" if declared_retryable in ("true", "false") else number in (4, 8, 10, 14)
     retry_after = _number_from_string(_first(trailing, "retry-after") or _first(initial, "retry-after"))
     details = _first(trailing, "honua-error-details") or _first(initial, "honua-error-details")
@@ -290,8 +292,10 @@ def _grpc_failure_receipt(
         code=machine_code or _default_code(kind),
         retryable=retryable,
         retry_after_seconds=retry_after,
-        correlation_id=_first(trailing, "x-correlation-id", "honua-request-id", "x-request-id")
-        or _first(initial, "x-correlation-id", "honua-request-id", "x-request-id"),
+        correlation_id=_first(
+            trailing, "x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id"
+        )
+        or _first(initial, "x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id"),
         field_errors=_field_errors(errors),
         protocol_metadata=ProtocolMetadata(initial=initial, trailing=trailing),
     )

--- a/packages/honua-sdk/honua_sdk/errors.py
+++ b/packages/honua-sdk/honua_sdk/errors.py
@@ -24,10 +24,15 @@ The subclasses of :class:`HonuaHttpError` are drop-in: existing
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
-from typing import Any
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, TypeAlias
 
 __all__ = [
+    "FailureKind",
+    "FieldFailure",
     "HonuaAuthError",
     "HonuaCapabilityNotSupportedError",
     "HonuaError",
@@ -36,7 +41,269 @@ __all__ = [
     "HonuaRateLimitError",
     "HonuaTimeoutError",
     "HonuaTransportError",
+    "ProtocolMetadata",
+    "TerminalFailureReceipt",
 ]
+
+
+class FailureKind(StrEnum):
+    """Stable failure classes shared across Honua transports."""
+
+    UNKNOWN = "unknown"
+    AUTHENTICATION = "authentication"
+    AUTHORIZATION = "authorization"
+    NOT_FOUND = "not-found"
+    VALIDATION = "validation"
+    CONFLICT = "conflict"
+    THROTTLED = "throttled"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class FieldFailure:
+    """One field- or item-addressable failure."""
+
+    code: str | None = None
+    severity: str | None = None
+    path: str | None = None
+    field_id: str | None = None
+    item_index: int | None = None
+    message: str | None = None
+
+
+ProtocolValues: TypeAlias = Mapping[str, tuple[str, ...]]
+
+
+@dataclass(frozen=True, slots=True)
+class ProtocolMetadata:
+    """Safe protocol metadata, separated into initial headers and trailers."""
+
+    initial: ProtocolValues
+    trailing: ProtocolValues
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalFailureReceipt:
+    """Machine-actionable terminal failure data retained without flattening."""
+
+    transport_status: int | None
+    protocol_code: str | None
+    kind: FailureKind
+    code: str
+    retryable: bool
+    retry_after_seconds: float | None
+    correlation_id: str | None
+    field_errors: tuple[FieldFailure, ...]
+    protocol_metadata: ProtocolMetadata
+
+
+_SENSITIVE_METADATA = frozenset({"authorization", "cookie", "set-cookie", "x-api-key"})
+_HTTP_KINDS = {
+    400: FailureKind.VALIDATION,
+    401: FailureKind.AUTHENTICATION,
+    403: FailureKind.AUTHORIZATION,
+    404: FailureKind.NOT_FOUND,
+    409: FailureKind.CONFLICT,
+    412: FailureKind.CONFLICT,
+    422: FailureKind.VALIDATION,
+    428: FailureKind.CONFLICT,
+    429: FailureKind.THROTTLED,
+    498: FailureKind.AUTHORIZATION,
+    499: FailureKind.AUTHORIZATION,
+}
+_RETRYABLE_HTTP_CODES = frozenset({408, 429, 500, 502, 503, 504})
+_SERVER_ERROR_MIN = 500
+
+
+def _metadata(values: Mapping[str, Any] | None) -> dict[str, tuple[str, ...]]:
+    result: dict[str, tuple[str, ...]] = {}
+    for key, value in (values or {}).items():
+        normalized = str(key).lower()
+        if normalized in _SENSITIVE_METADATA:
+            continue
+        sequence = value if isinstance(value, (list, tuple)) else (value,)
+        result[normalized] = tuple(
+            item.decode("utf-8", errors="replace") if isinstance(item, bytes) else str(item)
+            for item in sequence
+        )
+    return result
+
+
+def _first(metadata: ProtocolValues, *keys: str) -> str | None:
+    for key in keys:
+        values = metadata.get(key)
+        if values:
+            return values[0]
+    return None
+
+
+def _kind(value: object, fallback: FailureKind) -> FailureKind:
+    if isinstance(value, str):
+        try:
+            return FailureKind(value)
+        except ValueError:
+            pass
+    return fallback
+
+
+def _http_kind(code: int, transport_status: int) -> FailureKind:
+    kind = _HTTP_KINDS.get(code)
+    if kind is not None:
+        return kind
+    if code in _RETRYABLE_HTTP_CODES or transport_status >= _SERVER_ERROR_MIN:
+        return FailureKind.UNAVAILABLE
+    return FailureKind.UNKNOWN
+
+
+def _grpc_kind(code: int) -> FailureKind:
+    return {
+        16: FailureKind.AUTHENTICATION,
+        7: FailureKind.AUTHORIZATION,
+        5: FailureKind.NOT_FOUND,
+        3: FailureKind.VALIDATION,
+        6: FailureKind.CONFLICT,
+        10: FailureKind.CONFLICT,
+        8: FailureKind.THROTTLED,
+        4: FailureKind.UNAVAILABLE,
+        14: FailureKind.UNAVAILABLE,
+    }.get(code, FailureKind.UNKNOWN)
+
+
+def _default_code(kind: FailureKind) -> str:
+    return {
+        FailureKind.AUTHENTICATION: "authentication_required",
+        FailureKind.AUTHORIZATION: "permission_denied",
+        FailureKind.NOT_FOUND: "resource_not_found",
+        FailureKind.VALIDATION: "validation_failed",
+        FailureKind.CONFLICT: "resource_conflict",
+        FailureKind.THROTTLED: "rate_limited",
+        FailureKind.UNAVAILABLE: "service_unavailable",
+    }.get(kind, "unknown_failure")
+
+
+def _field_errors(value: object) -> tuple[FieldFailure, ...]:
+    failures: list[FieldFailure] = []
+    if isinstance(value, list):
+        for item in value:
+            if not isinstance(item, Mapping):
+                continue
+            failures.append(
+                FieldFailure(
+                    code=item.get("code") if isinstance(item.get("code"), str) else None,
+                    severity=item.get("severity") if isinstance(item.get("severity"), str) else None,
+                    path=item.get("path") if isinstance(item.get("path"), str) else None,
+                    field_id=item.get("fieldId") if isinstance(item.get("fieldId"), str) else None,
+                    item_index=item.get("itemIndex") if isinstance(item.get("itemIndex"), int) else None,
+                    message=item.get("message") if isinstance(item.get("message"), str) else None,
+                )
+            )
+    elif isinstance(value, Mapping):
+        for field_id, messages in value.items():
+            if isinstance(messages, list):
+                failures.extend(
+                    FieldFailure(path=str(field_id), field_id=str(field_id), message=message)
+                    for message in messages
+                    if isinstance(message, str)
+                )
+    return tuple(failures)
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value >= 0:
+        return float(value)
+    return None
+
+
+def _http_failure_receipt(
+    *,
+    transport_status: int,
+    body: Any | None,
+    headers: Mapping[str, Any] | None,
+    protocol_code: int | None = None,
+    retry_after_seconds: float | None = None,
+) -> TerminalFailureReceipt:
+    root = body if isinstance(body, Mapping) else {}
+    error = root.get("error")
+    source = error if isinstance(error, Mapping) else root
+    classification_code = protocol_code if protocol_code is not None else transport_status
+    kind = _kind(source.get("kind"), _http_kind(classification_code, transport_status))
+    declared_code = source.get("machineCode") or source.get("code")
+    code = declared_code if isinstance(declared_code, str) else _default_code(kind)
+    declared_retryable = source.get("retryable")
+    retryable = (
+        declared_retryable
+        if isinstance(declared_retryable, bool)
+        else classification_code in _RETRYABLE_HTTP_CODES
+    )
+    safe_headers = _metadata(headers)
+    correlation_id = source.get("correlationId") or root.get("correlationId") or _first(
+        safe_headers, "x-correlation-id", "honua-request-id", "x-request-id"
+    )
+    declared_retry_after = _number(source.get("retryAfterSeconds"))
+    return TerminalFailureReceipt(
+        transport_status=transport_status,
+        protocol_code=str(protocol_code) if protocol_code is not None else None,
+        kind=kind,
+        code=code,
+        retryable=retryable,
+        retry_after_seconds=(
+            declared_retry_after
+            if declared_retry_after is not None
+            else retry_after_seconds
+        ),
+        correlation_id=correlation_id if isinstance(correlation_id, str) else None,
+        field_errors=_field_errors(source.get("errors") or root.get("errors")),
+        protocol_metadata=ProtocolMetadata(initial=safe_headers, trailing={}),
+    )
+
+
+def _grpc_code_number(code: Any) -> int:
+    value = getattr(code, "value", code)
+    if isinstance(value, tuple):
+        value = value[0]
+    return value if isinstance(value, int) else 2
+
+
+def _grpc_failure_receipt(
+    code: Any,
+    initial_metadata: Mapping[str, Any] | None,
+    trailing_metadata: Mapping[str, Any] | None,
+) -> TerminalFailureReceipt:
+    number = _grpc_code_number(code)
+    initial = _metadata(initial_metadata)
+    trailing = _metadata(trailing_metadata)
+    declared_kind = _first(trailing, "honua-error-kind") or _first(initial, "honua-error-kind")
+    kind = _kind(declared_kind, _grpc_kind(number))
+    machine_code = _first(trailing, "honua-error-code") or _first(initial, "honua-error-code")
+    declared_retryable = _first(trailing, "honua-error-retryable") or _first(initial, "honua-error-retryable")
+    retryable = declared_retryable == "true" if declared_retryable in ("true", "false") else number in (4, 8, 10, 14)
+    retry_after = _number_from_string(_first(trailing, "retry-after") or _first(initial, "retry-after"))
+    details = _first(trailing, "honua-error-details") or _first(initial, "honua-error-details")
+    try:
+        errors: object = json.loads(details) if details else None
+    except json.JSONDecodeError:
+        errors = None
+    return TerminalFailureReceipt(
+        transport_status=None,
+        protocol_code=str(number),
+        kind=kind,
+        code=machine_code or _default_code(kind),
+        retryable=retryable,
+        retry_after_seconds=retry_after,
+        correlation_id=_first(trailing, "x-correlation-id", "honua-request-id", "x-request-id")
+        or _first(initial, "x-correlation-id", "honua-request-id", "x-request-id"),
+        field_errors=_field_errors(errors),
+        protocol_metadata=ProtocolMetadata(initial=initial, trailing=trailing),
+    )
+
+
+def _number_from_string(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return _number(float(value))
+    except ValueError:
+        return None
 
 
 class HonuaError(Exception):
@@ -116,6 +383,7 @@ class HonuaHttpError(HonuaError):
         request_id: str | None = None,
         headers: Mapping[str, str] | None = None,
         error_code: int | None = None,
+        receipt: TerminalFailureReceipt | None = None,
     ) -> None:
         super().__init__(f"HTTP {status_code}: {message}")
         self.status_code = status_code
@@ -124,6 +392,19 @@ class HonuaHttpError(HonuaError):
         self.request_id = request_id
         self.headers: Mapping[str, str] = dict(headers) if headers is not None else {}
         self.error_code = error_code
+        self.receipt = receipt or _http_failure_receipt(
+            transport_status=status_code,
+            body=body,
+            headers=headers,
+            protocol_code=error_code,
+        )
+        self.failure_kind = self.receipt.kind
+        self.machine_code = self.receipt.code
+        self.retryable = self.receipt.retryable
+        self.retry_after = self.receipt.retry_after_seconds
+        self.correlation_id = self.receipt.correlation_id
+        self.field_errors = self.receipt.field_errors
+        self.protocol_metadata = self.receipt.protocol_metadata
 
 
 class HonuaAuthError(HonuaHttpError):
@@ -171,6 +452,7 @@ class HonuaRateLimitError(HonuaHttpError):
         request_id: str | None = None,
         headers: Mapping[str, str] | None = None,
         error_code: int | None = None,
+        receipt: TerminalFailureReceipt | None = None,
     ) -> None:
         super().__init__(
             status_code,
@@ -179,8 +461,9 @@ class HonuaRateLimitError(HonuaHttpError):
             request_id=request_id,
             headers=headers,
             error_code=error_code,
+            receipt=receipt,
         )
-        self.retry_after = retry_after
+        self.retry_after = self.receipt.retry_after_seconds if retry_after is None else retry_after
 
 
 class HonuaTransportError(HonuaError):
@@ -208,9 +491,25 @@ class HonuaTimeoutError(HonuaTransportError):
 class HonuaGrpcError(HonuaError):
     """Raised when a gRPC call fails."""
 
-    def __init__(self, code: Any, message: str, details: Any = None) -> None:
+    def __init__(
+        self,
+        code: Any,
+        message: str,
+        details: Any = None,
+        *,
+        initial_metadata: Mapping[str, Any] | None = None,
+        trailing_metadata: Mapping[str, Any] | None = None,
+    ) -> None:
         code_display = getattr(code, "name", code)
         super().__init__(f"gRPC {code_display}: {message}")
         self.code = code
         self.message = message
         self.details = details
+        self.receipt = _grpc_failure_receipt(code, initial_metadata, trailing_metadata)
+        self.failure_kind = self.receipt.kind
+        self.machine_code = self.receipt.code
+        self.retryable = self.receipt.retryable
+        self.retry_after = self.receipt.retry_after_seconds
+        self.correlation_id = self.receipt.correlation_id
+        self.field_errors = self.receipt.field_errors
+        self.protocol_metadata = self.receipt.protocol_metadata

--- a/packages/honua-sdk/honua_sdk/errors.py
+++ b/packages/honua-sdk/honua_sdk/errors.py
@@ -108,8 +108,8 @@ _HTTP_KINDS = {
     422: FailureKind.VALIDATION,
     428: FailureKind.CONFLICT,
     429: FailureKind.THROTTLED,
-    498: FailureKind.AUTHORIZATION,
-    499: FailureKind.AUTHORIZATION,
+    498: FailureKind.AUTHENTICATION,
+    499: FailureKind.AUTHENTICATION,
 }
 _RETRYABLE_HTTP_CODES = frozenset({408, 429, 500, 502, 503, 504})
 _SERVER_ERROR_MIN = 500
@@ -123,8 +123,7 @@ def _metadata(values: Mapping[str, Any] | None) -> dict[str, tuple[str, ...]]:
             continue
         sequence = value if isinstance(value, (list, tuple)) else (value,)
         result[normalized] = tuple(
-            item.decode("utf-8", errors="replace") if isinstance(item, bytes) else str(item)
-            for item in sequence
+            item.decode("utf-8", errors="replace") if isinstance(item, bytes) else str(item) for item in sequence
         )
     return result
 
@@ -214,13 +213,14 @@ def _number(value: object) -> float | None:
     return None
 
 
-def _http_failure_receipt(
+def _http_failure_receipt(  # noqa: PLR0913 - explicit carriers prevent receipt data loss
     *,
     transport_status: int,
     body: Any | None,
     headers: Mapping[str, Any] | None,
     protocol_code: int | None = None,
     retry_after_seconds: float | None = None,
+    correlation_id: str | None = None,
 ) -> TerminalFailureReceipt:
     root = body if isinstance(body, Mapping) else {}
     error = root.get("error")
@@ -233,11 +233,14 @@ def _http_failure_receipt(
     retryable = (
         declared_retryable
         if isinstance(declared_retryable, bool)
-        else classification_code in _RETRYABLE_HTTP_CODES
+        else classification_code in _RETRYABLE_HTTP_CODES or transport_status in _RETRYABLE_HTTP_CODES
     )
     safe_headers = _metadata(headers)
-    correlation_id = source.get("correlationId") or root.get("correlationId") or _first(
-        safe_headers, "x-correlation-id", "honua-request-id", "x-request-id"
+    correlation_id = (
+        source.get("correlationId")
+        or root.get("correlationId")
+        or _first(safe_headers, "x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id")
+        or correlation_id
     )
     declared_retry_after = _number(source.get("retryAfterSeconds"))
     return TerminalFailureReceipt(
@@ -246,11 +249,7 @@ def _http_failure_receipt(
         kind=kind,
         code=code,
         retryable=retryable,
-        retry_after_seconds=(
-            declared_retry_after
-            if declared_retry_after is not None
-            else retry_after_seconds
-        ),
+        retry_after_seconds=(declared_retry_after if declared_retry_after is not None else retry_after_seconds),
         correlation_id=correlation_id if isinstance(correlation_id, str) else None,
         field_errors=_field_errors(source.get("errors") or root.get("errors")),
         protocol_metadata=ProtocolMetadata(initial=safe_headers, trailing={}),
@@ -292,9 +291,7 @@ def _grpc_failure_receipt(
         code=machine_code or _default_code(kind),
         retryable=retryable,
         retry_after_seconds=retry_after,
-        correlation_id=_first(
-            trailing, "x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id"
-        )
+        correlation_id=_first(trailing, "x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id")
         or _first(initial, "x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id"),
         field_errors=_field_errors(errors),
         protocol_metadata=ProtocolMetadata(initial=initial, trailing=trailing),
@@ -387,6 +384,7 @@ class HonuaHttpError(HonuaError):
         request_id: str | None = None,
         headers: Mapping[str, str] | None = None,
         error_code: int | None = None,
+        retry_after: float | None = None,
         receipt: TerminalFailureReceipt | None = None,
     ) -> None:
         super().__init__(f"HTTP {status_code}: {message}")
@@ -401,6 +399,8 @@ class HonuaHttpError(HonuaError):
             body=body,
             headers=headers,
             protocol_code=error_code,
+            retry_after_seconds=retry_after,
+            correlation_id=request_id,
         )
         self.failure_kind = self.receipt.kind
         self.machine_code = self.receipt.code
@@ -465,9 +465,10 @@ class HonuaRateLimitError(HonuaHttpError):
             request_id=request_id,
             headers=headers,
             error_code=error_code,
+            retry_after=retry_after,
             receipt=receipt,
         )
-        self.retry_after = self.receipt.retry_after_seconds if retry_after is None else retry_after
+        self.retry_after = self.receipt.retry_after_seconds
 
 
 class HonuaTransportError(HonuaError):

--- a/packages/honua-sdk/honua_sdk/errors.py
+++ b/packages/honua-sdk/honua_sdk/errors.py
@@ -384,7 +384,6 @@ class HonuaHttpError(HonuaError):
         request_id: str | None = None,
         headers: Mapping[str, str] | None = None,
         error_code: int | None = None,
-        retry_after: float | None = None,
         receipt: TerminalFailureReceipt | None = None,
     ) -> None:
         super().__init__(f"HTTP {status_code}: {message}")
@@ -399,7 +398,6 @@ class HonuaHttpError(HonuaError):
             body=body,
             headers=headers,
             protocol_code=error_code,
-            retry_after_seconds=retry_after,
             correlation_id=request_id,
         )
         self.failure_kind = self.receipt.kind
@@ -458,6 +456,14 @@ class HonuaRateLimitError(HonuaHttpError):
         error_code: int | None = None,
         receipt: TerminalFailureReceipt | None = None,
     ) -> None:
+        resolved_receipt = receipt or _http_failure_receipt(
+            transport_status=status_code,
+            body=body,
+            headers=headers,
+            protocol_code=error_code,
+            retry_after_seconds=retry_after,
+            correlation_id=request_id,
+        )
         super().__init__(
             status_code,
             message,
@@ -465,8 +471,7 @@ class HonuaRateLimitError(HonuaHttpError):
             request_id=request_id,
             headers=headers,
             error_code=error_code,
-            retry_after=retry_after,
-            receipt=receipt,
+            receipt=resolved_receipt,
         )
         self.retry_after = self.receipt.retry_after_seconds
 

--- a/packages/honua-sdk/honua_sdk/grpc/_client.py
+++ b/packages/honua-sdk/honua_sdk/grpc/_client.py
@@ -17,6 +17,21 @@ from . import _models as models
 from . import _proto_adapter as adapter
 
 
+def _rpc_metadata(error: grpc.RpcError, attribute: str) -> dict[str, list[object]]:
+    """Copy available gRPC metadata without allowing metadata access to mask the RPC failure."""
+    accessor = getattr(error, attribute, None)
+    if accessor is None:
+        return {}
+    try:
+        entries = accessor()
+    except (grpc.RpcError, RuntimeError):
+        return {}
+    copied: dict[str, list[object]] = {}
+    for key, value in entries or ():
+        copied.setdefault(str(key), []).append(value)
+    return copied
+
+
 def build_grpc_metadata(
     *,
     api_key: str | None = None,
@@ -149,7 +164,12 @@ class HonuaGrpcClient:
                 timeout=self._timeout,
             )
         except grpc.RpcError as e:
-            raise HonuaGrpcError(e.code(), e.details() or str(e)) from e
+            raise HonuaGrpcError(
+                e.code(),
+                e.details() or str(e),
+                initial_metadata=_rpc_metadata(e, "initial_metadata"),
+                trailing_metadata=_rpc_metadata(e, "trailing_metadata"),
+            ) from e
         return adapter.from_proto_response(proto_response)
 
     def query_features_stream(
@@ -168,7 +188,12 @@ class HonuaGrpcClient:
                 if page.is_last_page:
                     break
         except grpc.RpcError as e:
-            raise HonuaGrpcError(e.code(), e.details() or str(e)) from e
+            raise HonuaGrpcError(
+                e.code(),
+                e.details() or str(e),
+                initial_metadata=_rpc_metadata(e, "initial_metadata"),
+                trailing_metadata=_rpc_metadata(e, "trailing_metadata"),
+            ) from e
 
 
 class HonuaGrpcAsyncClient:
@@ -242,7 +267,12 @@ class HonuaGrpcAsyncClient:
                 timeout=self._timeout,
             )
         except grpc.aio.AioRpcError as e:
-            raise HonuaGrpcError(e.code(), e.details() or str(e)) from e
+            raise HonuaGrpcError(
+                e.code(),
+                e.details() or str(e),
+                initial_metadata=_rpc_metadata(e, "initial_metadata"),
+                trailing_metadata=_rpc_metadata(e, "trailing_metadata"),
+            ) from e
         return adapter.from_proto_response(proto_response)
 
     async def query_features_stream(  # type: ignore[no-untyped-def]
@@ -262,4 +292,9 @@ class HonuaGrpcAsyncClient:
                 if page.is_last_page:
                     break
         except grpc.aio.AioRpcError as e:
-            raise HonuaGrpcError(e.code(), e.details() or str(e)) from e
+            raise HonuaGrpcError(
+                e.code(),
+                e.details() or str(e),
+                initial_metadata=_rpc_metadata(e, "initial_metadata"),
+                trailing_metadata=_rpc_metadata(e, "trailing_metadata"),
+            ) from e

--- a/tests/fixtures/terminal-error-receipts.v1.json
+++ b/tests/fixtures/terminal-error-receipts.v1.json
@@ -76,7 +76,7 @@
       "geoServicesCode": 429,
       "grpcStatus": { "name": "RESOURCE_EXHAUSTED", "number": 8 },
       "kind": "throttled",
-      "code": "rate_limited",
+      "code": "rate_limit_exceeded",
       "retryable": true,
       "retryAfterSeconds": 30,
       "detail": "Request capacity is temporarily exhausted."
@@ -109,19 +109,15 @@
         "code",
         "message",
         "details",
-        "kind",
-        "machineCode",
-        "correlationId",
         "retryable",
-        "retryAfterSeconds",
-        "errors"
+        "retryAfterSeconds"
       ]
     },
     "grpc": {
-      "correlationKeys": ["x-correlation-id", "honua-request-id", "x-request-id"],
+      "correlationKeys": ["x-correlation-id", "honua-request-id", "x-request-id", "honua-correlation-id"],
       "machineCodeKey": "honua-error-code",
       "kindKey": "honua-error-kind",
-      "retryableKey": "honua-error-retryable",
+      "retryableKey": "honua-retryable",
       "retryKey": "retry-after",
       "structuredErrorsKey": "honua-error-details",
       "retainInitialMetadata": true,

--- a/tests/fixtures/terminal-error-receipts.v1.json
+++ b/tests/fixtures/terminal-error-receipts.v1.json
@@ -1,0 +1,151 @@
+{
+  "schemaVersion": "1.0.0",
+  "manifestId": "honua.terminal-error-receipts/v1",
+  "trackingIssue": "https://github.com/honua-io/honua-server/issues/3907",
+  "expectedCellCount": 40,
+  "sdkPaths": [
+    { "id": "js-http", "sdk": "javascript", "transport": "http" },
+    { "id": "js-geoservices", "sdk": "javascript", "transport": "geoservices-http-200" },
+    { "id": "js-grpc", "sdk": "javascript", "transport": "grpc" },
+    { "id": "dotnet-http", "sdk": "dotnet", "transport": "http" },
+    { "id": "dotnet-geoservices", "sdk": "dotnet", "transport": "geoservices-http-200" },
+    { "id": "dotnet-grpc", "sdk": "dotnet", "transport": "grpc" },
+    { "id": "python-http-geoservices", "sdk": "python", "transport": "http-and-geoservices" },
+    { "id": "python-grpc", "sdk": "python", "transport": "grpc" }
+  ],
+  "failureClasses": [
+    {
+      "id": "authz-denied",
+      "httpStatus": 403,
+      "geoServicesCode": 403,
+      "grpcStatus": { "name": "PERMISSION_DENIED", "number": 7 },
+      "kind": "authorization",
+      "code": "permission_denied",
+      "retryable": false,
+      "detail": "The current principal lacks permission.",
+      "authenticationRequired": {
+        "httpStatus": 401,
+        "grpcStatus": { "name": "UNAUTHENTICATED", "number": 16 },
+        "kind": "authentication",
+        "code": "authentication_required"
+      }
+    },
+    {
+      "id": "not-found",
+      "httpStatus": 404,
+      "geoServicesCode": 404,
+      "grpcStatus": { "name": "NOT_FOUND", "number": 5 },
+      "kind": "not-found",
+      "code": "resource_not_found",
+      "retryable": false,
+      "detail": "The requested resource was not found."
+    },
+    {
+      "id": "validation",
+      "httpStatus": 400,
+      "geoServicesCode": 400,
+      "grpcStatus": { "name": "INVALID_ARGUMENT", "number": 3 },
+      "kind": "validation",
+      "code": "validation_failed",
+      "retryable": false,
+      "detail": "One or more fields are invalid.",
+      "errors": [
+        {
+          "code": "required",
+          "severity": "error",
+          "path": "/name",
+          "fieldId": "name",
+          "itemIndex": null,
+          "message": "Name is required."
+        }
+      ]
+    },
+    {
+      "id": "conflict",
+      "httpStatus": 409,
+      "geoServicesCode": 409,
+      "grpcStatus": { "name": "ABORTED", "number": 10 },
+      "kind": "conflict",
+      "code": "resource_conflict",
+      "retryable": false,
+      "detail": "The resource changed; reload before retrying."
+    },
+    {
+      "id": "backpressure",
+      "httpStatus": 429,
+      "geoServicesCode": 429,
+      "grpcStatus": { "name": "RESOURCE_EXHAUSTED", "number": 8 },
+      "kind": "throttled",
+      "code": "rate_limited",
+      "retryable": true,
+      "retryAfterSeconds": 30,
+      "detail": "Request capacity is temporarily exhausted."
+    }
+  ],
+  "wireShapes": {
+    "http": {
+      "contentType": "application/problem+json",
+      "correlationHeader": "X-Correlation-ID",
+      "retryHeader": "Retry-After",
+      "bodyFields": [
+        "type",
+        "title",
+        "status",
+        "detail",
+        "instance",
+        "version",
+        "kind",
+        "code",
+        "correlationId",
+        "retryable",
+        "retryAfterSeconds",
+        "errors"
+      ]
+    },
+    "geoservices-http-200": {
+      "transportStatus": 200,
+      "bodyPath": "error",
+      "bodyFields": [
+        "code",
+        "message",
+        "details",
+        "kind",
+        "machineCode",
+        "correlationId",
+        "retryable",
+        "retryAfterSeconds",
+        "errors"
+      ]
+    },
+    "grpc": {
+      "correlationKeys": ["x-correlation-id", "honua-request-id", "x-request-id"],
+      "machineCodeKey": "honua-error-code",
+      "kindKey": "honua-error-kind",
+      "retryableKey": "honua-error-retryable",
+      "retryKey": "retry-after",
+      "structuredErrorsKey": "honua-error-details",
+      "retainInitialMetadata": true,
+      "retainTrailingMetadata": true
+    }
+  },
+  "receiptFields": [
+    "transportStatus",
+    "protocolCode",
+    "kind",
+    "code",
+    "retryable",
+    "retryAfterSeconds",
+    "correlationId",
+    "fieldErrors",
+    "protocolMetadata"
+  ],
+  "safety": {
+    "rawBodyInDefaultSerialization": false,
+    "sensitiveMetadataKeys": [
+      "authorization",
+      "cookie",
+      "set-cookie",
+      "x-api-key"
+    ]
+  }
+}

--- a/tests/test_http_errors.py
+++ b/tests/test_http_errors.py
@@ -33,6 +33,7 @@ def test_request_id_extracted_from_x_request_id_header() -> None:
     error = _to_http_error(response)
     assert isinstance(error, HonuaHttpError)
     assert error.request_id == "abc-123"
+    assert error.receipt.correlation_id == "abc-123"
 
 
 def test_headers_exposed_on_error() -> None:
@@ -104,6 +105,7 @@ def test_rate_limit_error_has_retry_after_and_request_id() -> None:
     error = _to_http_error(response)
     assert isinstance(error, HonuaRateLimitError)
     assert error.retry_after == pytest.approx(30.0)
+    assert error.receipt.retry_after_seconds == pytest.approx(30.0)
     assert error.request_id == "rl-9"
     assert error.headers.get("retry-after") == "30"
 
@@ -115,3 +117,16 @@ def test_honua_http_error_default_request_id_and_headers() -> None:
     error = HonuaHttpError(500, "boom")
     assert error.request_id is None
     assert error.headers == {}
+
+
+def test_direct_error_receipt_retains_explicit_request_id() -> None:
+    error = HonuaHttpError(500, "boom", request_id="direct-request")
+
+    assert error.receipt.correlation_id == "direct-request"
+
+
+def test_direct_rate_limit_receipt_retains_explicit_retry_after() -> None:
+    error = HonuaRateLimitError(429, "slow down", retry_after=2.5)
+
+    assert error.retry_after == pytest.approx(2.5)
+    assert error.receipt.retry_after_seconds == pytest.approx(2.5)

--- a/tests/test_terminal_error_receipts.py
+++ b/tests/test_terminal_error_receipts.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import grpc
+import httpx
+import pytest
+
+from honua_sdk import FailureKind, HonuaGrpcError
+from honua_sdk._http import _build_geoservices_error, _build_http_error
+
+
+CONTRACT = json.loads(
+    (Path(__file__).parent / "fixtures" / "terminal-error-receipts.v1.json").read_text(encoding="utf-8")
+)
+FAILURES = CONTRACT["failureClasses"]
+
+
+def test_contract_has_exactly_40_global_and_10_python_cells() -> None:
+    assert CONTRACT["expectedCellCount"] == 40
+    assert len(CONTRACT["sdkPaths"]) * len(FAILURES) == 40
+    assert len([path for path in CONTRACT["sdkPaths"] if path["sdk"] == "python"]) * len(FAILURES) == 10
+
+
+@pytest.mark.parametrize("failure", FAILURES, ids=[failure["id"] for failure in FAILURES])
+def test_http_and_geoservices_terminal_path_preserves_receipt(failure: dict[str, Any]) -> None:
+    correlation_id = "contract-correlation-id"
+    headers = {
+        "X-Correlation-ID": correlation_id,
+        "Retry-After": str(failure.get("retryAfterSeconds", "")),
+        "Authorization": "secret",
+    }
+    body = {
+        "kind": failure["kind"],
+        "code": failure["code"],
+        "retryable": failure["retryable"],
+        "retryAfterSeconds": failure.get("retryAfterSeconds"),
+        "correlationId": correlation_id,
+        "errors": failure.get("errors"),
+    }
+    response = httpx.Response(failure["httpStatus"], headers=headers, json=body)
+    http_error = _build_http_error(
+        status_code=response.status_code,
+        message=failure["detail"],
+        body=body,
+        response=response,
+    )
+
+    geo_body = {
+        "error": {
+            **body,
+            "code": failure["geoServicesCode"],
+            "machineCode": failure["code"],
+            "message": failure["detail"],
+        }
+    }
+    geo_response = httpx.Response(200, headers=headers, json=geo_body)
+    geo_error = _build_geoservices_error(
+        error_code=failure["geoServicesCode"],
+        message=failure["detail"],
+        body=geo_body,
+        response=geo_response,
+    )
+
+    _assert_receipt(http_error.receipt, failure, transport_status=failure["httpStatus"], protocol_code=None)
+    _assert_receipt(
+        geo_error.receipt,
+        failure,
+        transport_status=200,
+        protocol_code=str(failure["geoServicesCode"]),
+    )
+    assert "authorization" not in http_error.protocol_metadata.initial
+
+
+@pytest.mark.parametrize("failure", FAILURES, ids=[failure["id"] for failure in FAILURES])
+def test_grpc_terminal_path_preserves_initial_and_trailing_metadata(failure: dict[str, Any]) -> None:
+    status = getattr(grpc.StatusCode, failure["grpcStatus"]["name"])
+    trailing: dict[str, Any] = {
+        "honua-error-kind": failure["kind"],
+        "honua-error-code": failure["code"],
+        "honua-error-retryable": str(failure["retryable"]).lower(),
+    }
+    if retry_after := failure.get("retryAfterSeconds"):
+        trailing["retry-after"] = str(retry_after)
+    if errors := failure.get("errors"):
+        trailing["honua-error-details"] = json.dumps(errors)
+    error = HonuaGrpcError(
+        status,
+        failure["detail"],
+        initial_metadata={"x-correlation-id": "contract-correlation-id", "authorization": "secret"},
+        trailing_metadata=trailing,
+    )
+
+    _assert_receipt(
+        error.receipt,
+        failure,
+        transport_status=None,
+        protocol_code=str(failure["grpcStatus"]["number"]),
+    )
+    assert error.protocol_metadata.initial
+    assert error.protocol_metadata.trailing
+    assert "authorization" not in error.protocol_metadata.initial
+
+
+def test_unauthenticated_remains_distinct_from_permission_denied() -> None:
+    auth = FAILURES[0]["authenticationRequired"]
+    response = httpx.Response(auth["httpStatus"], json={})
+    error = _build_http_error(
+        status_code=response.status_code,
+        message="Authentication required",
+        body={},
+        response=response,
+    )
+
+    assert error.failure_kind is FailureKind.AUTHENTICATION
+    assert error.machine_code == "authentication_required"
+    assert error.failure_kind is not FailureKind.AUTHORIZATION
+
+
+def _assert_receipt(
+    receipt: Any,
+    failure: dict[str, Any],
+    *,
+    transport_status: int | None,
+    protocol_code: str | None,
+) -> None:
+    assert receipt.transport_status == transport_status
+    assert receipt.protocol_code == protocol_code
+    assert receipt.kind.value == failure["kind"]
+    assert receipt.code == failure["code"]
+    assert receipt.retryable is failure["retryable"]
+    assert receipt.retry_after_seconds == failure.get("retryAfterSeconds")
+    assert receipt.correlation_id == "contract-correlation-id"
+    assert len(receipt.field_errors) == len(failure.get("errors") or [])

--- a/tests/test_terminal_error_receipts.py
+++ b/tests/test_terminal_error_receipts.py
@@ -122,6 +122,25 @@ def test_unauthenticated_remains_distinct_from_permission_denied() -> None:
     assert error.failure_kind is not FailureKind.AUTHORIZATION
 
 
+@pytest.mark.parametrize("error_code", [498, 499])
+def test_geoservices_token_codes_are_authentication_failures(error_code: int) -> None:
+    body = {"error": {"code": error_code, "message": "Token required"}}
+    response = httpx.Response(200, headers={"X-Request-ID": "geo-token"}, json=body)
+
+    error = _build_geoservices_error(
+        error_code=error_code,
+        message="Token required",
+        body=body,
+        response=response,
+    )
+
+    assert error.receipt.transport_status == 200
+    assert error.receipt.protocol_code == str(error_code)
+    assert error.receipt.kind is FailureKind.AUTHENTICATION
+    assert error.receipt.code == "authentication_required"
+    assert error.receipt.correlation_id == "geo-token"
+
+
 def _assert_receipt(
     receipt: Any,
     failure: dict[str, Any],

--- a/tests/test_terminal_error_receipts.py
+++ b/tests/test_terminal_error_receipts.py
@@ -50,9 +50,10 @@ def test_http_and_geoservices_terminal_path_preserves_receipt(failure: dict[str,
 
     geo_body = {
         "error": {
-            **body,
             "code": failure["geoServicesCode"],
-            "machineCode": failure["code"],
+            "details": [f"Correlation ID: {correlation_id}"],
+            "retryable": failure["retryable"],
+            "retryAfterSeconds": failure.get("retryAfterSeconds"),
             "message": failure["detail"],
         }
     }
@@ -70,6 +71,7 @@ def test_http_and_geoservices_terminal_path_preserves_receipt(failure: dict[str,
         failure,
         transport_status=200,
         protocol_code=str(failure["geoServicesCode"]),
+        expected_field_errors=0,
     )
     assert "authorization" not in http_error.protocol_metadata.initial
 
@@ -78,9 +80,10 @@ def test_http_and_geoservices_terminal_path_preserves_receipt(failure: dict[str,
 def test_grpc_terminal_path_preserves_initial_and_trailing_metadata(failure: dict[str, Any]) -> None:
     status = getattr(grpc.StatusCode, failure["grpcStatus"]["name"])
     trailing: dict[str, Any] = {
+        "honua-correlation-id": "contract-correlation-id",
         "honua-error-kind": failure["kind"],
         "honua-error-code": failure["code"],
-        "honua-error-retryable": str(failure["retryable"]).lower(),
+        "honua-retryable": str(failure["retryable"]).lower(),
     }
     if retry_after := failure.get("retryAfterSeconds"):
         trailing["retry-after"] = str(retry_after)
@@ -89,7 +92,7 @@ def test_grpc_terminal_path_preserves_initial_and_trailing_metadata(failure: dic
     error = HonuaGrpcError(
         status,
         failure["detail"],
-        initial_metadata={"x-correlation-id": "contract-correlation-id", "authorization": "secret"},
+        initial_metadata={"x-test-initial": failure["id"], "authorization": "secret"},
         trailing_metadata=trailing,
     )
 
@@ -125,6 +128,7 @@ def _assert_receipt(
     *,
     transport_status: int | None,
     protocol_code: str | None,
+    expected_field_errors: int | None = None,
 ) -> None:
     assert receipt.transport_status == transport_status
     assert receipt.protocol_code == protocol_code
@@ -133,4 +137,6 @@ def _assert_receipt(
     assert receipt.retryable is failure["retryable"]
     assert receipt.retry_after_seconds == failure.get("retryAfterSeconds")
     assert receipt.correlation_id == "contract-correlation-id"
-    assert len(receipt.field_errors) == len(failure.get("errors") or [])
+    assert len(receipt.field_errors) == (
+        len(failure.get("errors") or []) if expected_field_errors is None else expected_field_errors
+    )


### PR DESCRIPTION
## Summary

Expose frozen terminal-failure receipt models on official synchronous/asynchronous HTTP, GeoServices, and gRPC exceptions. Preserve protocol-native status and metadata alongside machine kind/code, retry guidance, correlation/request identity, and structured field/item failures. Update the public compatibility snapshot and canonical fixture.

## Validation

- `pytest tests -q` — 1585 passed, 44 skipped
- `ruff check .` — passed
- Public API compatibility gate — passed
- Changed-file mypy — passed
- Contract tests verify the exact 10 Python cells and shared exact 40-cell denominator.

Closes #221
